### PR TITLE
feat(hub): /api/nodes 显式给出 lifecycle_controllable —— 别让前端靠 id 前缀猜

### DIFF
--- a/server/src/node-lifecycle-controllable.test.ts
+++ b/server/src/node-lifecycle-controllable.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  childNodeIdForCreateRequest,
+  buildControllableMap,
+  isLifecycleControllable,
+} from "./node-lifecycle-controllable.js";
+
+// app#196 —— 桌面端对 218 个节点里的 207 个（95%）显示了「停止/重启/删除」，
+// 而那三个工具的 schema 是 regex(/^node_[a-z0-9_-]+$/)，那 207 个是 n_ 开头，
+// 点下去只会看到一段 zod 正则原文。
+describe("childNodeIdForCreateRequest —— 推导规则", () => {
+  test("cr_ 前缀 → node_ 前缀，其余部分逐字保留", () => {
+    // 🔴 这一对是 2026-08-28 生产 hub 日志里真实的 create-node finalize 行，
+    //    不是我按注释造的。
+    expect(childNodeIdForCreateRequest("cr_59723b24-8372-4270-9b3c-1552e592a09f"))
+      .toBe("node_59723b24-8372-4270-9b3c-1552e592a09f");
+  });
+  test("不是 cr_ 开头的一律 null —— 不猜、不截断", () => {
+    expect(childNodeIdForCreateRequest("node_abc")).toBeNull();
+    expect(childNodeIdForCreateRequest("n_abc")).toBeNull();
+    expect(childNodeIdForCreateRequest("abc")).toBeNull();
+    expect(childNodeIdForCreateRequest("cr_")).toBeNull();   // 只有前缀，没有主体
+  });
+  test("非字符串输入不抛，返回 null", () => {
+    for (const v of [undefined, null, 123, {}, []]) {
+      expect(childNodeIdForCreateRequest(v as any)).toBeNull();
+    }
+  });
+});
+
+describe("isLifecycleControllable —— 判据不是 id 前缀", () => {
+  const map = buildControllableMap([
+    { request_id: "cr_aaa", daemon_node_id: "node_daemon_x" },
+    { request_id: "cr_bbb", daemon_node_id: "node_daemon_y" },
+    { request_id: "not-a-request", daemon_node_id: "node_daemon_z" },  // 应被丢弃
+  ]);
+
+  test("有创建记录的 → 可控", () => {
+    expect(isLifecycleControllable("node_aaa", null, map)).toBe(true);
+    expect(map.get("node_aaa")).toBe("node_daemon_x");
+  });
+
+  test("🔴 光有 node_ 前缀但没有创建记录 → 不可控", () => {
+    // 这条是本模块存在的理由：前缀是实现细节，不是判据。
+    expect(isLifecycleControllable("node_never_created", null, map)).toBe(false);
+  });
+
+  test("手工起的 n_ 节点 → 不可控（那 207 个）", () => {
+    expect(isLifecycleControllable("n_22b777bf", null, map)).toBe(false);
+  });
+
+  test("🔴 daemon 自己可控 —— 它在 node_create_requests 里没有记录", () => {
+    // 漏掉这条会把 3 个 daemon 从可控名单里误删。
+    expect(isLifecycleControllable("node_daemon_39bd1eeae3ee", "host_supervisor", map)).toBe(true);
+    // 正控：同一个 id 但 role 不是 host_supervisor ⇒ 仍不可控，
+    // 证明上面那条过是因为 role，不是因为 id 恰好带 node_ 前缀。
+    expect(isLifecycleControllable("node_daemon_39bd1eeae3ee", null, map)).toBe(false);
+  });
+
+  test("坏的 request_id 不会污染映射", () => {
+    expect(map.has("node_not-a-request")).toBe(false);
+    expect(map.size).toBe(2);
+  });
+});

