### PR TITLE
feat(#1353): daemon 上报「我现在能不能创建节点」——让失败在离用户最近的地方出现

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -166,6 +166,40 @@ import {
   type CompensationPoller,
 } from "./runtime/commhub-poll-compensator";
 
+
+// ── #1353 —— daemon 当下能不能创建节点,上报给 hub ──────────────────
+//
+// 背景:创建子节点要用一个**已验证的 anet 二进制 pin**,它只来自
+// `/etc/anet-daemon/path.conf`(生产信任根)或显式开启的 ANET_BIN_ABS 环境变量。
+// 🔴 环境变量**重启不带就会丢**,而丢了之后 daemon 照常注册、在线、收 doorbell,
+//    hub 返回 ok:true + request_id —— 节点永远不出现,失败只写在 daemon 自己的日志里。
+//    **「在线」和「能干活」是两件事。** 这个函数让 hub 看得见后者。
+//
+// 只对 host_supervisor 算。普通节点返回 undefined ⇒ 快照里完全不出现这两个字段,
+// 行为与改动前逐字相同。
+//
+// 🔴 算一次就缓存:report_status 是心跳路径,而 loadAndVerifyAnetBin() 会做
+//    realpathSync + statSync + 读文件哈希。每次心跳都跑一遍是纯浪费。
+//    代价是 daemon 运行期间修好了 pin 也要重启才会反映 —— 可接受,
+//    因为修 pin 的正规做法(写 /etc/anet-daemon/path.conf)本来就伴随重启。
+let _createCapCache: { ok: boolean; reason?: "anet_bin_pin_unresolved" } | null | undefined;
+function daemonCreateCapability(): { ok: boolean; reason?: "anet_bin_pin_unresolved" } | undefined {
+  if (_createCapCache !== undefined) return _createCapCache ?? undefined;
+  if (fileConfig?.role !== "host_supervisor") { _createCapCache = null; return undefined; }
+  try {
+    // 同步 require 而不是顶层 import:cli.ts 对 create-node-daemon 一直是按需加载的,
+    // 保持一致,也避免非 daemon 节点为这一个函数拉进整个模块。
+    const mod = require("./runtime/create-node-daemon.js");
+    mod.loadAndVerifyAnetBin();
+    _createCapCache = { ok: true };
+  } catch {
+    // 🔴 只报代码,**不报原始报错文本**。unsafePathHelp() 的消息里带完整机器路径,
+    //    而这个字段会一路走到 hub 和 Dashboard —— 一条「哪台机器的哪个路径缺什么」
+    //    本身就是一张地图。原文仍然进 daemon 自己的日志,那里是本地的。
+    _createCapCache = { ok: false, reason: "anet_bin_pin_unresolved" };
+  }
+  return _createCapCache;
+}
 const home = homedir();
 const peerReplyCapabilityCache = createPeerReplyCapabilityCache();
 
@@ -1431,7 +1465,7 @@ const reportStatus = async (status: string, task?: string) => {
     // fails → update stays pending → reaper timeouts → dashboard sees
     // timeout (NOT false ✓).
     config_snapshot: configApplyDraining ? undefined : {
-      ...buildConfigSnapshot(fileConfig, process.env.ANET_CONFIG_UPDATE_CAPABLE === "1", currentConfigRevision),
+      ...buildConfigSnapshot(fileConfig, process.env.ANET_CONFIG_UPDATE_CAPABLE === "1", currentConfigRevision, daemonCreateCapability()),
       ...(sideThreadCapabilitySnapshot ? { side_thread_capability: sideThreadCapabilitySnapshot } : {}),
     },
   });

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -621,3 +621,58 @@ describe("buildConfigSnapshot — always emits channels for content-match finali
     expect(buildConfigSnapshot({ channels: null }, false, 0).channels).toEqual([]);
   });
 });
