### PR TITLE
chore(release): commhub-server 0.9.0-preview.37（带 #1381 卡死行出口）

### DIFF
--- a/docs/tests/release-v0.9.0-preview.37.md
+++ b/docs/tests/release-v0.9.0-preview.37.md
@@ -1,0 +1,29 @@
+# commhub-server v0.9.0-preview.37 — 卡死 deleting 行的重派出口
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+单改动版本：**#1381（#1286 第三块）** —— `deleting` 状态的 stale 重派出口。
+
+在此之前，daemon 丢失 ack 会让节点行**永远**停在 `deleting`：重发被状态机挡住、
+`force=true` 也一样（2026-08-28 实测，生产两行卡死，API 层面无解）。
+
+现在 `delete_node` 满足三条件时放行重派（缺一不放行）：
+① 显式 `force=true`（默认行为不变）② 最近一条 delete 请求非终态
+③ 该请求已晾超 5 分钟（给正常 doorbell→ack 往返留时间）。
+拒绝时带 `last_request_id`/`status`/`hint`。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.37
+```
+
+## Upgrade
+
+生产走 RUNTIME_DIR 切换 + pm2 restart（旧目录保留可回滚）。
+含 preview.36 全部内容（#1376 放开共存 runtime / #1372 / #1374 / #1360 / #1377）——
+**从 .35 直升 .37 即可，不必经停 .36**。
+
+升级后收尾：对卡死的两行各发一次 `delete_node … force=true`，行应立即转移并收敛。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.36",
+  "version": "0.9.0-preview.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.36",
+      "version": "0.9.0-preview.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.36",
+  "version": "0.9.0-preview.37",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
单改动版本：#1381（stale-deleting 重派出口）。不动 `PINNED_SERVER_VERSION`（先发 server 再改 pin 的顺序）。发布后生产可从 `.35` **直升 `.37`**（含 .36 全部内容），升级后对两行卡死节点各发一次 `force=true` 即清。