--- a/server/src/node-lifecycle-controllable.ts
+++ b/server/src/node-lifecycle-controllable.ts
@@ -1,0 +1,51 @@
+/**
+ * app#196 —— 哪些节点能走 stop_node / restart_node / delete_node。
+ *
+ * 抽成独立模块而不是写在 /api/nodes 的路由里,因为路由里的内联逻辑测不到 ——
+ * 现有的 api-nodes-shape.test.ts 是直跑 handler 的 SQL,拿不到映射步骤。
+ * 🔴 「不可测」本身就是一个设计信号,不是测试的问题。
+ */
+
+/** 子节点 id 由创建请求 id 确定性推导。
+ *
+ * 🔴 这条规则我用真实一对验过,不是只读注释:
+ *    cr_59723b24-8372-4270-9b3c-1552e592a09f → node_59723b24-8372-4270-9b3c-…
+ *    (2026-08-28 生产 hub 日志的 `create-node finalize` 行)
+ *
+ * 非 `cr_` 开头的一律返回 null —— 不猜,不截断。 */
+export function childNodeIdForCreateRequest(requestId: unknown): string | null {
+  if (typeof requestId !== "string") return null;
+  if (!requestId.startsWith("cr_")) return null;
+  const rest = requestId.slice(3);
+  if (!rest) return null;
+  return `node_${rest}`;
+}
+
+/** 由创建记录建出「child node_id → daemon node_id」的映射。 */
+export function buildControllableMap(
+  createRequests: Array<{ request_id?: unknown; daemon_node_id?: unknown }>,
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const cr of createRequests) {
+    const child = childNodeIdForCreateRequest(cr?.request_id);
+    if (!child) continue;
+    m.set(child, typeof cr?.daemon_node_id === "string" ? cr.daemon_node_id : "");
+  }
+  return m;
+}
+
+/** 一个节点能不能走生命周期操作。
+ *
+ * 🔴 判据**不是 id 前缀**。前缀是实现细节;判据是 node_create_requests 里真有创建记录。
+ *
+ * 例外:daemon 自己(role=host_supervisor)也能被 restart/stop,而它在
+ * node_create_requests 里**没有**记录(它不是被别的 daemon 创建的)—— 单独放行。
+ * 漏掉这一条会把可控的 daemon 判成不可控。 */
+export function isLifecycleControllable(
+  nodeId: unknown,
+  role: unknown,
+  controllable: Map<string, string>,
+): boolean {
+  if (role === "host_supervisor") return true;
+  return typeof nodeId === "string" && controllable.has(nodeId);
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parseDbTimestampMs } from "./db-timestamp.js";
+import { buildControllableMap, isLifecycleControllable } from "./node-lifecycle-controllable.js";
 import { resolvePort } from "./resolve-port.js";
 import { normalizeSessionRuntime } from "./runtime-label.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -3143,6 +3144,33 @@ return Bun.serve({
       // discovery (replacing the prior `node_daemon_` prefix heuristic).
       // RFC-026 P1 P2 §9 will supersede this REST proxy with the
       // `list_host_supervisors` MCP tool.
