### PR TITLE
fix(hub): runtime_invalid 要说清「允许哪些」和「还有什么路」

### DIFF
--- a/server/src/create-node-validate.test.ts
+++ b/server/src/create-node-validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ValidationError,
-  validateName, validateRuntime, validateModel, validateFlagValue,
+  validateName, validateRuntime, validateModel, validateFlagValue, RUNTIMES,
   validateEnvRefs, validateChannelsP1, serializeEnvLocal, buildAnetArgs,
   MAX_ENV_KEYS_PER_NODE,
 } from "./create-node-validate.js";
@@ -193,5 +193,49 @@ describe("buildAnetArgs (§4.2.2 F2 — fully validated argv)", () => {
       name: "x", runtime: "claude-agent-sdk", model: "x",
       channels: ["telegram"],
     } as any)).toThrow(ValidationError);
+  });
+});
+
+// ─── runtime_invalid 要说清「允许哪些」和「还有什么路」 ────────────────
+//
+// 2026-08-28 实测：从 Dashboard 建一个 codex-app-server 节点，用户拿到的是
+//   {"ok":false,"error":"runtime_invalid","value":"codex-app-server"}
+// 而目标机器的 daemon 日志里一行都没有 —— 请求被 hub 拦在最前面，
+// 用户无从知道①哪些允许②是不是打错了③有没有别的办法。
+describe("validateRuntime — 报错要可操作", () => {
+  function thrown(v: unknown): any {
+    try { validateRuntime(v); } catch (e: any) { return e; }
+    throw new Error("expected validateRuntime to throw");
+  }
+
+  test("非法 runtime 的报错带上允许集合", () => {
+    const e = thrown("codex-app-server");
+    expect(e.code).toBe("runtime_invalid");
+    expect(Array.isArray(e.detail?.allowed)).toBe(true);
+    // 🔴 断言它等于 RUNTIMES 本身,而不是等于一份手抄的清单 ——
+    //    手抄的那份会漂,漂了之后报错会理直气壮地告诉用户一组错的名字。
+    expect(e.detail.allowed).toEqual([...RUNTIMES]);
+  });
+
+  test("报错带上一条出路提示", () => {
+    const e = thrown("opencode-cli");
+    expect(typeof e.detail?.hint).toBe("string");
+    expect(e.detail.hint.length).toBeGreaterThan(10);
+    // 提示必须点名那条真实存在的路,否则它只是安慰话
+    expect(e.detail.hint).toContain("anet node create");
+  });
+
+  test("仍然回报用户传进来的那个值（便于识别是不是打错了）", () => {
+    const e = thrown("codex-app-servr");   // 故意少一个 e
+    expect(e.detail.value).toBe("codex-app-servr");
+  });
+
+  test("🔴 合法 runtime 一个都不能被这次改动误伤", () => {
+    for (const r of RUNTIMES) {
+      expect(() => validateRuntime(r)).not.toThrow();
+    }
+    // 正控：非字符串必须仍然被拒 —— 否则上面那条循环全过也说明不了什么
+    expect(() => validateRuntime(123 as any)).toThrow();
+    expect(() => validateRuntime(undefined as any)).toThrow();
   });
 });

--- a/server/src/create-node-validate.ts
+++ b/server/src/create-node-validate.ts
@@ -42,7 +42,23 @@ export function validateName(s: unknown): asserts s is string {
 
 export function validateRuntime(s: unknown): asserts s is Runtime {
   if (typeof s !== "string" || !(RUNTIMES as readonly string[]).includes(s)) {
-    throw new ValidationError("runtime_invalid", { value: typeof s === "string" ? s.slice(0, 80) : typeof s });
+    // 🔴 原来只回一个 `runtime_invalid` + 用户传进来的那个值 —— **不说允许哪些,
+    //    也不说还有没有别的路**。2026-08-28 实测:从 Dashboard 建一个
+    //    `codex-app-server` 节点,用户拿到的就是
+    //      {"ok":false,"error":"runtime_invalid","value":"codex-app-server"}
+    //    而目标机器的 daemon 日志里一行都没有(请求根本没到)。
+    //    用户无从知道:①哪些是允许的 ②这个名字是不是打错了 ③有没有别的办法。
+    //
+    // `allowed` 直接由 RUNTIMES 展开,不是手写的第二份清单 ——
+    // 🔴 手写一份会漂移,而漂移之后报错会**理直气壮地告诉用户一组错的名字**。
+    throw new ValidationError("runtime_invalid", {
+      value: typeof s === "string" ? s.slice(0, 80) : typeof s,
+      allowed: [...RUNTIMES],
+      // 这句提示的前提是查过的:`agent-network/src/normalize-runtime.ts` 的
+      // `RuntimeName` / `SUPPORTED_RUNTIME_NAMES` 是 7 个,包含此处不放行的那几个,
+      // 所以「在目标机器上直接建」确实是一条真实存在的路,不是安慰话。
+      hint: "daemon 远程创建目前只放行以上 runtime；其余 runtime 可以在目标机器上直接 `anet node create --runtime <name>` 创建。",
+    });
   }
 }
 


### PR DESCRIPTION
## 用户现在拿到的是什么

2026-08-28 实测，从 Dashboard 建一个 `codex-app-server` 节点：

```json
{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}
```

而目标机器的 daemon 日志里**一行都没有** —— 请求被 hub 拦在最前面。

**用户无从知道三件事**：① 哪些是允许的 ② 这个名字是不是打错了 ③ 有没有别的办法。

## 改成什么

带上 `allowed` 和 `hint`。`ValidationError` 的 `detail` 被 `tools.ts` 的
`validationFailReply` **原样展开**（`...(e.detail || {})`），所以新字段自动到用户面前，**不用改映射层**。

🔴 **`allowed` 直接由 `RUNTIMES` 展开，不手抄第二份** —— 手抄的会漂，
而漂了之后**报错会理直气壮地告诉用户一组错的名字**。测试直接断言 `allowed === [...RUNTIMES]`。

🔴 **hint 里那句「其余 runtime 可以在目标机器上直接 `anet node create`」是查过的**：
`agent-network/src/normalize-runtime.ts` 的 `RuntimeName` / `SUPPORTED_RUNTIME_NAMES` 是 **7 个**，
包含此处不放行的那几个。**不是安慰话。**

## 这个改动与「要不要放开到 7」无关，所以先做

| 决定 | 这个 PR 还需要吗 |
|---|---|
| 放开到 7 | **需要** —— 对真正非法的 runtime 仍要说清楚 |
| 不放开 | **需要** —— 它本身就是修复 |

两条分支的交集，不等决定。

## witnessed-red

| 变异 | 结果 |
|---|---|
| 去掉 `allowed` + `hint`（回到改动前） | **32 pass / 2 fail** |
| `allowed` 改成手抄清单 | **33 pass / 1 fail** |
| 还原 | **34 pass / 0 fail** |

另有一条正控：合法 runtime 全循环 + **非字符串/undefined 必须仍被拒** ——
否则「7 个全过」这条断言本身说明不了什么。

Refs #1298