### PR TITLE
fix(#1286): stale-deleting 重派出口 —— 卡死的 deleting 行第一次有了 API 层的解

### DIFF
--- a/server/src/stop-delete-node.test.ts
+++ b/server/src/stop-delete-node.test.ts
@@ -718,3 +718,60 @@ describe("RFC-027 PR1.2a — restart_node resets lifecycle_state to 'active'", (
     expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("active");
   });
 });
+
+// ── #1286 stale-deleting 重派出口 ──────────────────────────────────
+//
+// 修复前 daemon 丢 ack 会让行永远停在 deleting：重发被挡、force 也一样。
+// 2026-08-28 实测两行卡死（acc-…-3373 / probe-tl2），API 层面无解。
+// 出口三条件缺一不放行：force=true + 最近 delete 请求非终态 + 晾超 5 分钟。
+describe("delete_node — stale-deleting redispatch exit (#1286)", () => {
+  function seedDeletingChild() {
+    setupAlphaNetwork();
+    db.run(`UPDATE nodes SET lifecycle_state = 'deleting' WHERE node_id = ?1`, [CHILD_A_ID]);
+  }
+  function seedStopRequest(status: string, ageMs: number) {
+    db.run(
+      `INSERT INTO node_stop_requests (request_id, network_id, daemon_node_id, child_node_id,
+         child_alias, action, delete_config, created_by_token, status, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 'delete', 1, 'tok_test', ?6, ?7)`,
+      [`sr_stale_${Date.now()}_${Math.floor(ageMs)}`, NET_A, DAEMON_A_ID, CHILD_A_ID,
+       CHILD_A_ALIAS, status, Date.now() - ageMs],
+    );
+  }
+  const base = { child_node_id: CHILD_A_ID, daemon_node_id: DAEMON_A_ID, network_id: NET_A, confirm_alias: CHILD_A_ALIAS };
+
+  test("无 force：仍拒，且带 hint 指出口（不是让人反复撞墙）", async () => {
+    seedDeletingChild(); seedStopRequest("pending", 10 * 60_000);
+    const r = await call(buildHandlers(USER_A_ID).delete_node, base);
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_already_deleting");
+    expect(typeof r.hint).toBe("string");
+  });
+
+  test("🔴 force 但请求还新鲜（1 分钟）：仍拒 —— force 不能变成竞态放大器", async () => {
+    seedDeletingChild(); seedStopRequest("pending", 60_000);
+    const r = await call(buildHandlers(USER_A_ID).delete_node, { ...base, force: true });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_already_deleting");
+  });
+
+  test("🔴 force 但上一条已终态（stopped）：仍拒 —— daemon 刚 ack 过，行马上会转移", async () => {
+    seedDeletingChild(); seedStopRequest("stopped", 10 * 60_000);
+    const r = await call(buildHandlers(USER_A_ID).delete_node, { ...base, force: true });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_already_deleting");
+  });
+
+  test("force + pending 晾超 5 分钟：放行，生成新 request_id", async () => {
+    seedDeletingChild(); seedStopRequest("pending", 10 * 60_000);
+    const r = await call(buildHandlers(USER_A_ID).delete_node, { ...base, force: true });
+    expect(r.ok).toBe(true);
+    expect((r.request_id as string).startsWith("sr_")).toBe(true);
+  });
+
+  test("force + dispatched 晾超 5 分钟：同样放行", async () => {
+    seedDeletingChild(); seedStopRequest("dispatched", 10 * 60_000);
+    const r = await call(buildHandlers(USER_A_ID).delete_node, { ...base, force: true });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3561,7 +3561,39 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       return { ok: false, error: state === "stopping" ? "node_already_stopping" : "node_not_active", current_state: state };
     }
     if (args.action === "delete" && state === "deleting") {
-      return { ok: false, error: "node_already_deleting", current_state: state };
+      // #1286 —— stale-deleting 重派出口。
+      //
+      // 在 .40 埋点修复之前,daemon 丢失 ack 会让行**永远**停在 deleting:
+      // 重发 delete 被这里挡住,force=true 也一样 —— 状态机没有出口,
+      // 2026-08-28 实测两行卡死(acc-…-3373 / probe-tl2),API 层面无解。
+      //
+      // 出口的三个条件,缺一不放行:
+      //   ① 调用方显式 force=true(不改默认行为 —— 正常并发的重复 delete 仍被拒)
+      //   ② 该 child 最近一条 delete 请求不是终态(pending/dispatched)
+      //      —— 终态说明 daemon 刚 ack 过,行马上会转移,不该重派
+      //   ③ 那条请求已经晾了超过 STALE_DELETING_MS —— 🔴 不是"刚派发就能 force":
+      //      给正常的 doorbell→ack 往返留时间,否则 force 变成竞态放大器。
+      const STALE_DELETING_MS = 5 * 60_000;
+      const last = db.get<{ request_id: string; status: string; created_at: number }>(
+        `SELECT request_id, status, created_at FROM node_stop_requests
+          WHERE child_node_id = ?1 AND action = 'delete'
+          ORDER BY created_at DESC LIMIT 1`, node.node_id,
+      );
+      const lastIsStale = !!last
+        && (last.status === "pending" || last.status === "dispatched")
+        && (Date.now() - last.created_at) > STALE_DELETING_MS;
+      if (!(args.force === true && (lastIsStale || !last))) {
+        return {
+          ok: false, error: "node_already_deleting", current_state: state,
+          // 🔴 告诉调用方出口在哪,而不是让他反复撞同一面墙。
+          ...(last ? { last_request_id: last.request_id, last_request_status: last.status } : {}),
+          hint: last && (last.status === "pending" || last.status === "dispatched")
+            ? `再等一下;若超过 ${STALE_DELETING_MS / 60000} 分钟仍未收敛,带 force=true 重试可重新派发`
+            : "上一条请求已终态,行应即将转移;稍后重查",
+        };
+      }
+      // 放行:走正常派发路径,生成新 request_id。旧请求行保留(审计线索),
+      // daemon 侧对未知 request 的 get_stop_request 会拿到 request_not_found,无副作用。
     }
     if (args.action === "delete" && state === "stopping") {
       // Can't start delete while a stop is mid-flight — race-prone.


### PR DESCRIPTION
## 问题

`.40` 埋点修复防住了**新的** delete 卡死，但**修复前就卡死的行**没有出口：

```
delete_node …              → node_already_deleting
delete_node … force=true   → node_already_deleting    ← force 也不行（实测）
```

当前生产还有 2 行这样的（`acc-…-3373` / `probe-tl2`），daemon 都在线且已升级 —— **问题在 hub 状态机**。

## 出口三条件，缺一不放行

| # | 条件 | 为什么 |
|---|---|---|
| ① | 显式 `force=true` | 默认行为不变，正常并发重复 delete 仍被拒 |
| ② | 最近一条 delete 请求**非终态** | 终态=刚 ack 过，行马上转移，不该重派 |
| ③ | 晾超 **5 分钟** | 🔴 **不是"刚派发就能 force"** —— 给正常往返留时间，否则 force 变成竞态放大器 |

拒绝时带 `last_request_id`/`status` + `hint` —— **告诉调用方出口在哪，而不是让他反复撞同一面墙**（今天我自己就撞了两次）。

## witnessed-red

| | 结果 |
|---|---|
| 变异（撤掉出口） | **27 pass / 2 fail**（恰好是两条「放行」用例） |
| 还原 | **29 pass / 0 fail** |

## 合入 + 发版后

生产那 2 行卡死节点用 `force=true` 一发即清 —— **不用碰 DB**。

Refs #1286