### PR TITLE
fix(btw): give Codex co-presence an owned executor

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1991,6 +1991,7 @@ async function ensureCodexAppServerSession(): Promise<
   return session;
 }
 let sideThreadNodeRuntime: { enabled: boolean; capability: Record<string, unknown>; close(): void } | null = null;
+let sideThreadOwnedSession: import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession | null = null;
 // Always publish an explicit closed capability. This is not merely cosmetic:
 // nodes.config_snapshot is durable, so omitting the field after a local flag
 // is turned off could leave a previously-supported node looking eligible.
@@ -6297,7 +6298,26 @@ if (sideThreadsEnabled) {
     warn("[side-thread] enable requested but codex-app-server, stable node_id, or dedicated CODEX_HOME is unavailable");
   } else {
     try {
-      const session = await ensureCodexAppServerSession();
+      const sharedSession = await ensureCodexAppServerSession();
+      const { openCodexAppServerRuntime } = await import("./runtime/codex-app-server/runtime");
+      // The human-TUI bridge deliberately attaches to a shared WebSocket.
+      // Native BTW must not borrow that client: its reviewed fork boundary
+      // requires a process-owned app-server.  Resume the exact same source
+      // thread through a dedicated owned process and fail closed if Codex
+      // creates/falls back to any other identity.
+      const expectedThreadId = sharedSession.threadId;
+      const { selectOwnedSideThreadSession } = await import("./runtime/side-thread/owned-session");
+      const selected = await selectOwnedSideThreadSession(sharedSession, () => openCodexAppServerRuntime({
+        threadId: expectedThreadId,
+        approvalPolicy: (fileConfig.flags as { approvalPolicy?: string } | undefined)?.approvalPolicy,
+        sandboxMode: (fileConfig.flags as { sandboxMode?: string } | undefined)?.sandboxMode,
+        commhubMcpUrl: `${COMMHUB_URL.replace(/\/+$/, "")}/mcp`,
+        commhubToken: AUTH_TOKEN || undefined,
+        log: (message) => log(`[side-thread-owned] ${message}`),
+        warn: (message) => warn(`[side-thread-owned] ${message}`),
+      }));
+      const session = selected.session;
+      if (selected.dedicated) sideThreadOwnedSession = session;
       const { startCliSideThreadConsumer, detectCodexRuntimeVersion } = await import("./runtime/side-thread/production");
       sideThreadNodeRuntime = startCliSideThreadConsumer({
         enabled: true,
@@ -6309,7 +6329,7 @@ if (sideThreadsEnabled) {
         runtimeVersion: detectCodexRuntimeVersion(),
         // An app-server spawned and owned by this exact node is the reviewed
         // owned topology. A user-supplied remote is shared and fails closed.
-        topology: session.proc ? "owned-stdio" : "shared-websocket",
+        topology: "owned-stdio",
         experimentalApi: fileConfig?.flags?.sideThreadExperimentalApi === true,
         log,
         warn,
@@ -6457,6 +6477,8 @@ const shutdown = async () => {
   shuttingDown = true;
   ownerScheduleConsumer?.stop();
   sideThreadNodeRuntime?.close();
+  sideThreadOwnedSession?.client.close();
+  sideThreadOwnedSession?.proc?.kill("SIGTERM");
   log("shutting down...");
   await closeOpencodeRuntime("signal shutdown");
   await grokCopresenceRuntimeSession?.close().catch((e: any) => {

--- a/agent-node/src/runtime/side-thread/owned-session.test.ts
+++ b/agent-node/src/runtime/side-thread/owned-session.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { selectOwnedSideThreadSession } from "./owned-session";
+
+const fake = (threadId: string, owned: boolean) => {
+  let closed = 0;
+  let killed = 0;
+  return {
+    session: {
+      threadId,
+      proc: owned ? { kill: () => { killed += 1; return true; }, exitCode: null, killed: false } : null,
+      client: { close: () => { closed += 1; }, isConnected: true },
+      bridge: {},
+      get isRunning() { return true; },
+    } as any,
+    counts: () => ({ closed, killed }),
+  };
+};
+
+describe("BTW owned app-server selection", () => {
+  test("reuses an already-owned ordinary session without spawning another", async () => {
+    const shared = fake("thread-source", true);
+    let opens = 0;
+    const selected = await selectOwnedSideThreadSession(shared.session, async () => {
+      opens += 1;
+      return fake("thread-source", true).session;
+    });
+    expect(selected).toEqual({ session: shared.session, dedicated: false });
+    expect(opens).toBe(0);
+  });
+
+  test("shared TUI bridge gets a dedicated owned executor on the exact source thread", async () => {
+    const shared = fake("thread-source", false);
+    const owned = fake("thread-source", true);
+    const selected = await selectOwnedSideThreadSession(shared.session, async () => owned.session);
+    expect(selected).toEqual({ session: owned.session, dedicated: true });
+    expect(owned.counts()).toEqual({ closed: 0, killed: 0 });
+  });
+
+  test("fallback to another thread closes and kills the candidate fail-closed", async () => {
+    const shared = fake("thread-source", false);
+    const wrong = fake("thread-fallback", true);
+    await expect(selectOwnedSideThreadSession(shared.session, async () => wrong.session)).rejects.toThrow("exact source thread");
+    expect(wrong.counts()).toEqual({ closed: 1, killed: 1 });
+  });
+
+  test("a second shared client cannot masquerade as an owned executor", async () => {
+    const shared = fake("thread-source", false);
+    const notOwned = fake("thread-source", false);
+    await expect(selectOwnedSideThreadSession(shared.session, async () => notOwned.session)).rejects.toThrow("exact source thread");
+    expect(notOwned.counts()).toEqual({ closed: 1, killed: 0 });
+  });
+});

--- a/agent-node/src/runtime/side-thread/owned-session.ts
+++ b/agent-node/src/runtime/side-thread/owned-session.ts
@@ -1,0 +1,23 @@
+import type { CodexAppServerRuntimeSession } from "../codex-app-server/runtime";
+
+type OpenOwned = () => Promise<CodexAppServerRuntimeSession>;
+
+/**
+ * BTW never executes through the human TUI's shared WebSocket client. When
+ * the ordinary bridge is shared, open a process-owned app-server and require
+ * it to resume the exact same source thread. A stale/fallback identity is
+ * closed before it can be published as capable.
+ */
+export async function selectOwnedSideThreadSession(
+  shared: CodexAppServerRuntimeSession,
+  openOwned: OpenOwned,
+): Promise<{ session: CodexAppServerRuntimeSession; dedicated: boolean }> {
+  if (shared.proc) return { session: shared, dedicated: false };
+  const owned = await openOwned();
+  if (!owned.proc || owned.threadId !== shared.threadId) {
+    owned.client.close();
+    owned.proc?.kill("SIGTERM");
+    throw new Error("dedicated side-thread app-server did not resume the exact source thread");
+  }
+  return { session: owned, dedicated: true };
+}


### PR DESCRIPTION
## Problem
Codex co-presence uses a shared WebSocket bridge, while native BTW intentionally accepts only a process-owned app-server. Nodes therefore reported `side_thread_capability.supported=false` even though task boundaries reached the desktop.

## Fix
- keep the human TUI shared bridge unchanged
- start a dedicated package-owned app-server for BTW
- require it to resume the exact source thread; close/kill any fallback identity
- close the dedicated client/process during node shutdown

## Docker verification
- agent-node production build PASS
- SideThread + Codex app-server focused suite: 146 pass / 0 fail
- new owned-session contract: 4/4 PASS (shared bridge, exact resume, wrong-thread fail-closed, non-owned fail-closed)

No production process or DB is changed by this PR.