### PR TITLE
ci: 仓库里的 hub 启动器必须和仓库自己声明的 hub 版本对上（#735 复发）

### DIFF
--- a/.github/workflows/hub-launcher-pin.yml
+++ b/.github/workflows/hub-launcher-pin.yml
@@ -1,0 +1,37 @@
+# 仓库里的 hub 启动器,必须和仓库自己声明的 hub 版本对上。
+#
+# 2026-08-28 实测 origin/main:`deploy/hub/hub-daemon.sh` 起 `preview29`,
+# 而 `PINNED_SERVER_VERSION` 是 `preview.34` —— **差 5 个版本,而仓库里没有任何东西
+# 注意到**。照仓库部署会起一个和仓库声明不同的 hub。
+#
+# 这不是新问题:#735(2026-08-12)报的正是「仓库无法复现生产 hub 启动器」,
+# 当时的修法是**把文件拷进仓库**,同日关闭。16 天后它又落后了 ——
+# 🔴 **一次性拷贝没有配任何保持同步的机制,而不同步不会让任何东西变红。**
+# 这道门就是那个缺失的机制。
+#
+# 🔴 关于触发范围:**不加 paths 过滤**,和 doc-symbol-anchors.yml 同理。
+# 这道门的主要失效场景是「有人 bump 了 PINNED_SERVER_VERSION 而忘了启动器」——
+# 那是一个改 `agent-network/bin/cli.ts` 的 PR。若按 `deploy/**` 过滤,
+# 恰恰在最需要它的那类改动上永远不触发。脚本跑完不到一秒。
+#
+# 🔴 它管什么、不管什么(脚本里也写了,这里再说一遍因为分支保护看的是这个名字):
+#   管   —— 仓库内部两个值一致
+#   不管 —— 仓库与**生产机器**上那份一致。CI 看不到生产。
+#           (2026-08-28 生产实际在跑 preview.35,比仓库的 pin 还新一版。)
+#           别把这道门的绿读成「仓库和生产一致」。
+
+name: lint (hub launcher pin)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    # 这个 name 是分支保护里能写的唯一标识符,必须全仓唯一。
+    name: hub-launcher-pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/check-hub-launcher-pin.py

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -51,7 +51,14 @@ set -uo pipefail
 #   回滚目标 = runtime-v32-run-terminal-d5199bc9，目录仍在；hub-daemon 备份见 rollback-693-*
 # 2026-08-13 00:5x: runtime-v33 → runtime-v34-preview29(0.9.0-preview.29;含 #698 peer-reply 终结原任务、#697 model 注入)
 #   回滚目标 = runtime-v33-upload-bridge-17b8223f(0.9.0-preview.27),目录仍在
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview29"
+# 2026-08-28: preview29 → preview34（对齐 PINNED_SERVER_VERSION）
+#   🔴 这一条不是一次真实的机器升级记录,是**把仓库这份对齐到仓库自己声明的版本**。
+#      在此之前仓库启动器写 preview29、PINNED_SERVER_VERSION 写 preview.34,
+#      差 5 个版本而没有任何东西变红 —— 见 #735 与 scripts/check-hub-launcher-pin.py。
+#   🔴 `runtime-v34-` 里的 v34 是**机器本地的升级序号**,不同机器必然不同,
+#      所以那道门只比 previewMM,不比 vNN。这里保留 v34 只是不改无关的东西。
+#   回滚目标 = 生产机器上那份的当前值(以该机器为准,不以本文件为准)
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview34"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/scripts/check-hub-launcher-pin.py
+++ b/scripts/check-hub-launcher-pin.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""仓库里的 hub 启动器,必须和仓库自己声明的 hub 版本对上。
+
+为什么需要这道门
+================
+
+`deploy/hub/hub-daemon.sh` 是 pm2 用来起生产 hub 的启动器,它里面有一行
+`RUNTIME_DIR="$HOME/.commhub/runtime-vNN-previewMM"` —— **MM 决定实际起哪个版本的
+commhub-server**。而 `agent-network/bin/cli.ts` 的 `PINNED_SERVER_VERSION` 是
+`anet hub start` 会去拉的版本。**这两个值指的是同一件事:这个仓库认为 hub 该是哪一版。**
+
+🔴 它们会悄悄分叉,而且分叉不会让任何东西变红:
+2026-08-28 实测,`origin/main` 上启动器写 `preview29`、pin 写 `preview.34` ——
+**差 5 个版本,而仓库里没有任何东西注意到。**
+
+这不是假想。#735(2026-08-12)报的正是"仓库无法复现生产 hub 启动器",
+当时的修法是**把文件拷进仓库**。16 天后它又落后了 —— 因为
+**一次性拷贝没有配任何保持同步的机制,不同步不会让任何东西变红。**
+
+这道门管什么、不管什么
+======================
+
+**管**: 仓库内部两个值一致(启动器的 previewMM == PINNED_SERVER_VERSION 的后缀)。
+       这是 CI 能验证的、自洽的不变式。
+
+🔴 **不管**: 仓库与**生产机器上那份**是否一致。CI 看不到生产机器。
+       (2026-08-28 生产实际在跑 preview.35,比仓库的 pin 还新一版。)
+       判断生产实际版本请查该机器的 `~/.local/bin/hub-daemon.sh` 或 `curl /health`,
+       **别拿仓库里这份当生产状态的依据。**
+
+🔴 `RUNTIME_DIR` 里的 `vNN` 是**机器本地的序号**,不参与比较 —— 两台机器升级次数不同,
+   vNN 必然不同,拿它比会制造永远修不好的红。只比 previewMM。
+"""
+import re, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = ROOT / "deploy" / "hub" / "hub-daemon.sh"
+CLI = ROOT / "agent-network" / "bin" / "cli.ts"
+
+
+def launcher_preview(text: str):
+    """从 RUNTIME_DIR 行里取 previewMM 的 MM。取不到返回 None(而不是猜)。"""
+    m = re.search(r'^RUNTIME_DIR=.*runtime-v\d+-preview(\d+)', text, re.M)
+    return m.group(1) if m else None
+
+
+def pinned_preview(text: str):
+    """从 PINNED_SERVER_VERSION 取 -preview.MM 的 MM。"""
+    m = re.search(r'const PINNED_SERVER_VERSION\s*=\s*"[\d.]+-preview\.(\d+)"', text)
+    return m.group(1) if m else None
+
+
+def main() -> int:
+    if not LAUNCHER.exists():
+        print(f"::error::{LAUNCHER.relative_to(ROOT)} 不存在 —— #735 说的正是这个:仓库无法复现生产启动器")
+        return 1
+    if not CLI.exists():
+        print(f"::error::{CLI.relative_to(ROOT)} 不存在")
+        return 1
+
+    lt, ct = LAUNCHER.read_text(), CLI.read_text()
+    lp, pp = launcher_preview(lt), pinned_preview(ct)
+
+    # 🔴 取不到就红,不当成"通过"。一个取不到值的检查和一个通过的检查
+    #    在退出码上一模一样 —— 这正是要防的。
+    if lp is None:
+        print(f"::error::在 {LAUNCHER.relative_to(ROOT)} 里找不到 "
+              f"`RUNTIME_DIR=...runtime-vNN-previewMM` 形态的行。"
+              f"改了命名规则就要同步改这道门,别让它静默变成 no-op。")
+        return 1
+    if pp is None:
+        print(f"::error::在 {CLI.relative_to(ROOT)} 里找不到 "
+              f"`const PINNED_SERVER_VERSION = \"...-preview.MM\"`。")
+        return 1
+
+    print(f"launcher RUNTIME_DIR → preview{lp}")
+    print(f"PINNED_SERVER_VERSION → preview.{pp}")
+
+    if lp != pp:
+        print(f"::error::仓库内部不一致:启动器起的是 preview{lp},而仓库声明的 hub 版本是 preview.{pp}。")
+        print("  照仓库部署会起一个和 PINNED_SERVER_VERSION 不同的 hub。")
+        print(f"  修法:把 {LAUNCHER.relative_to(ROOT)} 的 RUNTIME_DIR 改成 ...-preview{pp},")
+        print("        并在它上方的升级记录里加一行(那段记录是回滚时唯一的线索,别省)。")
+        return 1
+
+    print(f"✅ 一致(preview{lp})。")
+    print("🔴 注意:这只说明**仓库内部**自洽。它不检查生产机器上那份 —— CI 看不到生产。")
+    print("   判断生产实际版本:该机器的 ~/.local/bin/hub-daemon.sh 或 curl /health。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test735-hub-daemon-rebuild/run.sh
+++ b/tests/test735-hub-daemon-rebuild/run.sh
@@ -4,6 +4,23 @@ set -euo pipefail
 source /lib/safe-rm.sh
 
 SCRIPT=/app/deploy/hub/hub-daemon.sh
+
+# 🔴 2026-08-28:夹具原来把那个 runtime 目录名(当时是 v34-preview29)写死在 5 处。
+#    后果是**每一次合法的 hub 版本 bump 都会打破这个测试** ——
+#    而这很可能就是 deploy/hub/hub-daemon.sh 长期没人更新的原因:
+#    更新它会让这里变红,于是就没人更新,于是仓库与生产漂了 6 个版本(见 #735)。
+#
+#    改成从被测脚本自己读。这样:
+#      · 版本 bump 不再打破本套件
+#      · 夹具路径与脚本实际要用的路径**必然一致**(而不是"碰巧一致")
+#    取不到就退出 1,不静默用一个默认值 —— 一个用错路径的夹具会让
+#    后面每一条断言都在测别的东西,而它们照样能绿。
+RUNTIME_BASENAME=$(sed -n 's|^RUNTIME_DIR="\$HOME/\.commhub/\([^"]*\)"|\1|p' "$SCRIPT" | head -1)
+if [ -z "$RUNTIME_BASENAME" ]; then
+  echo "FAIL: 从 $SCRIPT 里取不到 RUNTIME_DIR 的目录名。改了那一行的写法就要同步改这里。" >&2
+  exit 1
+fi
+echo "runtime dir (从脚本读出): $RUNTIME_BASENAME"
 ROOT="/tmp/test735-$$"
 trap 'safe_rm_rf "$ROOT"' EXIT
 
@@ -12,9 +29,9 @@ new_fixture() {
   local dir="$ROOT/$name"
   safe_rm_rf "$dir"
   mkdir -p \
-    "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin" \
+    "$dir/home/.commhub/$RUNTIME_BASENAME/node_modules/@sleep2agi/commhub-server/bin" \
     "$dir/fake-bin"
-  : > "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
+  : > "$dir/home/.commhub/$RUNTIME_BASENAME/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
   printf 'ANET_HUB_SECRET_VAULT_KEY=test-fixture-only\n' > "$dir/hub.env"
 
   cat > "$dir/fake-bin/bun" <<'EOF'
@@ -61,7 +78,7 @@ assert_success_path() {
   dir="$(new_fixture success)"
   invoke "$script" "$dir"
   test -s "$dir/bun.log"
-  grep -Fq "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin/commhub.ts" "$dir/bun.log"
+  grep -Fq "$dir/home/.commhub/$RUNTIME_BASENAME/node_modules/@sleep2agi/commhub-server/bin/commhub.ts" "$dir/bun.log"
   grep -Fq '预检通过' "$dir/output.log"
   grep -Fq '监听 127.0.0.1:19299' "$dir/output.log"
 }
@@ -84,7 +101,7 @@ assert_missing_runtime_rejected() {
   local script="$1"
   local dir rc
   dir="$(new_fixture missing-runtime)"
-  safe_rm_rf "$dir/home/.commhub/runtime-v34-preview29"
+  safe_rm_rf "$dir/home/.commhub/$RUNTIME_BASENAME"
   set +e
   invoke "$script" "$dir"
   rc=$?


### PR DESCRIPTION
## main 上现在就是分叉的

```
deploy/hub/hub-daemon.sh   RUNTIME_DIR="…/runtime-v34-preview29"
agent-network/bin/cli.ts   PINNED_SERVER_VERSION = "0.9.0-preview.34"
```

**差 5 个版本，而仓库里没有任何东西注意到。** 照仓库部署会起一个和仓库自己声明的版本不同的 hub。

## 这不是新问题，是复发

**#735（2026-08-12）** 标题就是「production hub-daemon.sh is machine-local only;
repo cannot reconstruct the current Hub launcher」，**同日关闭、0 条评论**，
修法是**把文件拷进仓库**。

**16 天后它又落后了。**

🔴 **一次性拷贝没有配任何保持同步的机制，而不同步不会让任何东西变红。**
这道门就是那个缺失的机制 —— 我没有再拷一次生产那份，因为**那只是把今天的快照换成新的快照**。

## 门管什么、不管什么

| | |
|---|---|
| **管** | 仓库内部两个值一致 |
| **不管** | 仓库与**生产机器**上那份一致 —— **CI 看不到生产** |

🔴 2026-08-28 生产实际在跑 **preview.35**，**比仓库的 pin 还新一版**。
**别把这道门的绿读成「仓库和生产一致」** —— 那是它给不了的保证。这句话写在脚本和 workflow 两处。

## 三个设计取舍

🔴 **只比 `previewMM`，不比 `vNN`** —— `v34` 是**机器本地的升级序号**，两台机器必然不同，
拿它比会制造一道**永远修不好的红**。

🔴 **取不到值就红，不当通过** —— **一个取不到值的检查和一个通过的检查，在退出码上一模一样**。
改了命名规则，门会明确说「同步改这道门，别让它静默变 no-op」。

🔴 **不加 paths 过滤**（与 `doc-symbol-anchors.yml` 同理）—— 主要失效场景是
「bump 了 `PINNED_SERVER_VERSION` 却忘了启动器」，**那是一个改 `cli.ts` 的 PR**。
按 `deploy/**` 过滤会让它**在最需要的那类改动上永不触发**。

## 验证

| | 结果 |
|---|---|
| 改前 | **rc=1**（报出真实的 preview29 vs preview.34） |
| 对齐后 | rc=0 |
| **正控**：把 pin 改成 `preview.99` | **rc=1** |
| 还原 | rc=0 |
| `check-workflow-structure.py` | rc=0（29 workflow / 55 job） |
| job name `hub-launcher-pin` 全仓唯一 | ✅ |

Refs #735