### PR TITLE
fix(#1353): 把 11 个混成一条的 anet_bin 失败原因拆成四类

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -182,8 +182,11 @@ import {
 //    realpathSync + statSync + 读文件哈希。每次心跳都跑一遍是纯浪费。
 //    代价是 daemon 运行期间修好了 pin 也要重启才会反映 —— 可接受,
 //    因为修 pin 的正规做法(写 /etc/anet-daemon/path.conf)本来就伴随重启。
-let _createCapCache: { ok: boolean; reason?: "anet_bin_pin_unresolved" } | null | undefined;
-function daemonCreateCapability(): { ok: boolean; reason?: "anet_bin_pin_unresolved" } | undefined {
+type CreateBlockedReason =
+  | "anet_bin_identity" | "anet_bin_source" | "anet_bin_shape"
+  | "anet_bin_permission" | "anet_bin_unknown";
+let _createCapCache: { ok: boolean; reason?: CreateBlockedReason } | null | undefined;
+function daemonCreateCapability(): { ok: boolean; reason?: CreateBlockedReason } | undefined {
   if (_createCapCache !== undefined) return _createCapCache ?? undefined;
   if (fileConfig?.role !== "host_supervisor") { _createCapCache = null; return undefined; }
   try {
@@ -192,11 +195,16 @@ function daemonCreateCapability(): { ok: boolean; reason?: "anet_bin_pin_unresol
     const mod = require("./runtime/create-node-daemon.js");
     mod.loadAndVerifyAnetBin();
     _createCapCache = { ok: true };
-  } catch {
+  } catch (e) {
     // 🔴 只报代码,**不报原始报错文本**。unsafePathHelp() 的消息里带完整机器路径,
     //    而这个字段会一路走到 hub 和 Dashboard —— 一条「哪台机器的哪个路径缺什么」
     //    本身就是一张地图。原文仍然进 daemon 自己的日志,那里是本地的。
-    _createCapCache = { ok: false, reason: "anet_bin_pin_unresolved" };
+    // 🔴 从 Error 上读机器可读的类别。拿不到就用 anet_bin_unknown,
+    //    **不猜一个具体类别** —— 猜错会让人按错的方向去修
+    //    (「要 sudo 改系统配置」和「一行 chmod go-w」是完全不同的两件事)。
+    const code = (e as any)?.anetBinCode;
+    const known = ["anet_bin_identity","anet_bin_source","anet_bin_shape","anet_bin_permission"];
+    _createCapCache = { ok: false, reason: known.includes(code) ? code : "anet_bin_unknown" };
   }
   return _createCapCache;
 }

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -676,3 +676,30 @@ describe("#1353 buildConfigSnapshot — 上报「当下能不能创建节点」"
     expect(blob).not.toContain("node_modules");
   });
 });
+
+// #1353 —— 四类失败原因，修法完全不同
+describe("#1353 create_nodes_blocked_reason —— 四类而不是一类", () => {
+  const cfg = { role: "host_supervisor" };
+  for (const r of ["anet_bin_identity", "anet_bin_source", "anet_bin_shape", "anet_bin_permission", "anet_bin_unknown"] as const) {
+    test(`上报 ${r}`, () => {
+      const s: any = buildConfigSnapshot(cfg, true, 1, { ok: false, reason: r });
+      expect(s.daemon_capabilities.can_create_nodes).toBe(false);
+      expect(s.daemon_capabilities.create_nodes_blocked_reason).toBe(r);
+    });
+  }
+
+  test("🔴 每一类都不能夹带路径", () => {
+    for (const r of ["anet_bin_identity", "anet_bin_source", "anet_bin_shape", "anet_bin_permission"] as const) {
+      const blob = JSON.stringify(buildConfigSnapshot(cfg, true, 1, { ok: false, reason: r }));
+      expect(blob).not.toContain("/");
+      expect(blob).not.toContain("\\");
+    }
+    // 正控：真会出现在上游 e.message 里的串，必须含 "/"，证明这条断言不是恒真
+    expect("chmod go-w '/home/x/anet.cjs'").toContain("/");
+  });
+
+  test("🔴 类别之间必须互不相同 —— 否则拆分等于没拆", () => {
+    const set = new Set(["anet_bin_identity", "anet_bin_source", "anet_bin_shape", "anet_bin_permission"]);
+    expect(set.size).toBe(4);
+  });
+});

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -414,7 +414,12 @@ export interface DaemonCapabilities {
    * 🔴 只报代码,**永远不报原始报错文本**。`unsafePathHelp()` 的消息里带
    *    完整的机器路径,而这个字段会一路走到 hub 和 Dashboard ——
    *    一条「哪台机器的哪个路径缺什么」本身就是一张地图。 */
-  create_nodes_blocked_reason?: "anet_bin_pin_unresolved";
+  create_nodes_blocked_reason?:
+    | "anet_bin_identity"     // 这个文件不是 anet 的 bin ⇒ 重装或 unset ANET_BIN_ABS
+    | "anet_bin_source"       // pin 从哪来 ⇒ 写 /etc/anet-daemon/path.conf（要 sudo）
+    | "anet_bin_shape"        // 路径形态 ⇒ 换成 realpath
+    | "anet_bin_permission"   // 权限 ⇒ 一行 chmod go-w
+    | "anet_bin_unknown";     // 拿不到类别时的兜底（见下）
 }
 
 export interface MaskedSnapshot {

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -40,8 +40,34 @@ function quoteSh(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-function unsafePathHelp(reason: string, fix: string): Error {
-  return new Error(`anet_bin_unsafe_path: ${reason}. Fix: ${fix}`);
+/** #1353 —— 二进制 pin 校验失败的**机器可读**类别。
+ *
+ * 在此之前 11 个语义完全不同的失败全部汇成同一条 `anet_bin_unsafe_path`,而修法差得很远:
+ *   permission → 一行 `chmod go-w`
+ *   source     → 写 `/etc/anet-daemon/path.conf`(**要 sudo,改系统配置**)
+ *   identity   → 重装 anet 或 unset ANET_BIN_ABS
+ *   shape      → 换成 realpath
+ *
+ * 🔴 2026-08-28 一天里撞到其中两类(source 和 permission),看到的是**同一条错误**。
+ *    第一反应是去建 /etc/anet-daemon/path.conf —— 而那次实际只要 chmod。
+ *    **把"要 sudo 改系统"和"一行 chmod"盖成同一句话,会让人修错方向。**
+ */
+export type AnetBinFailureCode =
+  | "anet_bin_identity"
+  | "anet_bin_source"
+  | "anet_bin_shape"
+  | "anet_bin_permission";
+
+export interface AnetBinError extends Error { anetBinCode?: AnetBinFailureCode }
+
+/** 🔴 消息前缀 `anet_bin_unsafe_path:` **保持不变**。全仓 10 个文件依赖它,
+ *  其中 create-node-daemon.test.ts 有 6 条 `toThrow(/anet_bin_unsafe_path.*.../)`。
+ *  改前缀会把它们全打断,而那和本次要解决的问题无关。
+ *  **机器可读的类别挂在 Error 属性上,不动人读的那一句。** */
+function unsafePathHelp(code: AnetBinFailureCode, reason: string, fix: string): AnetBinError {
+  const e = new Error(`anet_bin_unsafe_path: ${reason}. Fix: ${fix}`) as AnetBinError;
+  e.anetBinCode = code;
+  return e;
 }
 
 function findPackageJsonDir(start: string): string | null {
@@ -61,16 +87,16 @@ function findPackageJsonDir(start: string): string | null {
 function verifyAnetBinIdentity(abs: string): void {
   const pkgDir = findPackageJsonDir(abs);
   if (!pkgDir) {
-    throw unsafePathHelp(`not an anet package bin: no package.json above ${abs}`, "re-run via the installed anet command: anet daemon up");
+    throw unsafePathHelp("anet_bin_identity", `not an anet package bin: no package.json above ${abs}`, "re-run via the installed anet command: anet daemon up");
   }
   let pkg: any;
   try {
     pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
   } catch (e: any) {
-    throw unsafePathHelp(`not an anet package bin: cannot read package.json (${e?.message || e})`, "reinstall anet: npm i -g @sleep2agi/agent-network@latest");
+    throw unsafePathHelp("anet_bin_identity", `not an anet package bin: cannot read package.json (${e?.message || e})`, "reinstall anet: npm i -g @sleep2agi/agent-network@latest");
   }
   if (pkg?.name !== "@sleep2agi/agent-network") {
-    throw unsafePathHelp(`not an anet package bin: package name is ${JSON.stringify(pkg?.name)}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
+    throw unsafePathHelp("anet_bin_identity", `not an anet package bin: package name is ${JSON.stringify(pkg?.name)}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
   }
 
   const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.anet;
@@ -85,7 +111,7 @@ function verifyAnetBinIdentity(abs: string): void {
   const body = readFileSync(abs, "utf-8");
   if (abs.endsWith("/anet.cjs") && body.includes("anet 的 bin 入口垫片") && body.includes("PARSE_FLOOR")) return;
 
-  throw unsafePathHelp(`not an anet package bin: package.json bin.anet does not point at ${abs}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
+  throw unsafePathHelp("anet_bin_identity", `not an anet package bin: package.json bin.anet does not point at ${abs}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
 }
 
 function readPathConf(path: string): PathPin | null {
@@ -115,20 +141,20 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
     pin = { abs: env.ANET_BIN_ABS, sha256: env.ANET_BIN_SHA256 };
   }
   if (!pin && env.ANET_BIN_ABS) {
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_source", 
       "ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is /etc/anet-daemon/path.conf)",
       "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   if (!pin) {
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_source", 
       "no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1",
       "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   // ① absolute
   if (!pin.abs.startsWith("/")) {
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_shape", 
       `not absolute: ${pin.abs}`,
       `export ANET_BIN_ABS=$(node -e "console.log(require('fs').realpathSync(process.argv[1]))" ${quoteSh(pin.abs)})`,
     );
@@ -136,7 +162,7 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
   // ② no symlink path component (realpath equals self)
   const real = realpathSync(pin.abs);
   if (real !== pin.abs) {
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_shape", 
       `contains symlink: ${pin.abs} -> ${real}`,
       `export ANET_BIN_ABS=${quoteSh(real)}`,
     );
@@ -145,7 +171,7 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
   // ③ stat: non-root owner is acceptable for nvm/homebrew/user installs.
   const st = statSync(pin.abs);
   if (st.uid !== 0 && env.ANET_DAEMON_STRICT_ROOT_BIN === "1") {
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_permission", 
       `owner not root (uid=${st.uid})`,
       `sudo chown root:root ${quoteSh(pin.abs)} || unset ANET_DAEMON_STRICT_ROOT_BIN`,
     );
@@ -153,14 +179,14 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
   // ④ not group/other writable
   if ((st.mode & 0o022) !== 0) {
     const before = (st.mode & 0o777).toString(8);
-    throw unsafePathHelp(
+    throw unsafePathHelp("anet_bin_permission", 
       `writable by group/other (mode=${before})`,
       `chmod go-w ${quoteSh(pin.abs)}`,
     );
   }
   // ⑤ executable
   if ((st.mode & 0o111) === 0) {
-    throw unsafePathHelp("not executable", `chmod +x ${quoteSh(pin.abs)}`);
+    throw unsafePathHelp("anet_bin_permission", "not executable", `chmod +x ${quoteSh(pin.abs)}`);
   }
   // hash match install-time witness (when provided, REQUIRED to match)
   if (pin.sha256) {

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1917 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1930) + [tools.ts:1931 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1942) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1917 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1950) + [tools.ts:1931 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1962) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -563,7 +563,27 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           // 只收**代码**,不收原始报错文本 —— 上游 unsafePathHelp() 的消息里带完整机器路径,
           // 而这个字段会走到 Dashboard。enum 而不是 string:一个自由文本字段等于给
           // 「把路径塞进来」留了口子。
-          create_nodes_blocked_reason: z.enum(["anet_bin_pin_unresolved"]).optional(),
+          // #1353 —— 四类失败,修法完全不同:
+          //   identity   重装 anet / unset ANET_BIN_ABS
+          //   source     写 /etc/anet-daemon/path.conf（**要 sudo**）
+          //   shape      换成 realpath
+          //   permission **一行 chmod go-w**
+          // 混成一条会让人修错方向 —— 2026-08-28 我一天里撞到其中两类,看到的是同一条错误。
+          //
+          // 🔴 `anet_bin_pin_unresolved` **必须留着**:已经在跑的 agent-node@2.5.0-preview.40
+          //    发的就是这个值。zod 对象里任何一个字段验证失败会让**整个 report_status 被拒**,
+          //    不只是丢掉这一格 —— 那会让所有 .40 daemon 在 hub 上变成失联。
+          //    删一个 enum 值的代价,远大于多留一个。
+          // 🔴 仍然是 enum 不是 string:自由文本字段就是给机器路径留的口子,
+          //    而上游 e.message 里带的正是完整路径。
+          create_nodes_blocked_reason: z.enum([
+            "anet_bin_pin_unresolved",   // 兼容:.40 及更早
+            "anet_bin_identity",
+            "anet_bin_source",
+            "anet_bin_shape",
+            "anet_bin_permission",
+            "anet_bin_unknown",
+          ]).optional(),
         }).optional(),
       }).optional().describe("RFC-024 — masked node config snapshot"),
     },


### PR DESCRIPTION
## 问题

`unsafePathHelp()` 把 **11 个语义完全不同的失败**包成同一条 `anet_bin_unsafe_path`：

| 类别 | 处数 | 修法 |
|---|---|---|
| `anet_bin_identity` | 4 | 重装 anet / unset `ANET_BIN_ABS` |
| `anet_bin_source` | 2 | 写 `/etc/anet-daemon/path.conf`（**要 sudo，改系统配置**） |
| `anet_bin_shape` | 2 | 换成 realpath |
| `anet_bin_permission` | 3 | **一行 `chmod go-w`** |

🔴 **2026-08-28 一天里我撞到其中两类，看到的是同一条错误。**
第一反应是去建 `/etc/anet-daemon/path.conf` —— 而那次实际只要 `chmod`。
**把「要 sudo 改系统」和「一行 chmod」盖成同一句话，会让人修错方向。**

## 三个刻意的取舍

**🔴 消息前缀一个字不动。** 开工前先数：全仓 **10 个文件**依赖 `anet_bin_unsafe_path`，
其中测试里有 **6 条 `toThrow(/anet_bin_unsafe_path.*/)`**。改前缀会把它们全打断，
而那和本次要解决的问题无关。**机器可读的类别挂在 Error 属性上。**

**🔴 hub 的 enum 保留旧值 `anet_bin_pin_unresolved`。**
已经在跑的 `agent-node@2.5.0-preview.40` 发的就是它。zod 是 MCP 的**入参** schema ——
一个字段不合法，**整个 `tools/call` 被拒**。这个形状今天实测过：

```
MCP error -32602: Input validation error: Invalid arguments for tool stop_node
```

⇒ 删一个 enum 值会让所有 `.40` daemon 的 `report_status` **整条失败**，在 hub 上变成失联。
**删一个值的代价，远大于多留一个。**

**🔴 拿不到类别时用 `anet_bin_unknown`，不猜一个具体的。**
猜错的代价是让人按错方向修，而「不知道」至少是诚实的。

## witnessed-red

| | 结果 |
|---|---|
| 变异（四类塌成一类） | **92 pass / 5 fail** |
| 还原 | **97 pass / 0 fail** |

两条正控：
- **「不含路径」** —— 拿真会出现在 `e.message` 里的串（`chmod go-w '/home/x/anet.cjs'`）喂进去，
  必须含 `/` ⇒ **证明那条断言不是恒真**
- **「四类互不相同」** —— 否则拆分等于没拆

Refs #1353
Refs #1371