### PR TITLE
docs(support-matrix): 更正脚注 ^1^ —— 是四道闸，而且其中三道已经开了

### DIFF
--- a/docs-site/docs/en/guide/support-matrix.md
+++ b/docs-site/docs/en/guide/support-matrix.md
@@ -59,10 +59,29 @@ The authoritative runtime list is the code (`OK_RUNTIMES`, see `deploy/fleet/ane
 
 **Footnotes (each one measured, not read from docs)**
 
-- **^1^** None of the three TUI co-presence runtimes can be created by a daemon. Three separate gates
-  block them; one of them, `VALID_RUNTIMES` in `create-node-daemon.ts`, is a **hard-coded constant** that
-  no operator config can work around. Verified by grepping the **published artifact**
-  (`@sleep2agi/agent-node@2.5.0-preview.34`), not just the source.
+- **^1^** 🔴 **This footnote was corrected on 2026-08-28; the original text no longer holds.**
+  It used to say "three separate gates block them; one of them, `VALID_RUNTIMES` in
+  `create-node-daemon.ts`, is a hard-coded constant that no operator config can work around."
+  Reading all four places on `origin/main`, it is **four gates, and three of them are already open**:
+
+  | # | Location | Current contents | Blocks the three? |
+  |---|---|---|---|
+  | **①** | **`server/src/create-node-validate.ts:20` `RUNTIMES`** | **3 entries** | 🔴 **yes — and it fires first** |
+  | ② | `agent-network/src/normalize-runtime.ts` `SUPPORTED_RUNTIME_NAMES` | **all 7** | no |
+  | ③ | `agent-node/src/runtime/create-node-daemon.ts` `VALID_RUNTIMES` | **all 7** | no |
+  | ④ | the daemon's `allowedRuntimes` (from config) | operator-configurable | depends on config |
+
+  Measured on the Mac Mini daemon, 2026-08-28: `codex-app-server` returns
+  `{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}` and the target machine's
+  daemon log has **not a single line** ⇒ the hub gate fired first and the request never reached the machine.
+  The discriminator is that the response **carries `value`** — `runtime_invalid` has two sources in this
+  repo and only the hub one attaches `value`. On the same machine `codex-sdk` was created successfully
+  (four spawn-verification lines + hub registration + full delete chain) — **a control.**
+
+  ⚠️ Widening that hub constant is technically a one-liner, but **a product question comes first**:
+  these three runtimes exist so a **human and an agent share one TUI session**, while a daemon creates an
+  **unattended** background process. **Who would use the result?** Widening the constant only lets the
+  request reach the daemon; it does **not** mean the resulting node is usable.
   → [#1298](https://github.com/sleep2agi/agent-network/issues/1298)
 - **^2^** Under `claude-code-cli`, Claude Code itself hosts commhub as an in-process channel, so the
   **`agent-node` process is never started** — and node-level logs are written by `agent-node`. Its session

--- a/docs-site/docs/guide/support-matrix.md
+++ b/docs-site/docs/guide/support-matrix.md
@@ -56,9 +56,27 @@
 
 **脚注（每一条都是实测，不是读文档）**
 
-- **^1^** 三个 TUI 共存 runtime 在 daemon 上一个都创建不出来，卡在三道闸，其中
-  `create-node-daemon.ts` 里的 `VALID_RUNTIMES` 是**写死的常量**，运维改配置也绕不过。
-  已在已发布产物（`@sleep2agi/agent-node@2.5.0-preview.34`）里 grep 复核，不是只看源码。
+- **^1^** 🔴 **这条脚注 2026-08-28 更正过一次,原文已经不成立。**
+  原文说「卡在三道闸,其中 `create-node-daemon.ts` 里的 `VALID_RUNTIMES` 是**写死的常量**,
+  运维改配置也绕不过」。逐处读完 `origin/main`,实际是**四道,而且其中三道已经开了**:
+
+  | # | 位置 | 现在的内容 | 阻不阻这三个 |
+  |---|---|---|---|
+  | **①** | **`server/src/create-node-validate.ts:20` `RUNTIMES`** | **3 个** | 🔴 **阻,而且排最前** |
+  | ② | `agent-network/src/normalize-runtime.ts` `SUPPORTED_RUNTIME_NAMES` | **7 个全在** | 不阻 |
+  | ③ | `agent-node/src/runtime/create-node-daemon.ts` `VALID_RUNTIMES` | **7 个全在** | 不阻 |
+  | ④ | daemon 的 `allowedRuntimes`（来自 config） | 运维可配 | 取决于配置 |
+
+  2026-08-28 在 Mac Mini 的 daemon 上实测:`codex-app-server` 返回
+  `{"ok":false,"error":"runtime_invalid","value":"codex-app-server"}`,**目标机器 daemon 日志一行都没有**
+  ⇒ hub 那道先响,请求根本没到机器。判据是返回**带 `value` 字段** ——
+  `runtime_invalid` 在仓里有两个来源,只有 hub 那处带 `value`。
+  同一台机器上 `codex-sdk` 创建成功(spawn 四行验证 + hub 注册 + 删除全链)—— **有对照**。
+
+  ⚠️ 放开 hub 那个常量技术上是一行,但**放开之前要先回答一个产品问题**:
+  这三个 runtime 的本质是「人和 agent 共用一个 TUI 会话」,而 daemon 建出来的是
+  **无人值守**的后台进程。**建出来给谁用?** 放开常量只让请求走到 daemon,
+  **不等于那个节点能用**。
   → [#1298](https://github.com/sleep2agi/agent-network/issues/1298)
 - **^2^** `claude-code-cli` 模式下 Claude Code 自己以 in-process channel 承载 commhub，
   **`agent-node` 进程从来没有被启动过** —— 节点层日志是 agent-node 写的，那个进程不存在。


### PR DESCRIPTION
## 原文哪里不成立

> 三个 TUI 共存 runtime 在 daemon 上一个都创建不出来，卡在**三道闸**，其中
> `create-node-daemon.ts` 里的 `VALID_RUNTIMES` 是**写死的常量**，运维改配置也绕不过。

逐处读 `origin/main`，两句话都不成立：

| # | 位置 | 现在的内容 | 阻不阻 |
|---|---|---|---|
| **①** | **`server/src/create-node-validate.ts:20` `RUNTIMES`** | **3 个** | 🔴 **阻，且排最前**（原文说 hub 侧「没有」） |
| ② | `SUPPORTED_RUNTIME_NAMES` | **7 个全在** | 不阻 |
| ③ | `VALID_RUNTIMES` | **7 个全在**（原文说是写死的 3 元组） | 不阻 |
| ④ | daemon `allowedRuntimes` | 运维可配 | 可配 |

🔴 **按原文去做，会花时间改两处已经改好的地方，然后发现还是过不去。**

## 实测支撑（2026-08-28，Mac Mini daemon + 生产 hub）

```
codex-app-server → {"ok":false,"error":"runtime_invalid","value":"codex-app-server"}
                   目标机器 daemon 日志**一行都没有**
codex-sdk        → 创建成功（spawn 四行验证 + hub 注册 + 删除全链）   ← 对照
```

**判据是返回带 `value` 字段** —— `runtime_invalid` 在仓里有两个来源，只有 hub 那处带。

## 同时写明了放开之前要先答的问题

三个共存 runtime 的本质是**人和 agent 共用一个 TUI 会话**，而 daemon 建的是**无人值守**后台进程。
**建出来给谁用？** 放开常量只让请求走到 daemon，**不等于那个节点能用**。

## 一条方法上的自查

改文档前**重验了一次三个常量的实际内容**，没有凭上一轮的记忆写。
其中一次我的取数脚本还错了一回（`s.index(']')` 撞上类型标注 `readonly RuntimeName[]` 里的 `]`，
切在数组开始之前，得出「0 个」）—— **加了正控（同样取法用在已知 3 个的 hub 常量上）才发现**。

中英两份同步；三道文档门 rc=0。

Refs #1298