### PR TITLE
chore(release): prepare BTW owned executor preview pair

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.54",
+  "version": "2.3.0-preview.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.54",
+      "version": "2.3.0-preview.55",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.54",
+  "version": "2.3.0-preview.55",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.54";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.40";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.55";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.41";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.40",
+  "version": "2.5.0-preview.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.40",
+      "version": "2.5.0-preview.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.40",
+  "version": "2.5.0-preview.41",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.54 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.55 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.54` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.55` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.54 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.55 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.54`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.55`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.55.md
+++ b/docs/tests/release-v2.3.0-preview.55.md
@@ -1,0 +1,17 @@
+# agent-network v2.3.0-preview.55 — BTW owned-executor pair
+
+**Channel:** `preview` only
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.55
+```
+
+This CLI is paired exactly with `agent-node@2.5.0-preview.41` so new and
+restarted Codex co-presence nodes receive the owned BTW executor.
+
+## Upgrade
+
+Install the exact preview and restart affected nodes. Do not promote this build
+to `latest` until a real BTW create/terminal round trip succeeds.

--- a/docs/tests/release-v2.5.0-preview.41.md
+++ b/docs/tests/release-v2.5.0-preview.41.md
@@ -1,0 +1,22 @@
+# agent-node v2.5.0-preview.41 — owned BTW executor
+
+**Channel:** `preview` only
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.41
+```
+
+Codex co-presence keeps its human TUI bridge unchanged and starts a separate
+package-owned app-server for native BTW. The executor must resume the exact
+source thread; a missing process identity or fallback thread fails closed.
+
+## Upgrade
+
+Install the exact version and restart the node. Enable `flags.sideThreads` only
+after the node token has an authenticated owner binding. Verify the Hub status
+snapshot reports `side_thread_capability.supported=true` before using BTW.
+
+Docker verification: agent-node build PASS; SideThread and Codex focused suite
+146/146 PASS; owned-session selection 4/4 PASS.


### PR DESCRIPTION
## Summary
- prepare `@sleep2agi/agent-node@2.5.0-preview.41` with the merged owned BTW executor
- pair `@sleep2agi/agent-network@2.3.0-preview.55` exactly to node `.41`
- add preview-only release notes and update current preview claims

## Why a fresh pair
`agent-node@2.5.0-preview.40` was published concurrently from an older main commit. npm versions are immutable and its tarball does not contain the owned SideThread executor, so `.40/.54` cannot deliver the merged fix.

## Local Docker gates
- sync-pinned dry-run + witnessed-red: PASS
- agent-node locked install/build: PASS
- agent-network locked install/typecheck/build: PASS

No package has been published from this branch. Publishing remains main-only.