### PR TITLE
chore(release): prepare agent-node preview.40 + CLI preview.54（只准备，不发布）

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.53",
+  "version": "2.3.0-preview.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.53",
+      "version": "2.3.0-preview.54",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.53",
+  "version": "2.3.0-preview.54",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.53";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.39";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.54";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.40";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.39",
+  "version": "2.5.0-preview.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.39",
+      "version": "2.5.0-preview.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.39",
+  "version": "2.5.0-preview.40",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.53 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.54 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.53` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.54` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.53 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.54 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.53`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.54`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.5.0-preview.40.md
+++ b/docs/tests/release-v2.5.0-preview.40.md
@@ -1,0 +1,65 @@
+# agent-node v2.5.0-preview.40 — 让「节点删不掉」那段可读
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+这一版**不修** #1286（节点 `delete_node` 后永远停在 `lifecycle_state=deleting`），
+它让下一次复现**能给出答案**。
+
+## 这一版包含什么
+
+**① daemon 的「备份 workdir → 发 ack」那段全程留痕**（#1356）
+
+复现时 daemon 日志**每次都停在** `backed up child workdir`，之后零输出。
+那段里只有三步，而三步在源码上都有 try/catch 或 `.catch` 保护 —— **静态读不出是哪一步**。
+现在三步之间各有一行日志，ack 成功也打一行：
+
+```
+[stop-daemon] entering residual sweep alias=…
+[stop-daemon] residual sweep returned alias=…
+[stop-daemon] dropped from children map child_node_id=…, sending ack action=…
+[stop-daemon] ack accepted request_id=… action=…
+```
+
+**② 关键路径上的 `execSync` 加了 timeout 和 maxBuffer**（#1356）
+
+`execSync("pgrep -af 'agent-node' || true")` 原来两者都没有，而它就坐在备份与 ack 之间。
+🔴 **这不是 #1286 的成因** —— 同机实测 pgrep 63ms、输出 22299 字节（1MB 上限的 2.1%），
+两个数量级的差距。这是一条独立成立的硬化：daemon 关键路径上不该有无上限的同步子进程调用。
+
+## 已排除的（都有读数，写在这里免得下一个人重走）
+
+| 假设 | 判定 | 证据 |
+|---|---|---|
+| pgrep 慢 / 缓冲区溢出 | ❌ | 63ms、22299 字节 = 上限的 2.1% |
+| 线上产物与源码不同 | ❌ | `.39` 产物未混淆，逐字比对那一段与 main 一致 |
+| 异常逃逸被静默吞掉 | ❌ | 调用方有 `.catch → warn`；正控证明 warn 确实写进该日志文件 |
+| 卡在 ack 的网络等待 | ❌ | 进程只持 1 个 socket（SSE），事件循环 `ep_poll` 空转，43 分钟累计 CPU 2 秒 |
+| hub 返回 `ok:false` 被忽略 | ❌ | `classifyCommHubResponse` 里 `ok===false` 走 appLevel，会抛异常并留日志 |
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.40
+```
+
+配对的 CLI 是 `@sleep2agi/agent-network@2.3.0-preview.54`，它钉住这个 runtime 和
+已发布的 `commhub-server@0.9.0-preview.34`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.40
+```
+
+🔴 **装完必须 stop + start 该节点**，正在跑的 agent-node 进程不会自己换成 `.40`。
+（启动横幅不等于就绪：看到节点重新注册也不代表新代码生效，要看日志里出现上面那四行。）
+
+## 复现步骤（用来读那四行）
+
+```
+1. 通过 daemon 建一个全新子节点
+2. 不 stop，直接 delete_node
+3. 看 daemon 日志停在上面四行的哪一行 —— 那就是卡住的那一步
+```


### PR DESCRIPTION
## 本 PR 不发布任何东西

只改版本号和发版说明。publish 走 GitHub Actions、从 main 出（按仓库既有规矩）。

## 为什么现在发

**#1356（daemon 侧埋点）已在 main，但读不到。** 因为：

```
main 的 agent-node/package.json  = 2.5.0-preview.39
npm dist-tag preview             = 2.5.0-preview.39   ← 一样
```

🔴 **一个 commit 处的 version 是「上一次已发布的」，不是「下一次要发的」。**
所以那段埋点现在不在任何产物里，#1286 的复现读不到它 —— 而它正是继续排查的唯一手段。

## 内容

| 包 | 版本 | 带上什么 |
|---|---|---|
| `@sleep2agi/agent-node` | `.39` → **`.40`** | #1356 daemon「备份 workdir → 发 ack」全程埋点 + 关键路径 `execSync` 加 timeout/maxBuffer |
| `@sleep2agi/agent-network` | `.53` → **`.54`** | #1354 daemon 的 anet 二进制 pin 传给 spawn 出来的子进程 |

🔴 **这两个改动分属不同的 npm 包**（`agent-node/src/runtime/` vs `agent-network/bin/cli.ts`）——
只发一个到不了生产。单仓多包，每次都要单独查一遍「我改的文件由哪个包分发」。

## 做法：跑仓库自己的脚本，不手改

```
scripts/sync-pinned-versions.sh @sleep2agi/agent-node    2.5.0-preview.40   # 先 dry-run
scripts/sync-pinned-versions.sh @sleep2agi/agent-network 2.3.0-preview.54   # 看 diff 再 --apply
```

没有手改任何 `package.json` / `package-lock.json` / `PAIRED_*` 常量。

## 文档版本断言：验过才改

`getting-started.md` 的 version-claim `.53` → `.54`。那一行断言的是**实测行为**
（「admin 密码是随机串 —— 未逐版本重测：生成它的 `server/src/auth.ts` 自 `.49` 起零提交」）。

🔴 **改戳之前复验了它的证据**：

```
git log --since='2026-08-27T02:25Z' -- server/src/auth.ts   → 0 提交
blob 哈希 .49 时期 = 当前 main = ea246a8357d32209f6e707209dfc1e2088ea81ee   → 逐字相同
正控：不限时间取该文件历史 → 有行，证明路径和取法有效
```

## 门

| 门 | rc |
|---|---|
| `check-doc-version-claims.py` | 0 |
| `check-doc-source-pins.py` | 0 |
| `check-doc-symbol-pins.py` | 0 |

🔴 version-claims 那道门**先做了正控**：把戳改成 `9.9.9-nonsense` → rc=1 会红。
所以它的绿是有效的 —— 但它说明的是「**戳与正文一致**」，**不是**「戳等于发版版本」。
这两件事不一样，别把它的绿读成后者。

## 发布后要做的

装完 `.40` 的节点**必须 stop + start**，正在跑的 agent-node 进程不会自己换。
验收不是看节点重新注册，是看日志里出现这四行：

```
[stop-daemon] entering residual sweep alias=…
[stop-daemon] residual sweep returned alias=…
[stop-daemon] dropped from children map …, sending ack action=…
[stop-daemon] ack accepted request_id=… action=…
```

Refs #1286
Refs #1356
Refs #1354