### PR TITLE
docs(release.yml): 让文件头部的说明等于它自己的步骤（只动注释）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,18 @@
 #     through that real-TTY drive caught
 #
 # This workflow encodes the manual SOP as automated gates that run on
-# every tag push and any workflow_dispatch invocation. It is **report-only
-# by design** (does not block `npm publish` itself) — the publisher decides
-# whether to proceed. The goal is to make the checks impossible to skip.
+# every tag push and any workflow_dispatch invocation.
+#
+# 🔴 它**是不是只报告、还是会真发布,取决于怎么触发的** —— 唯一的权威是
+#    `publish` job 的 if 条件(本文件下方):
+#
+#      if: github.event_name == 'workflow_dispatch' && inputs.publish && <四道门全 success>
+#
+#    · tag push            → 只跑门,**不发布**
+#    · workflow_dispatch   → 只跑门,**除非**显式勾了 `publish`
+#    · workflow_dispatch + publish:true + 四道门全绿 → **真的 `npm publish --tag preview`**
+#
+#    读这段说明的人不需要往下翻 500 行才知道自己会不会把包发出去。
 #
 # WHAT IT GATES
 # =============
@@ -59,9 +68,12 @@
 #
 # WHAT IT DOES NOT DO
 # ===================
-# - Does NOT publish to npm. Publishing remains a manual `npm publish` step
-#   on the maintainer's machine. This workflow runs against the locally
-#   built tarball + tag metadata, then reports verdict.
+# - **不会在 tag push 上发布**。tag push 只跑四道门然后出 verdict。
+#   🔴 这一条原来写的是「Does NOT publish to npm. Publishing remains a manual
+#   `npm publish` step」—— 那是本文件加上 `publish` job **之前**的事实,
+#   而 job 加进来之后这句没跟着改。同一个文件里,头部说不发、第 666 行是
+#   `npm publish "$TARBALL" --tag preview --provenance --access public`。
+#   **两种读法都能自圆其说,只有 `publish` job 的 if 条件是权威。**
 # - Does NOT run the full v0.11 onboarding 5-scenario suite from
 #   /tmp/p-v0.11-onboarding (that's the contract-test layer). Release gate
 #   is a smaller, faster confidence check focused on install-path + version
@@ -225,7 +237,13 @@ jobs:
           # workflow 发它时，dispatch 直接被拒：
           #   HTTP 422: Provided value 'commhub-server' for input 'package' not in the
           #   list of allowed values
-          # —— 也就是说 **生产 hub 的包一直没有发布通道**，历史版本都是手工 npm publish。
+          # —— 当时 **生产 hub 的包确实没有发布通道**,历史版本都是手工 npm publish。
+          #
+          # 🔴 那是 2026-08-27 的**记录**,不是现在的事实:`commhub-server` 现在已经在
+          #    本文件 workflow_dispatch 的 `package` options 里(与 agent-network /
+          #    agent-node 并列),422 不再复现。记录留着是因为它解释了这段分流为什么存在;
+          #    但**别再据此推论「hub 包发不了」** —— 这类「真前提 + 已经过期的结论」
+          #    读起来和完全正确一模一样。
           if [ "${GATED_PKG}" = "commhub-server" ]; then
             docker run --rm \
               -v "$PWD/tarball:/tarball:ro" \


### PR DESCRIPTION
## 同一个文件，自己和自己矛盾

头部（第 62 行）：

> Does NOT publish to npm. Publishing remains a manual `npm publish` step on the maintainer's machine.

第 666 行：

```bash
npm publish "$TARBALL" --tag preview --provenance --access public
```

🔴 **两种读法都能自圆其说。** 唯一的权威是 `publish` job 的 if 条件：

```yaml
if: github.event_name == 'workflow_dispatch' && inputs.publish && <四道门全 success>
```

| 触发方式 | 会不会发布 |
|---|---|
| tag push | ❌ 只跑门 |
| workflow_dispatch（没勾 publish） | ❌ 只跑门 |
| workflow_dispatch + `publish: true` + 四道门全绿 | ✅ **真的发** |

改写头部两段，让读的人**不必往下翻 500 行**才知道自己会不会把包发出去。

## 第三处：一条已经过期的结论

第 228 行：

> HTTP 422: Provided value 'commhub-server' for input 'package' not in the list of allowed values
> —— 也就是说 **生产 hub 的包一直没有发布通道**，历史版本都是手工 npm publish。

那个 422 是**真的**（2026-08-27 实测）。但结论已经过期：
`commhub-server` **现在就在本文件 workflow_dispatch 的 `package` options 里**，与
`agent-network` / `agent-node` 并列。

🔴 记录保留（它解释了下面那段按包分流为什么存在），**现在时的结论改掉**，
并在原地写明：**别再据此推论「hub 包发不了」——「真前提 + 已经过期的结论」
读起来和完全正确一模一样。**

## 自证：只动注释

```
剥掉全部注释后：旧 432 行 / 新 432 行，逐字相同
```

⇒ 零行为改动。

YAML 解析通过，且**先喂了一份坏 YAML 确认解析器会抛** —— 否则「解析通过」可能只是解析器没在工作。

## 为什么值得单独一个 PR

我今天就是照头部那句判断的：以为「打 tag 只跑门」，差点直接打 tag。
结论碰巧对，但**理由是错的** —— 如果我反过来照第 666 行读，就会得出「打 tag 就发布」，
同样自洽、同样错。**一个文件的说明和它的行为分叉时，下一个人踩哪一边是随机的。**