+      // app#196 —— 哪些节点能走 stop_node / restart_node / delete_node。
+      //
+      // 背景:那三个工具的 schema 是 `regex(/^node_[a-z0-9_-]+$/)`,而节点 id 有两种:
+      //   node_xxxx  daemon 建出来的子节点(+ daemon 自己)
+      //   n_xxxx     人手工 `anet node start` 起的
+      // 2026-08-28 对生产 hub 实测:218 个节点里 **207 个是 n_**,
+      // 在桌面端点「停止」只会看到一段 zod 正则原文。
+      //
+      // 🔴 这不是「正则写窄了」——那三个工具的做法是**让那台机器上的 daemon 去停它
+      //    自己建的子进程**。手工起的节点没有 daemon 可问,放宽正则只会把失败推到更深处。
+      //
+      // 所以这里给出一个显式标志,**让前端不必靠 id 前缀去猜**。判据不是前缀,
+      // 是 node_create_requests 里真的有对应的创建记录 ——
+      // 子节点 id 由 request_id 确定性推导:`node_${request_id.replace(/^cr_/,"")}`
+      // (2026-08-28 用真实一对验过:cr_59723b24-… → node_59723b24-…)。
+      const controllable = (() => {
+        try {
+          const crParams: any[] = [];
+          let crSql = "SELECT request_id, daemon_node_id FROM node_create_requests WHERE 1=1";
+          crSql = addNetworkScope(crSql, crParams, restScope);
+          return buildControllableMap(db.all<Record<string, any>>(crSql, ...crParams));
+        } catch {
+          // 表不存在/查询失败 ⇒ 全部按不可控处理,不让这一格拖垮整个列表
+          return new Map<string, string>();
+        }
+      })();
+
       const rows = rawRows.map(r => {
         let role: string | null = null;
         const snap = r.config_snapshot;
@@ -3155,11 +3183,17 @@ return Bun.serve({
         // it can map() without a guard, and normalise legacy/absent values
         // to [] rather than null. attrs_revision is normalised to a number
         // so pre-migration rows (NULL) read as 0.
+        // app#196 —— 显式告诉前端这个节点能不能走生命周期操作,以及该找哪个 daemon。
+        // daemon 自己(role=host_supervisor)也能被 restart/stop,它的 id 同样是 node_ 前缀
+        // 且在 node_create_requests 里没有记录,所以单独放行。
+        const lifecycle_controllable = isLifecycleControllable(r.node_id, role, controllable);
         return {
           ...rest,
           tags: parseStoredTags(r.tags),
           attrs_revision: Number(r.attrs_revision ?? 0),
           role,
+          lifecycle_controllable,
+          lifecycle_daemon_node_id: controllable.get(r.node_id) ?? null,
         };
       });
       return withCors(req, Response.json({ ok: true, nodes: rows, count: rows.length }));


### PR DESCRIPTION
## 问题

桌面端对**所有**节点显示「停止/重启/删除」，而 `stop_node` / `delete_node` 的 schema 是
`regex(/^node_[a-z0-9_-]+$/)`。2026-08-28 对生产 hub 实测：

| 格式 | 谁是这种 | 数量 | 点「停止」 |
|---|---|---|---|
| `node_xxxx` | daemon 建的子节点 + daemon 自己 | **11** | ✅ |
| `n_xxxx` | 人手工起的 | **207（95%）** | ❌ 一段 zod 正则原文 |

🔴 **这不是正则写窄了。** 那三个工具的做法是「让那台机器上的 daemon 去停它自己建的子进程」；
手工起的节点**没有 daemon 可问**，放宽正则只会把失败推到更深处。

## 改动

`/api/nodes` 每行新增：

```
lifecycle_controllable     能不能走 stop/restart/delete
lifecycle_daemon_node_id   能的话该找哪个 daemon（否则 null）
```

🔴 **判据不是 id 前缀，是 `node_create_requests` 里真有创建记录。**
前缀今天恰好等价 —— 而**一个「今天恰好成立」的判据会在明天悄悄失效**。

## 为什么抽成独立模块

第一版我写在路由内联里，然后发现**测不到** —— 现有的 `api-nodes-shape.test.ts`
是直跑 handler 的 SQL，拿不到映射步骤。
🔴 **「不可测」本身就是设计信号，不是测试的问题。**

## 一个漏掉就会误伤的边界

daemon 自己（`role=host_supervisor`）能被 restart/stop，但它**在 `node_create_requests` 里没有记录**。
漏掉这条会把 3 个 daemon 判成不可控。

**测试里配了正控**：同一个 id 但 `role` 不是 host_supervisor ⇒ 仍不可控 ——
证明它过是因为 role，**不是因为 id 恰好带 `node_` 前缀**。

## 推导规则用真实数据钉住

```
cr_59723b24-8372-4270-9b3c-1552e592a09f → node_59723b24-8372-4270-9b3c-…
```
取自 2026-08-28 生产 hub 日志的 `create-node finalize` 行，**不是按代码注释造的**。

## witnessed-red

| 变异 | 结果 |
|---|---|
| **判据改回 `nodeId.startsWith("node_")`** | **6 pass / 2 fail** |
| 去掉 daemon 自己的放行 | **7 pass / 1 fail** |
| 还原 | **8 pass / 0 fail** |

🔴 **变异 A 就是那个"顺手的错误写法"** —— 它在今天的生产数据上**看起来完全正确**。

Refs sleep2agi/agent-network-app#196