### PR TITLE
fix(agent-node): callCommHub fetch 加 30s 超时 (#1357)

### DIFF
--- a/agent-node/src/callcommhub-timeout.test.ts
+++ b/agent-node/src/callcommhub-timeout.test.ts
@@ -1,0 +1,68 @@
+// #1357 — callCommHub's fetch must carry a per-request timeout.
+//
+// Node's fetch has NO default timeout on an established connection: a hub
+// that accepts the POST but never finishes the response leaves the promise
+// unsettled forever. The retry loop in callCommHub only advances after fetch
+// settles, so that one call pins the caller with zero logs, zero alerts.
+//
+// cli.ts is a side-effecting entrypoint (it connects out on import), so the
+// wiring is asserted against the source text, and the mechanism itself —
+// AbortSignal.timeout aborts a hung fetch with a retryable error — is proven
+// behaviorally against a real hung HTTP server.
+import { describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("#1357 callCommHub per-request timeout", () => {
+  const src = readFileSync(join(import.meta.dir, "cli.ts"), "utf8");
+
+  test("cli.ts defines CALL_COMMHUB_TIMEOUT_MS", () => {
+    expect(src).toMatch(/const CALL_COMMHUB_TIMEOUT_MS = \d[\d_]*;/);
+  });
+
+  test("callCommHub's fetch carries signal: AbortSignal.timeout(CALL_COMMHUB_TIMEOUT_MS)", () => {
+    // Anchor inside the callCommHub function body, not anywhere in the file:
+    // the assertion must fail if the signal is moved to some other fetch.
+    const fnStart = src.indexOf("async function callCommHub(");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = src.indexOf("\n}", fnStart);
+    const body = src.slice(fnStart, fnEnd);
+    expect(body).toContain("signal: AbortSignal.timeout(CALL_COMMHUB_TIMEOUT_MS)");
+  });
+
+  test("AbortSignal.timeout aborts a hung fetch with a retryable (thrown) error", async () => {
+    // A server that accepts the request and then goes silent — the exact
+    // failure shape from the issue. Without a signal this fetch never settles.
+    const sockets = new Set<import("node:net").Socket>();
+    const server = createServer((req) => { req.socket.setTimeout(0); /* never respond */ });
+    server.on("connection", (s) => sockets.add(s));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as { port: number };
+    try {
+      const t0 = Date.now();
+      let thrown: any;
+      try {
+        await fetch(`http://127.0.0.1:${port}/mcp`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+          signal: AbortSignal.timeout(150),
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      const elapsed = Date.now() - t0;
+      // It settled (the whole point), promptly, and with an error the
+      // callCommHub catch-branch treats as retryable (any non-CommHubError).
+      expect(thrown).toBeDefined();
+      expect(["TimeoutError", "AbortError"]).toContain(thrown.name);
+      expect(elapsed).toBeLessThan(5_000);
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+    }
+  });
+});

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1156,6 +1156,15 @@ const taskTraceLog = (line: string) => {
 // in ./reply-reliability.ts so it can be unit-tested without spinning up
 // agent-node. This wrapper drives the classifier through the actual HTTP
 // transport with exponential backoff.
+// #1357 — per-request timeout. Node's fetch has NO default timeout on an
+// established connection: a server that accepts the request but never
+// finishes the response leaves the promise unsettled forever — the retry
+// loop below never advances and the caller's .catch never fires (zero logs,
+// zero alerts). Same fix/value as commhub-mcp.ts COMMHUB_CALL_TIMEOUT_MS;
+// AbortSignal.timeout also aborts the res.text() body read, and the
+// resulting TimeoutError falls into the retryable catch branch below.
+const CALL_COMMHUB_TIMEOUT_MS = 30_000;
+
 async function callCommHub(method: string, params: Record<string, unknown>, retries = 3) {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -1175,6 +1184,7 @@ async function callCommHub(method: string, params: Record<string, unknown>, retr
           method: "tools/call",
           params: { name: method, arguments: params },
         }),
+        signal: AbortSignal.timeout(CALL_COMMHUB_TIMEOUT_MS),
       });
       if (!res.ok) {
         if (attempt < retries) {


### PR DESCRIPTION
## 问题

#1357：`callCommHub`（agent-node/src/cli.ts）的 `fetch` 没有 `signal`。Node 的 fetch 对已建立的连接**没有默认超时**——hub 收下请求但永不结束响应时，promise 永不 settle，重试循环停在第一轮，调用方 `.catch` 永不触发：零日志、零告警、进程活着 CPU 为 0。与 #1286 同病族的独立缺陷。

## 修法

仓里同一个问题的正确写法已经存在于 `commhub-mcp.ts`（`COMMHUB_CALL_TIMEOUT_MS = 30_000` + `AbortSignal.timeout`）——本 PR 对齐它：

- `CALL_COMMHUB_TIMEOUT_MS = 30_000`，与 hub 最慢正常响应留足余量
- `signal: AbortSignal.timeout(...)` 挂在 callCommHub 的 fetch 上；它同时中断 `res.text()` 的 body 读取
- TimeoutError 落入现有 catch 重试分支（对任意非 appLevel 错误重试），最终失败时照常抛出——调用方 `.catch` 拿得到东西

## 测试（callcommhub-timeout.test.ts，3 条）

1. 常量存在
2. **源锚定**：signal 必须出现在 `callCommHub` 函数体内的 fetch 上（挪到别的 fetch 上即红）
3. **行为**：真 hung HTTP server（收请求不回）+ `AbortSignal.timeout(150)` → ~150ms 内以 `TimeoutError` settle（证机制在本运行时成立）

## 见红（行为变异）

删掉 signal 行（= 回到缺陷态）→ `1 fail`，红的正是「fetch carries signal」那条；恢复后 `3 pass / 0 fail`。`bun build` rc=0。

## 查重

按改动文件搜过：5 个 open PR 碰 `agent-node/src/cli.ts`（#1364/#1273/#1198/#1180/#460），全是 doorbell/SSE/OS-user 方向，无同内容改动；按关键词 `AbortSignal.timeout` 搜 open PR 零命中。

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)