### PR TITLE
feat(#1298): hub 放开 daemon 远程创建的 runtime，3 个 → 7 个

### DIFF
--- a/server/src/create-node-validate.test.ts
+++ b/server/src/create-node-validate.test.ts
@@ -202,6 +202,10 @@ describe("buildAnetArgs (§4.2.2 F2 — fully validated argv)", () => {
 //   {"ok":false,"error":"runtime_invalid","value":"codex-app-server"}
 // 而目标机器的 daemon 日志里一行都没有 —— 请求被 hub 拦在最前面，
 // 用户无从知道①哪些允许②是不是打错了③有没有别的办法。
+// 🔴 2026-08-28:这一节原本拿 `codex-app-server` / `opencode-cli` 当"非法 runtime"的例子。
+//    #1298 把 hub 的 RUNTIMES 从 3 个放开到 7 个之后,那两个变成了合法值,这两条测试因此红了 ——
+//    **测试正确地抓到了行为变更**。修法是换例子,不是削弱断言:
+//    意图仍然是「非法 runtime 要给可操作的报错」,只是例子换成永远不会合法的字符串。
 describe("validateRuntime — 报错要可操作", () => {
   function thrown(v: unknown): any {
     try { validateRuntime(v); } catch (e: any) { return e; }
@@ -209,7 +213,7 @@ describe("validateRuntime — 报错要可操作", () => {
   }
 
   test("非法 runtime 的报错带上允许集合", () => {
-    const e = thrown("codex-app-server");
+    const e = thrown("definitely-not-a-runtime");
     expect(e.code).toBe("runtime_invalid");
     expect(Array.isArray(e.detail?.allowed)).toBe(true);
     // 🔴 断言它等于 RUNTIMES 本身,而不是等于一份手抄的清单 ——
@@ -218,7 +222,7 @@ describe("validateRuntime — 报错要可操作", () => {
   });
 
   test("报错带上一条出路提示", () => {
-    const e = thrown("opencode-cli");
+    const e = thrown("another-bogus-runtime");
     expect(typeof e.detail?.hint).toBe("string");
     expect(e.detail.hint.length).toBeGreaterThan(10);
     // 提示必须点名那条真实存在的路,否则它只是安慰话
@@ -237,5 +241,26 @@ describe("validateRuntime — 报错要可操作", () => {
     // 正控：非字符串必须仍然被拒 —— 否则上面那条循环全过也说明不了什么
     expect(() => validateRuntime(123 as any)).toThrow();
     expect(() => validateRuntime(undefined as any)).toThrow();
+  });
+});
+
+// #1298 —— daemon 远程创建放开到 7 个 runtime（Vincent 2026-08-28 定，
+// 理由是兜底排错：节点不动了，人要能进去跟 Codex / Claude Code 对话）。
+describe("#1298 RUNTIMES —— 七个都放行，且与 CLI 侧一致", () => {
+  test("三个共存 runtime 不再被拒", () => {
+    for (const r of ["codex-app-server", "grok-build-cli", "opencode-cli"]) {
+      expect(() => validateRuntime(r)).not.toThrow();
+    }
+  });
+  test("原有四个仍然放行（放开不该顺手改坏别的）", () => {
+    for (const r of ["claude-agent-sdk", "claude-code-cli", "codex-sdk", "grok-build-acp"]) {
+      expect(() => validateRuntime(r)).not.toThrow();
+    }
+  });
+  test("🔴 恰好七个 —— 多一个少一个都要有人解释", () => {
+    expect(RUNTIMES.length).toBe(7);
+    // 正控：不在名单里的仍然被拒，证明上面不是"什么都放行"
+    expect(() => validateRuntime("definitely-not-a-runtime")).toThrow();
+    expect(() => validateRuntime("")).toThrow();
   });
 });

--- a/server/src/create-node-validate.ts
+++ b/server/src/create-node-validate.ts
@@ -17,7 +17,33 @@ export class ValidationError extends Error {
 }
 
 // §4.2.2 — structural enums.
-export const RUNTIMES = ["claude-agent-sdk", "codex-sdk", "grok-build-acp"] as const;
+// #1298 —— daemon 远程创建允许的 runtime。2026-08-28 从 3 个放开到 7 个。
+//
+// 放开之前挡着的问题是「daemon 建出来的是**无人值守**的后台进程,而三个共存 runtime
+// 的本质是人和 agent 共用一个 TUI 会话 —— 建出来给谁用?」
+//
+// Vincent 2026-08-28 定,理由是**兜底排错**:
+//   「某个节点突然不动了,人可以进去看。在 daemon 还没那么靠谱的情况下,
+//     这非常重要 —— 至少可以跟 Codex 和 Claude Code 对话。」
+// 🔴 关键在于 **attach 是「建好之后」的动作,不是「建的时候」的前提**。
+//
+// 支撑读数(2026-08-28 实测舰队):`通信牛` 跑 codex-app-server(共存 runtime),
+// **764 次成功完成任务**,当天仍在跑 —— 比两个普通 runtime 的节点(61 次 / 3 次)
+// 都多一个量级。⇒ 任务链路不需要人坐在屏幕前。
+//
+// 🔴 这七个名字与 `agent-network/src/normalize-runtime.ts` 的 `RuntimeName` 一致。
+//    那边是 CLI 侧的全集;两边分叉过一次(daemon 侧的 VALID_RUNTIMES 早就是 7 个,
+//    只有这里还是 3 个,而记录此事的 #1298 正文写的是「三道闸都关着」——
+//    **一份快照式的盘点,只在写下的那一刻是真的**)。
+export const RUNTIMES = [
+  "claude-agent-sdk",
+  "claude-code-cli",
+  "codex-sdk",
+  "codex-app-server",
+  "grok-build-acp",
+  "grok-build-cli",
+  "opencode-cli",
+] as const;
 export type Runtime = typeof RUNTIMES[number];
 
 export const FLAG_KEYS = ["permissionMode", "dangerouslySkipPermissions", "maxTurns", "budget", "timeout"] as const;


### PR DESCRIPTION
## 决定与理由（Vincent 2026-08-28）

挡着的问题是：三个共存 runtime 的本质是**人和 agent 共用一个 TUI 会话**，
而 daemon 建出来的是**无人值守**的后台进程 —— **建出来给谁用？**

> 「建远程的人机共存节点**肯定有意义**，因为人是要**进去排错**的。」
> 「某个节点突然不动了，人可以进去看。**在 daemon 还没那么靠谱的情况下，这非常重要** ——
> 至少可以跟 Codex 和 Claude Code 对话。」

🔴 **attach 是「建好之后」的动作，不是「建的时候」的前提。**

## 支撑读数（不是只凭理由）

2026-08-28 实测舰队：`通信牛` 跑 `codex-app-server`（共存 runtime），
**764 次成功完成任务**，当天仍在跑 —— 比两个普通 runtime 的节点（61 次 / 3 次）**多一个量级**。
⇒ **任务链路不需要人坐在屏幕前。**

（而「daemon 建的、从没人 attach 过的」这种节点当时**一个样本都没有** —— 因为这道闸拦着。
**鸡生蛋：不放开就永远没有样本。**）

## 七个名字不是手打的

从 `agent-network/src/normalize-runtime.ts` 的 `RuntimeName` 取，并用**集合差**验过：

```
hub - CLI = ∅        CLI - hub = ∅
```

🔴 这两边**分叉过一次**：daemon 侧的 `VALID_RUNTIMES` 早就是 7 个、CLI 侧也是 7 个，
**只有 hub 这一处还是 3 个**。而记录此事的 #1298 正文写的是「三道闸都关着，其中一道运维绕不过」——
**一份快照式的盘点，只在写下的那一刻是真的。**

## 顺带修了两条我自己的测试

#1372 里我拿 `codex-app-server` / `opencode-cli` 当「非法 runtime」的例子，放开后它们合法了 ——
**测试正确地抓到了行为变更**。
🔴 **修法是换例子不是削弱断言**：意图仍是「非法 runtime 要给可操作报错」，
只把例子换成永远不会合法的字符串，并在测试里写明为什么换。

## witnessed-red

| 变异 | 结果 |
|---|---|
| 改回 3 个 | **34 pass / 3 fail** |
| 只加 6 个（漏一个） | **35 pass / 2 fail** |
| 还原 | **37 pass / 0 fail** |

新测试含**正控**：不在名单里的仍被拒 —— **证明「七个都过」不是「什么都放行」**。

## 合入后我会做的

在 Mac Mini 上**真建一个 `codex-app-server` 节点**并验一次 —— 
判据是那个节点**真的完成一次任务**，不是「它注册上线了」。

Closes #1298