+
+// ─── #1353 —— daemon 把「我现在能不能创建节点」上报给 hub ──────────────
+//
+// 背景：创建子节点要用一个已验证的 anet 二进制 pin，它只来自
+// `/etc/anet-daemon/path.conf`（生产信任根）或显式开启的 ANET_BIN_ABS 环境变量。
+// 🔴 环境变量重启不带就会丢，而丢了之后 daemon 照常注册、在线、收 doorbell，
+//    hub 返回 ok:true —— 节点永远不出现。**「在线」和「能干活」是两件事。**
+//
+// 这几条测的是：那件事**说得出口**了没有。
+describe("#1353 buildConfigSnapshot — 上报「当下能不能创建节点」", () => {
+  const cfg = { role: "host_supervisor", runtimes_supported: ["claude-agent-sdk"] };
+
+  test("不传能力参数时，快照里完全不出现这两个字段（旧调用点行为逐字不变）", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 3);
+    // 🔴 断言的是「键不存在」，不是「值为 undefined」——
+    //    一个恒为 undefined 的键照样会被 JSON.stringify 丢掉，两者在线上无法区分；
+    //    但在对象层面它们不同，而 hub 的 zod 对多余键的处理取决于键在不在。
+    expect("can_create_nodes" in (s.daemon_capabilities ?? {})).toBe(false);
+    expect("create_nodes_blocked_reason" in (s.daemon_capabilities ?? {})).toBe(false);
+    // 正控：既有字段仍然在，证明这个快照不是空的
+    expect(s.daemon_capabilities?.runtimes_supported).toEqual(["claude-agent-sdk"]);
+  });
+
+  test("能力可用时上报 can_create_nodes=true，且不带 reason", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 3, { ok: true });
+    expect(s.daemon_capabilities.can_create_nodes).toBe(true);
+    expect("create_nodes_blocked_reason" in s.daemon_capabilities).toBe(false);
+  });
+
+  test("能力不可用时上报 false + 原因代码", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 3, { ok: false, reason: "anet_bin_pin_unresolved" });
+    expect(s.daemon_capabilities.can_create_nodes).toBe(false);
+    expect(s.daemon_capabilities.create_nodes_blocked_reason).toBe("anet_bin_pin_unresolved");
+  });
+
+  test("🔴 上报的原因里不能出现任何路径", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 3, { ok: false, reason: "anet_bin_pin_unresolved" });
+    const reason = String(s.daemon_capabilities.create_nodes_blocked_reason);
+    // unsafePathHelp() 的原始消息里带完整机器路径（/etc/anet-daemon/path.conf、
+    // /home/…/node_modules/…/anet.cjs）。这个字段会一路走到 Dashboard，
+    // 而一条「哪台机器的哪个路径缺什么」本身就是一张地图。
+    expect(reason).not.toContain("/");
+    expect(reason).not.toContain("\\");
+    // 正控：这条断言不是恒真 —— 拿真会出现在原始消息里的串喂进去，它必须判否
+    expect("no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf").toContain("/");
+  });
+
+  test("🔴 整个快照里不能夹带 anet 二进制的绝对路径", () => {
+    const s = buildConfigSnapshot(cfg, true, 3, { ok: false, reason: "anet_bin_pin_unresolved" });
+    const blob = JSON.stringify(s);
+    expect(blob).not.toContain("/etc/anet-daemon");
+    expect(blob).not.toContain("anet.cjs");
+    expect(blob).not.toContain("node_modules");
+  });
+});

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -398,6 +398,23 @@ export interface DaemonCapabilities {
   /** RFC-026 §9 — hub backpressure cap (tools.ts daemon_max_children).
    * Daemon-side enforcement also uses this. Default 20 if unset. */
   max_concurrent_children?: number;
+  /** #1353 —— 这个 daemon **现在**能不能创建节点。
+   *
+   * 🔴 它和 `runtimes_supported` 不是一回事:后者是**声明**(我支持哪些 runtime),
+   *    这个是**当下的实际能力**。一个 daemon 可以声明支持三种 runtime,
+   *    同时因为 ANET_BIN pin 解析不出来而一种也创建不了。
+   *
+   * 为什么需要它:pin 只存在于 `/etc/anet-daemon/path.conf` 或(显式开启的)环境变量里,
+   * **重启不带环境就会丢**。丢了之后 daemon 照常注册、在线、收 doorbell,
+   * hub 返回 `ok:true` + request_id,而节点永远不出现 ——
+   * 失败只写在 daemon 自己的日志里。**「在线」和「能干活」是两件事。** */
+  can_create_nodes?: boolean;
+  /** #1353 —— `can_create_nodes === false` 时的原因**代码**。
+   *
+   * 🔴 只报代码,**永远不报原始报错文本**。`unsafePathHelp()` 的消息里带
+   *    完整的机器路径,而这个字段会一路走到 hub 和 Dashboard ——
+   *    一条「哪台机器的哪个路径缺什么」本身就是一张地图。 */
+  create_nodes_blocked_reason?: "anet_bin_pin_unresolved";
 }
 
 export interface MaskedSnapshot {
@@ -450,6 +467,15 @@ export function buildConfigSnapshot(
   fileConfig: any,
   configUpdateCapable: boolean,
   revision: number,
+  /** #1353 —— daemon 当下能不能创建节点。**由调用方算好传进来**,不在这里算。
+   *
+   * 🔴 为什么是依赖注入而不是直接 import:算这个要用
+   *    `create-node-daemon.ts` 的 `loadAndVerifyAnetBin()`,而**那个文件已经
+   *    import 了本文件**(`atomicWriteJson` 等)。反向 import 会成环。
+   *
+   * `undefined` = 调用方没算(非 daemon 节点,或旧调用点)⇒ 不上报这两格,
+   * 与改动前的行为逐字相同。 */
+  createCapability?: { ok: boolean; reason?: "anet_bin_pin_unresolved" },
 ): MaskedSnapshot {
   const out: MaskedSnapshot = {
     model: typeof fileConfig?.model === "string" ? fileConfig.model : null,
@@ -490,6 +516,14 @@ export function buildConfigSnapshot(
   const mc = fileConfig?.max_concurrent_children;
   if (typeof mc === "number" && Number.isFinite(mc) && mc > 0) {
     caps.max_concurrent_children = mc;
+  }
+  // #1353 —— 只在调用方真的算过的时候才上报。没算过就完全不出现这两个字段,
+  // 这样旧 hub 和旧调用点的行为逐字不变。
+  if (createCapability) {
+    caps.can_create_nodes = createCapability.ok;
+    if (!createCapability.ok && createCapability.reason) {
+      caps.create_nodes_blocked_reason = createCapability.reason;
+    }
   }
   if (Object.keys(caps).length > 0) {
     out.daemon_capabilities = caps;

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1917 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1917) + [tools.ts:1931 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1931) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1917 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1930) + [tools.ts:1931 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1942) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -551,6 +551,19 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           runtimes_supported: z.array(z.string().max(64)).max(16).optional(),
           allowed_secret_keys: z.array(z.string().max(64)).max(64).optional(),
           max_concurrent_children: z.number().int().min(1).max(1000).optional(),
+          // #1353 —— daemon **当下**能不能创建节点。与 runtimes_supported 不是一回事:
+          // 后者是声明(我支持哪些 runtime),这个是实际能力。一个 daemon 可以声明支持
+          // 三种 runtime,同时因为 ANET_BIN pin 解析不出来而一种也创建不了。
+          //
+          // 🔴 为什么 hub 需要看见它:pin 只存在于 /etc/anet-daemon/path.conf 或
+          //    显式开启的环境变量里,**重启不带环境就会丢**。丢了之后 daemon 照常注册、
+          //    在线、收 doorbell,hub 返回 ok:true + request_id —— 而节点永远不出现。
+          //    在此之前 hub 完全看不出区别,Dashboard 的「选服务器」还会把它列为可选。
+          can_create_nodes: z.boolean().optional(),
+          // 只收**代码**,不收原始报错文本 —— 上游 unsafePathHelp() 的消息里带完整机器路径,
+          // 而这个字段会走到 Dashboard。enum 而不是 string:一个自由文本字段等于给
+          // 「把路径塞进来」留了口子。
+          create_nodes_blocked_reason: z.enum(["anet_bin_pin_unresolved"]).optional(),
         }).optional(),
       }).optional().describe("RFC-024 — masked node config snapshot"),
     },


