### PR TITLE
docs(release): v2.5.0-preview.42 / v2.3.0-preview.58 release notes

### DIFF
--- a/docs/tests/release-v2.3.0-preview.58.md
+++ b/docs/tests/release-v2.3.0-preview.58.md
@@ -1,0 +1,20 @@
+# agent-network v2.3.0-preview.58 — claude-code-cli 节点日志
+
+## 变更
+
+- #1386（#1345）：`node-server.js`（claude-code-cli stdio proxy）把每条日志双写进 `.anet/nodes/<alias>/logs/<UTC日期>.log`——该模式没有 agent-node 进程，此前 logs/ 恒空，「按 alias 读节点日志」对半个舰队结构性做不到。含 stop 竞态防护：节点目录被 stop 拆除后 sink 永久停写、绝不重建目录。
+- PAIRED_* 版本字面量随 sync-pinned-versions.sh 同步。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.58
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.58
+anet --version   # 应显示 2.3.0-preview.58
+# 已有 claude-code-cli 节点：下次 anet node start 时 .anet/node-server.js 会刷新为新 bundle
+```

--- a/docs/tests/release-v2.5.0-preview.42.md
+++ b/docs/tests/release-v2.5.0-preview.42.md
@@ -1,0 +1,19 @@
+# agent-node v2.5.0-preview.42 — callCommHub 请求超时
+
+## 变更
+
+- #1384（#1357）：`callCommHub` 的 fetch 加 `AbortSignal.timeout(30_000)`。此前 hub 收下请求但不结束响应时，promise 永不 settle、重试循环停在第一轮、调用方 `.catch` 永不触发——零日志零告警。与 `commhub-mcp.ts` 的 `COMMHUB_CALL_TIMEOUT_MS` 同法同值；TimeoutError 落入既有可重试分支。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.42
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.42
+# daemon 托管的机器：升级后重启对应 daemon 使新二进制生效
+# 🔴 本机 umask 0002 的机器装完跑一次: chmod go-w "$(npm root -g)/@sleep2agi/agent-node/dist/cli.js" 所在目录链
+```


### PR DESCRIPTION
发版 run `33173933194` 红在 **gate 3**：`no release notes for v2.5.0-preview.42` —— #1388 只 bump 版本没写配套 notes（.58 同样缺）。

补两份（照 .57 的 Install/Upgrade 形态），合并后重新 dispatch 两包 `release-gate (v0)` publish=true。

另：第一批重复 dispatch 的 run 已取消（两个守望撞车各派发一次的副作用，第二批 13:08 两条已 cancel）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)