### PR TITLE
docs(support-matrix): macOS 那批 ❓ 换成实测读数 + 修正 codex-app-server 的拦截位置

### DIFF
--- a/docs-site/docs/en/guide/support-matrix.md
+++ b/docs-site/docs/en/guide/support-matrix.md
@@ -153,10 +153,62 @@ So this cell reads **⚠️ "three non-reproductions on `.40`, root cause not lo
 
 ### The daemon on macOS (measured 2026-08-28)
 
-| | Status | Evidence |
+Mac Mini (macOS 26.3.1) + `agent-node@2.5.0-preview.40` + production hub, run end to end:
+
+| Operation | Status | What was checked (**not** the `ok:true` that `create_node` returns) |
 |---|---|---|
-| daemon **online** (registers / SSE connected) | **✅L2** | Mac Mini upgraded to `agent-node@2.5.0-preview.40` and restarted; hub side shows `11:34:27 SSE ← daemon-macmini connected` |
-| the daemon's **five lifecycle operations** | **❓** | **not run on macOS today** |
+| daemon online (registers / SSE connected) | **✅L2** | hub side `11:34:27 SSE ← daemon-macmini connected` |
+| **Create** `create_node` | **✅L2** | four daemon log lines: `wrote child config` → `spawned pid=79490` → `post-spawn kill-0 verify OK` → `+5000ms capability check OK`; child registered and reporting on the hub |
+| **Edit** `update_node_config` | **✅L2** | 🔴 the check is the **node-side file**: `model` actually changed in `~/.anet/nodes/<alias>/config.json` — not the hub's `config_revision` going 0→1 |
+| **Restart** `restart_node` | **✅L2** | `ok, apply_mode=restart_only` |
+| **Stop** `stop_node` | **✅L2** | `12:30:32`, four instrumentation lines + process gone |
+| **Delete** `delete_node` | **✅L2** | `delete without map entry (expected after stop)` → `backed up child workdir` → hub row `node_not_found`, original dir moved away |
+
+🔴 **The delete row took the "stop, then delete" path — exactly the one first reported in [#1286](https://github.com/sleep2agi/agent-network/issues/1286)** — and it passed first try on macOS + `.40`.
+(Delete on Linux still reads ⚠️, see the section above: that is "three non-reproductions, root cause not located", which is a different claim.)
+
+🔴 **A second reading**: the `residual sweep` instrumentation also prints on **macOS**. That is not a given —
+that code uses `pgrep -af` + `/proc/<pid>/cmdline`, and **macOS has no `/proc`**. It did not blow up,
+which means the function's error handling holds on macOS (it falls into the catch, returns normally, and does not block the ack).
+
+### macOS × Runtime (measured 2026-08-28; codex family prioritized per Vincent)
+
+| runtime | daemon creates a node | Evidence |
+|---|---|---|
+| `claude-agent-sdk` | **✅L2** | all six steps above |
+| `codex-sdk` | **✅L2** | four spawn-verification lines + child registered on hub + full delete chain (`ack accepted action=delete`) |
+| `codex-app-server` | **❌** | `{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}`, and **not a single line in the daemon log** |
+
+🔴 **`codex-app-server` is blocked somewhere other than what footnote ^1^ says.**
+`runtime_invalid` has **two sources** in this repo:
+
+| Location | How it throws | Does the response carry `value`? |
+|---|---|---|
+| **hub** `server/src/create-node-validate.ts:45` | `ValidationError("runtime_invalid", { value })` | **yes** |
+| daemon `agent-node/src/runtime/create-node-daemon.ts:310` | `throw new Error("runtime_invalid")` | no |
+
+The measured response **carries `value`** ⇒ **the hub gate fired first and the daemon never saw the request**.
+**Fixing only `VALID_RUNTIMES` in `create-node-daemon.ts` will still not get through** — both gates need changing.
+
+### Restarting a daemon silently costs it the ability to create nodes (reproduced on Linux and macOS)
+
+Hit once on each platform on 2026-08-28, identical shape:
+
+```
+← SSE create_node cr_…
+[WARN] anet_bin_unsafe_path: no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf
+```
+
+After a clean `anet daemon start` restart the daemon **registers, goes online, receives the doorbell,
+and the hub returns `ok:true`** — but **it cannot create a single node**, because the `ANET_BIN_ABS`
+family it depends on **is not persisted** and is lost on restart.
+
+🔴 **"Online" and "can do work" are two different things.** Anyone who restarts a daemon falls into this,
+and every signal facing the caller says success.
+
+**The persisted form is `/etc/anet-daemon/path.conf`** (survives restarts);
+`ANET_DAEMON_ALLOW_ENV_BIN=1` + `ANET_BIN_ABS=<realpath>` is the Docker/dev/manual-ops convenience path
+and **a restart will not carry it over**.
 
 🔴 **"the daemon is online" and "the daemon can do work" are two different things** — these rows stay separate.
 We were caught by exactly this on Linux the same day: the daemon registered, went online, received the

--- a/docs-site/docs/guide/support-matrix.md
+++ b/docs-site/docs/guide/support-matrix.md
@@ -143,10 +143,61 @@
 
 ### macOS 上的 daemon（2026-08-28 实测）
 
-| | 状态 | 依据 |
+Mac Mini（macOS 26.3.1）+ `agent-node@2.5.0-preview.40` + 生产 hub，逐个跑完：
+
+| 操作 | 状态 | 判据（**不是** `create_node` 返回的 `ok:true`） |
 |---|---|---|
-| daemon **在线**（注册 / SSE connected） | **✅L2** | Mac Mini 升到 `agent-node@2.5.0-preview.40` 并重启，hub 侧 `11:34:27 SSE ← daemon-macmini connected` |
-| daemon 的**五个生命周期操作** | **❓** | **今天没在 macOS 上逐个跑过** |
+| daemon 在线（注册 / SSE connected） | **✅L2** | hub 侧 `11:34:27 SSE ← daemon-macmini connected` |
+| **创建** `create_node` | **✅L2** | daemon 日志四行：`wrote child config` → `spawned pid=79490` → `post-spawn kill-0 verify OK` → `+5000ms capability check OK`；hub 侧子节点注册报活 |
+| **编辑** `update_node_config` | **✅L2** | 🔴 判据是**节点侧真实文件**：`~/.anet/nodes/<alias>/config.json` 里 `model` 真的变了 —— 不是 hub 的 `config_revision` 0→1 |
+| **重启** `restart_node` | **✅L2** | `ok, apply_mode=restart_only` |
+| **停止** `stop_node` | **✅L2** | `12:30:32` 四行埋点 + 进程消失 |
+| **删除** `delete_node` | **✅L2** | `delete without map entry (expected after stop)` → `backed up child workdir` → hub 行 `node_not_found`，原目录已移走 |
+
+🔴 **删除这一格走的是「stop 之后再 delete」—— 正是 [#1286](https://github.com/sleep2agi/agent-network/issues/1286) 最初报的那条路径**，在 macOS + `.40` 上一次通过。
+（Linux 上的删除仍记 ⚠️，见上一节：那是「三次未复现，成因未定位」，不是同一件事。）
+
+🔴 **另一条读数**：`residual sweep` 埋点在 **macOS 上也正常打出**。这不理所当然 ——
+那段用 `pgrep -af` + `/proc/<pid>/cmdline`，而 **macOS 没有 `/proc`**。它没炸，
+说明那个函数的错误处理在 macOS 上是有效的（走 catch 后正常返回，不阻断 ack）。
+
+### macOS × Runtime（2026-08-28 实测，Vincent 定的 codex 优先）
+
+| runtime | daemon 创建节点 | 判据 |
+|---|---|---|
+| `claude-agent-sdk` | **✅L2** | 上表六步全通 |
+| `codex-sdk` | **✅L2** | spawn 四行验证 + hub 注册报活 + 删除全链走通（`ack accepted action=delete`） |
+| `codex-app-server` | **❌** | `{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}`，**daemon 日志一行都没有** |
+
+🔴 **`codex-app-server` 被拦的位置和脚注 ^1^ 写的不是同一处。**
+`runtime_invalid` 在仓里有**两个来源**：
+
+| 位置 | 抛法 | 返回带 `value` 吗 |
+|---|---|---|
+| **hub** `server/src/create-node-validate.ts:45` | `ValidationError("runtime_invalid", { value })` | **带** |
+| daemon `agent-node/src/runtime/create-node-daemon.ts:310` | `throw new Error("runtime_invalid")` | 不带 |
+
+实测拿到的返回**带 `value`** ⇒ **是 hub 那道先响的，daemon 根本没收到这个请求**。
+**只修 `create-node-daemon.ts` 的 `VALID_RUNTIMES` 仍然过不去** —— 两道闸都要改。
+
+### daemon 重启会静默失去建节点能力（Linux + macOS 都复现）
+
+2026-08-28 在两个平台上各撞一次，形状完全相同：
+
+```
+← SSE create_node cr_…
+[WARN] anet_bin_unsafe_path: no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf
+```
+
+用干净的 `anet daemon start` 重启 daemon 后，它**照常注册、在线、收 doorbell、hub 返回 `ok:true`**，
+但**一个节点也建不出来** —— 因为它依赖的 `ANET_BIN_ABS` 等变量**没有落盘**，重启就丢。
+
+🔴 **「在线」和「能干活」是两件事。** 任何人重启一次 daemon 都会掉进去，
+而所有面向调用方的信号都说成功。
+
+**落盘的做法是 `/etc/anet-daemon/path.conf`**（跨重启存活）；
+`ANET_DAEMON_ALLOW_ENV_BIN=1` + `ANET_BIN_ABS=<realpath>` 是 Docker/dev/manual-ops 的便利路径，
+**重启不会自动带上**。
 
 🔴 **「daemon 在线」和「daemon 能干活」是两件事**，这两格必须分开。
 同一天在 Linux 上就栽过一次：daemon 注册成功、在线、收到 doorbell，


### PR DESCRIPTION
## macOS 六步全通，每格写明判据

Mac Mini（macOS 26.3.1）+ `agent-node@2.5.0-preview.40` + 生产 hub：

| 操作 | 状态 | 判据 |
|---|---|---|
| daemon 在线 | ✅L2 | hub 侧 `SSE ← daemon-macmini connected` |
| 创建 | ✅L2 | daemon 四行 spawn 验证 + hub 侧注册报活 |
| 编辑 | ✅L2 | 🔴 **节点侧真实文件**里 `model` 变了 |
| 重启 | ✅L2 | `apply_mode=restart_only` |
| 停止 | ✅L2 | 四行埋点 + 进程消失 |
| 删除 | ✅L2 | 备份 → hub 行 `node_not_found` → 原目录移走 |

🔴 **判据一律不是 `create_node` 返回的 `ok:true`** —— 那个 ok 在 spawn 失败时也一样返回，
今天早上就是这样骗过我一次的。编辑那格看的是**节点侧文件**，不是 hub 的 `config_revision` 0→1。

🔴 **删除那格走的是「stop 之后再 delete」，正是 #1286 最初报的路径**，macOS 上一次通过。
**Linux 上的删除仍记 ⚠️**（三次未复现、成因未定位）—— 两者是不同的结论，**没有合并成一个 ✅**。

## 修正脚注 ^1^ 的一半

`codex-app-server` 被拦的位置**不是**脚注写的 `create-node-daemon.ts` 的 `VALID_RUNTIMES`：

| 位置 | 抛法 | 返回带 `value` 吗 |
|---|---|---|
| **hub** `create-node-validate.ts:45` | `ValidationError("runtime_invalid", { value })` | **带** |
| daemon `create-node-daemon.ts:310` | `throw new Error("runtime_invalid")` | 不带 |

实测返回 `{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}` —— **带 `value`**
⇒ **hub 那道先响，daemon 根本没收到这个请求**（daemon 日志一行都没有）。

**只修 daemon 那道仍然过不去。** 这条对排期有实际影响。

## 新增一节：daemon 重启会静默失去建节点能力

Linux 和 macOS 各复现一次，形状完全相同：重启后 daemon **照常注册、在线、收 doorbell、
hub 返回 `ok:true`**，但**一个节点也建不出来** —— `ANET_BIN_ABS` 等变量没落盘，重启就丢。

🔴 **「在线」和「能干活」是两件事**，而所有面向调用方的信号都说成功。

## 一条附带读数

`residual sweep` 埋点在 macOS 上**也正常打出**。这不理所当然 ——
那段用 `pgrep -af` + `/proc/<pid>/cmdline`，而 **macOS 没有 `/proc`**。
它没炸，说明那个函数的错误处理在 macOS 上是有效的。

中英两份同步；`check-doc-version-claims` / `check-doc-source-pins` / `check-doc-symbol-pins` 均 rc=0。

Refs #1367
Refs #1286
Refs #1298