### PR DESCRIPTION
## 问题：所有面向调用方的信号都说成功

daemon 重启后如果丢了 `ANET_BIN_ABS`：

| 信号 | 说什么 |
|---|---|
| `create_node` 的返回 | `{"ok":true,"request_id":"cr_…"}` |
| hub 上 daemon 状态 | **在线** |
| daemon 是否收到 doorbell | **收到了**（日志里有 `← SSE create_node`） |
| 节点 | **永远不出现** |

🔴 **失败只写在 daemon 自己的日志里。** 2026-08-28 在 Linux 和 macOS 上**各自然复现一次**，形状逐字相同 —— 两次都是我升级 `agent-node` 顺手重启 daemon 之后撞上的，不是构造的。

## 明确不做的事：不动信任根

pin 必须来自 root 拥有的位置是**有意的** —— 它决定 daemon 去执行哪个二进制。
把它持久化到用户可写的节点配置里是最顺手的修法，**也是安全倒退**：后面那几道检查
（禁 symlink、`mode & 0o022`、可选 root owner）全都建立在「pin 的来源本身可信」这个前提上。

**本 PR 修的是「静默」，不是「需要 root」。**

## 三处改动

| 文件 | 改了什么 |
|---|---|
| `config-apply.ts` | `DaemonCapabilities` 加两格；`buildConfigSnapshot` 加**可选**入参 |
| `cli.ts` | `daemonCreateCapability()`，只对 host_supervisor 算，**算一次缓存** |
| `server/src/tools.ts` | hub zod 收这两格 |

