### PR TITLE
chore(release): commhub-server 0.9.0-preview.36（带 #1376 放开共存 runtime）

### DIFF
--- a/docs/tests/release-v0.9.0-preview.36.md
+++ b/docs/tests/release-v0.9.0-preview.36.md
@@ -1,0 +1,47 @@
+# commhub-server v0.9.0-preview.36 — daemon 远程创建放开共存 runtime
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+## 这一版带什么
+
+**① #1376 —— hub 的 `RUNTIMES` 从 3 个放开到 7 个**（Vincent 2026-08-28 定）
+
+daemon 远程创建现在接受全部 7 个 runtime，含三个人机共存的：
+`codex-app-server` / `grok-build-cli` / `opencode-cli`。
+
+理由（Vincent 原话大意）：节点不动了的时候，人要能进去跟 Codex / Claude Code 对话排错 ——
+attach 是「建好之后」的动作，不是「建的时候」的前提。
+
+🔴 **只升 hub 不够**：daemon 侧配置里的 `runtimes_supported` 也要是 7 个
+（旧 daemon 的 config.json 里存的是 3 个）。hub 会强制执行 daemon 自己声明的能力。
+
+**② #1372 —— `runtime_invalid` 现在会说清「允许哪些」和「还有什么路」**
+
+**③ #1374 —— `/api/nodes` 显式给出 `lifecycle_controllable` + `lifecycle_daemon_node_id`**
+
+客户端据此置灰不可用的「停止/重启/删除」按钮，不再靠 id 前缀猜。
+
+**④ #1360 —— `ack_stop_request` 六条出口全部留痕**（与 agent-node .40 的 daemon 侧埋点配对）
+
+**⑤ #1377（若已合入）—— `create_nodes_blocked_reason` 支持四类失败码**
+
+## Install
+
+```bash
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.36
+```
+
+## Upgrade
+
+生产 hub 走 `~/.local/bin/hub-daemon.sh` 的 RUNTIME_DIR 切换（保留旧目录可回滚）：
+
+```bash
+mkdir -p ~/.commhub/runtime-v40-preview36 && cd ~/.commhub/runtime-v40-preview36
+npm init -y >/dev/null && npm install @sleep2agi/commhub-server@0.9.0-preview.36
+# 备份 DB → 改 hub-daemon.sh 的 RUNTIME_DIR → pm2 restart commhub-hub
+```
+
+🔴 升级前照例：`VACUUM INTO` 备份 + integrity_check + 四表计数对照。
+🔴 升级后验收不是 /health 200，是**真建一个共存 runtime 的节点并让它完成一次任务**。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.35",
+  "version": "0.9.0-preview.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.35",
+      "version": "0.9.0-preview.36",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.35",
+  "version": "0.9.0-preview.36",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
只 bump server 版本 + 发版说明。🔴 **不动 `PINNED_SERVER_VERSION`** —— sync 脚本注释写明的顺序：先发 server，发完才改 pin（否则发版 run 被自己的 pin 卡死；且 `hub-launcher-pin` 门要求 launcher 与 pin 一致）。

带上：#1376（放开共存 runtime，Vincent 2026-08-28 定）、#1372（runtime_invalid 可操作报错）、#1374（lifecycle_controllable）、#1360（ack_stop_request 六出口留痕）。

发版走 Actions `release` workflow：`package=commhub-server` `version=0.9.0-preview.36` `publish=true`。