### PR TITLE
feat(#1345): node-server proxy 双写节点日志 —— claude-code-cli 节点恢复「按 alias 读日志」

### DIFF
--- a/agent-network/src/node-activity-log.test.ts
+++ b/agent-network/src/node-activity-log.test.ts
@@ -1,0 +1,42 @@
+// #1345 — the proxy's file log sink. Behavioral tests against a real fs.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, readdirSync, chmodSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createActivityLogSink } from "./node-activity-log";
+
+describe("#1345 createActivityLogSink", () => {
+  test("writes lines to .anet/nodes/<alias>/logs/<utc-date>.log and appends", () => {
+    const base = mkdtempSync(join(tmpdir(), "nal-"));
+    const fixed = new Date("2026-08-28T23:59:59.000Z"); // UTC date pins the filename
+    const sink = createActivityLogSink(base, "测试牛", () => fixed);
+    sink.append("[10:00:00] [commhub] first");
+    sink.append("[10:00:01] [commhub] second");
+    const dir = join(base, ".anet", "nodes", "测试牛", "logs");
+    expect(readdirSync(dir)).toEqual(["2026-08-28.log"]);
+    const content = readFileSync(join(dir, "2026-08-28.log"), "utf8");
+    expect(content).toBe("[10:00:00] [commhub] first\n[10:00:01] [commhub] second\n");
+  });
+
+  test("filename is the UTC date, not the local one", () => {
+    const base = mkdtempSync(join(tmpdir(), "nal-"));
+    // 2026-08-29T00:30Z is still 08-28 in UTC-8 and already 08-29 in UTC+8;
+    // the sink must follow UTC regardless of the host TZ (log-name discipline).
+    const sink = createActivityLogSink(base, "a", () => new Date("2026-08-29T00:30:00.000Z"));
+    sink.append("x");
+    expect(readdirSync(join(base, ".anet", "nodes", "a", "logs"))).toEqual(["2026-08-29.log"]);
+  });
+
+  test("an unwritable destination is swallowed, then recovers when writable again", () => {
+    const base = mkdtempSync(join(tmpdir(), "nal-"));
+    const nodesDir = join(base, ".anet", "nodes");
+    mkdirSync(nodesDir, { recursive: true });
+    chmodSync(nodesDir, 0o555); // mkdir of <alias> under it fails
+    const sink = createActivityLogSink(base, "b", () => new Date("2026-08-28T00:00:00.000Z"));
+    expect(() => sink.append("dropped")).not.toThrow();
+    chmodSync(nodesDir, 0o755);
+    sink.append("kept");
+    const content = readFileSync(join(nodesDir, "b", "logs", "2026-08-28.log"), "utf8");
+    expect(content).toBe("kept\n"); // the failed line is gone, the next one lands
+  });
+});

--- a/agent-network/src/node-activity-log.test.ts
+++ b/agent-network/src/node-activity-log.test.ts
@@ -1,6 +1,6 @@
 // #1345 — the proxy's file log sink. Behavioral tests against a real fs.
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, readdirSync, chmodSync, mkdirSync } from "fs";
+import { mkdtempSync, readFileSync, readdirSync, chmodSync, mkdirSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createActivityLogSink } from "./node-activity-log";
@@ -25,6 +25,22 @@ describe("#1345 createActivityLogSink", () => {
     const sink = createActivityLogSink(base, "a", () => new Date("2026-08-29T00:30:00.000Z"));
     sink.append("x");
     expect(readdirSync(join(base, ".anet", "nodes", "a", "logs"))).toEqual(["2026-08-29.log"]);
+  });
+
+  test("a torn-down node dir is NEVER recreated — sink goes permanently silent", () => {
+    // The race this guards: `anet node stop` removes .anet/nodes/<alias>/
+    // and then verifies nothing survived; the proxy's SSE-disconnect
+    // callbacks still log() during that window. Resurrecting the dir makes
+    // stop's cleanup verification fail (test225 CI red, 2026-08-28).
+    const base = mkdtempSync(join(tmpdir(), "nal-"));
+    const sink = createActivityLogSink(base, "c", () => new Date("2026-08-28T00:00:00.000Z"));
+    sink.append("before stop");
+    const nodeDir = join(base, ".anet", "nodes", "c");
+    rmSync(nodeDir, { recursive: true, force: true }); // stop tears the node dir down
+    sink.append("during stop teardown");
+    expect(existsSync(nodeDir)).toBe(false); // ← the actual invariant stop depends on
+    sink.append("after stop");
+    expect(existsSync(nodeDir)).toBe(false); // stays down: sink is permanently disabled
   });
 
   test("an unwritable destination is swallowed, then recovers when writable again", () => {

--- a/agent-network/src/node-activity-log.ts
+++ b/agent-network/src/node-activity-log.ts
@@ -1,0 +1,45 @@
+// #1345 — file sink for the node-server (claude-code-cli stdio proxy) log.
+//
+// claude-code-cli nodes have NO agent-node process, so nothing ever wrote
+// `.anet/nodes/<alias>/logs/` for them — "read the node log to verify a
+// member's real state" was structurally impossible for half the fleet, and
+// an empty logs/ dir looked exactly like "idle for a week" (#1345). The
+// proxy is the only long-lived process we own in that mode and it already
+// knows its alias (#203), so it carries the communication-layer log.
+//
+// Format parity with agent-node/src/cli.ts::_log: file named by UTC date
+// (`YYYY-MM-DD.log`), line carries local wall-clock time. Every failure is
+// swallowed — the MCP stdio loop must never die because a log line could
+// not be written.
+import { appendFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+export interface ActivityLogSink {
+  append(line: string): void;
+}
+
+export function createActivityLogSink(
+  baseDir: string,
+  alias: string,
+  now: () => Date = () => new Date(),
+): ActivityLogSink {
+  const dir = join(baseDir, ".anet", "nodes", alias, "logs");
+  let dirReady = false;
+  return {
+    append(line: string): void {
+      try {
+        if (!dirReady) {
+          mkdirSync(dir, { recursive: true });
+          dirReady = true;
+        }
+        const date = now().toISOString().slice(0, 10);
+        appendFileSync(join(dir, `${date}.log`), line + "\n");
+      } catch {
+        // Deliberately silent (same stance as cli.ts::_log): a broken or
+        // read-only working directory must not take down the proxy. The
+        // stderr copy of the same line still reaches the tmux pane.
+        dirReady = false;
+      }
+    },
+  };
+}

--- a/agent-network/src/node-activity-log.ts
+++ b/agent-network/src/node-activity-log.ts
@@ -11,7 +11,7 @@
 // (`YYYY-MM-DD.log`), line carries local wall-clock time. Every failure is
 // swallowed — the MCP stdio loop must never die because a log line could
 // not be written.
-import { appendFileSync, mkdirSync } from "fs";
+import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 
 export interface ActivityLogSink {
@@ -24,21 +24,34 @@ export function createActivityLogSink(
   now: () => Date = () => new Date(),
 ): ActivityLogSink {
   const dir = join(baseDir, ".anet", "nodes", alias, "logs");
-  let dirReady = false;
+  let created = false;
+  let disabled = false;
   return {
     append(line: string): void {
+      if (disabled) return;
       try {
-        if (!dirReady) {
+        if (!created) {
           mkdirSync(dir, { recursive: true });
-          dirReady = true;
+          created = true;
+        } else if (!existsSync(dir)) {
+          // 🔴 The directory existed and is now gone — that is `anet node
+          // stop`/delete tearing the node dir down while this proxy is still
+          // flushing its last lines (SSE-disconnect callbacks fire exactly
+          // then). Recreating it here loses the race on purpose-built
+          // cleanup verification: stop's "authoritative local resources
+          // survived" check red-flags the resurrected directory and the
+          // whole stop fails. Once torn down, never write again.
+          disabled = true;
+          return;
         }
         const date = now().toISOString().slice(0, 10);
         appendFileSync(join(dir, `${date}.log`), line + "\n");
       } catch {
         // Deliberately silent (same stance as cli.ts::_log): a broken or
         // read-only working directory must not take down the proxy. The
-        // stderr copy of the same line still reaches the tmux pane.
-        dirReady = false;
+        // stderr copy of the same line still reaches the tmux pane. Do NOT
+        // reset `created` — that would re-open the mkdir path and the
+        // resurrection race above.
       }
     },
   };

--- a/agent-network/src/node-server-activity-log-wiring.test.ts
+++ b/agent-network/src/node-server-activity-log-wiring.test.ts
@@ -1,0 +1,23 @@
+// #1345 — wiring assertion. node-server.ts is a side-effecting entrypoint
+// (importing it dials the hub), so the wiring is pinned against source text:
+// the log() body must feed the activity sink, and the sink must be created
+// from ALIAS. Deleting either line goes red.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("#1345 node-server log() wiring", () => {
+  const src = readFileSync(join(import.meta.dir, "node-server.ts"), "utf8");
+
+  test("creates the sink from cwd + ALIAS", () => {
+    expect(src).toContain("const activityLog = createActivityLogSink(process.cwd(), ALIAS)");
+  });
+
+  test("log() writes the same line to stderr and the sink", () => {
+    const fnStart = src.indexOf("function log(msg: string)");
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = src.slice(fnStart, src.indexOf("\n}", fnStart));
+    expect(body).toContain("activityLog.append(line)");
+    expect(body).toContain("process.stderr.write(`${line}\\n`)");
+  });
+});

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -22,6 +22,7 @@ import { hostname } from "os";
 import { execSync } from "child_process";
 import { encodeCwd } from "./project-key";
 import { loadOwnerOnlyEnvFile } from "./owner-env-file";
+import { createActivityLogSink } from "./node-activity-log";
 import {
   defaultControlledUploadRoots,
   uploadControlledLocalFile,
@@ -143,9 +144,16 @@ const AUTH_TOKEN = process.env.COMMHUB_TOKEN || ANET_CONFIG.token || "";
 // the default for Claude Code installations that launch this same artifact.
 const OUTBOUND_ONLY = process.env.ANET_COMMHUB_MODE === "outbound-only";
 
+// #1345 — claude-code-cli nodes have no agent-node process, so this proxy is
+// the only place a per-alias node log can come from. Mirror every log line
+// into .anet/nodes/<ALIAS>/logs/ (UTC-dated file, same as agent-node _log);
+// stderr remains the primary sink and file failures are swallowed inside.
+const activityLog = createActivityLogSink(process.cwd(), ALIAS);
 function log(msg: string) {
   const ts = new Date().toTimeString().slice(0, 8);
-  process.stderr.write(`[${ts}] [commhub] ${msg}\n`);
+  const line = `[${ts}] [commhub] ${msg}`;
+  process.stderr.write(`${line}\n`);
+  activityLog.append(line);
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## 问题

#1345：`claude-code-cli` 节点没有 agent-node 进程，`.anet/nodes/<alias>/logs/` 恒空——「读节点日志核实成员状态」对半个舰队结构上做不到，且**空目录与「闲了一周」不可区分**（issue 里差点因此误报 6 人闲置）。

## 修法（issue 评论区方案，已核可行性）

proxy（`node-server.ts`）是该模式下唯一常驻的我方进程且已知 alias（#203 起 `COMMHUB_ALIAS` 必设）：

- 新增 `node-activity-log.ts`：文件 sink——UTC 日期文件名 + 行内本地时间（对齐 `agent-node/src/cli.ts::_log` 与日志名纪律）；**任何失败静默吞掉**（MCP stdio 循环绝不能因写日志死掉），目录恢复可写后自动续写
- `node-server.ts` 的 `log()` 改为 stderr + sink 双写——**32 个既有调用点**（register/SSE 断连重连/收消息/收任务/回复……）全部自动落盘，零逐点插桩

**如实标注不解决的**：模型会话层记录仍在 `~/.claude/projects/*.jsonl`（Claude Code 自有，不分 alias）——本 PR 补的是缺失的通信层。

## 分发安全（关键前置核实）

`node-server.js` 以**自包含 bundle** 分发（#1216 的机制正是为相对 import 断链而设），新 import 被吸收进 bundle。

## 证据

- sink 行为测试 3 条：append 语义 / UTC 文件名（跨时区日界用例）/ 不可写吞掉+恢复续写
- wiring 源锚定 2 条：sink 从 ALIAS 创建 / log() 双写
- **见红**：删 `activityLog.append(line)`（=旧行为）→ wiring 1 fail；恢复 → 5 pass
- **端到端**：跑 build 后的 dist bundle（hub 指死地址）→ `.anet/nodes/probe-1345/logs/2026-08-28.log` 出现，内容为 ENV 行+MCP connected 行（bundle 经 obfuscator，grep 源标识 0 命中是已知假阴，故用行为判据）
- agent-network src 全测试：671 pass / 0 fail

## 查重

按改动文件搜 open PR：碰 `node-server.ts` 的为零。

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)