## 四个路上挡下的坑

**① 循环依赖** —— `create-node-daemon.ts` **已经 import 了 `config-apply.js`**，反向 import 成环 ⇒ 依赖注入。

**② 心跳路径不能做重活** —— `loadAndVerifyAnetBin()` 做 `realpathSync` + `statSync` + 文件哈希，而 `report_status` 是心跳 ⇒ 算一次缓存。代价写在注释里。

**③ 🔴 原因只能是代码，不能是原文** —— `unsafePathHelp()` 的消息**带完整机器路径**，而这个字段会走到 Dashboard。
**hub 侧用 `z.enum([...])` 而不是 `z.string()`** —— **一个自由文本字段等于给「把路径塞进来」留了口子。**

**④ `require()` 在 ESM 里能不能用** —— cli.ts **本来就有 3 处**，已发布产物开头就是 `import{createRequire}from"node:module"` ⇒ 打包器会注入。**查过才用。**

## 向后兼容

调用方不传参数时，快照里**完全不出现这两个字段**。第一条测试断的就是这个，
而且断的是**「键不存在」不是「值为 undefined」** —— 后者在 `JSON.stringify` 之后无法区分，
但在对象层面不同。

## witnessed-red

| | 结果 |
|---|---|
| 变异 A（删掉上报那段） | **88 pass / 2 fail** |
| 变异 B（原因换成带路径的原文） | **87 pass / 3 fail** |
| 还原 | **90 pass / 0 fail** |

🔴 **变异 A 只红了 5 条新测试里的 2 条** —— 两条「路径」测试仍绿，因为完全不上报时
根本没有 reason 可含路径。那是正确行为（它们守的是**内容**不是**存在性**），
但说明**单靠那两条测不出"功能被删掉"**，所以存在性和内容各有独立断言。

Refs #1353
Refs #1362