### PR TITLE
chore(release): bump agent-node .42 + agent-network .58

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.57",
+  "version": "2.3.0-preview.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.57",
+      "version": "2.3.0-preview.58",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.57",
+  "version": "2.3.0-preview.58",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.57";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.41";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.58";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.42";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.41",
+  "version": "2.5.0-preview.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.41",
+      "version": "2.5.0-preview.42",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.41",
+  "version": "2.5.0-preview.42",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"


### PR DESCRIPTION
## 目的

把今天合入但尚未上 npm 的两个修复发出去（发布时间戳核实过，不凭记忆）：

| 包 | npm 现状 | 缺的修复 |
|---|---|---|
| agent-node | `.41`（05:29Z 发布） | #1384 callCommHub 30s 超时（11:35Z 合入） |
| agent-network | `.57`（10:59Z 发布） | #1386 节点日志 + stop 竞态修复（12:30Z 合入） |

## 内容

- 两包 package.json + lock 版本号（lock 各 2 处：根 + "" 条目）
- `opencode-agent-node-pair.ts` 版本字面量由 `scripts/sync-pinned-versions.sh --apply` 同步（非手改）
- PINNED_SERVER_VERSION 不动（commhub-server 仍 `.37`，无 server 侧改动）

合并后走 `release-gate (v0)` dispatch 两个包 publish=true。

🤖 Generated with [Claude Code](https://claude.com/claude-code)