### PR TITLE
chore(release): pin server preview.36 + CLI preview.56 + launcher 同步

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1742,7 +1742,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.34";
+const PINNED_SERVER_VERSION = "0.9.0-preview.36";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.55",
+  "version": "2.3.0-preview.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.55",
+      "version": "2.3.0-preview.56",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.55",
+  "version": "2.3.0-preview.56",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.55";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.56";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.41";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -58,7 +58,10 @@ set -uo pipefail
 #   🔴 `runtime-v34-` 里的 v34 是**机器本地的升级序号**,不同机器必然不同,
 #      所以那道门只比 previewMM,不比 vNN。这里保留 v34 只是不改无关的东西。
 #   回滚目标 = 生产机器上那份的当前值(以该机器为准,不以本文件为准)
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview34"
+# 2026-08-28: preview34 → preview36（跟随 PINNED_SERVER_VERSION;server .36 已发 npm）
+#   内容 = #1376 放开共存 runtime(Vincent 定) + #1372/#1374/#1360/#1377
+#   回滚目标 = 生产机器上当前值(以该机器为准)
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview36"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.55 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.56 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.55` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.56` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.55 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.56 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.55`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.56`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.56.md
+++ b/docs/tests/release-v2.3.0-preview.56.md
@@ -1,0 +1,26 @@
+# agent-network v2.3.0-preview.56 — pin 到 hub preview.36
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+这一版只做一件事：`PINNED_SERVER_VERSION` 从 `0.9.0-preview.34` 升到 `0.9.0-preview.36`，
+让 `anet hub start` 拉到带 #1376（daemon 远程创建放开全部 7 个 runtime，含三个人机共存）
+的 hub。`deploy/hub/hub-daemon.sh` 的 RUNTIME_DIR 同步到 preview36（hub-launcher-pin 门要求一致）。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.56
+```
+
+配对：`@sleep2agi/agent-node@2.5.0-preview.40`、`@sleep2agi/commhub-server@0.9.0-preview.36`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.56
+```
+
+🔴 已在跑的 hub 不会自己换版本 —— 生产走 RUNTIME_DIR 切换 + pm2 restart（保留旧目录可回滚）。
+🔴 daemon 侧还要 `runtimes_supported` 是 7 个（旧配置存的是 3 个）才能真建共存 runtime 节点。

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.34' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.36' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
server `.36` 已发 npm（四门全绿）。按 sync 脚本注释的顺序（先发 server → 再改 pin）现在改是安全的：`PINNED_SERVER_VERSION` → `.36`、launcher RUNTIME_DIR 同步（`hub-launcher-pin` 门本地 rc=0）、CLI bump 到 `.56` + 发版说明 + version-claim。合入后 dispatch 发 agent-network preview.56。