### PR TITLE
docs(changelog): 2026-08-28 晚发版记录（中英）

### DIFF
--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -1,5 +1,17 @@
 # 更新日志
 
+## 可靠性冲刺：删除收敛 + 节点日志 + 超时防线——preview（2026-08-28 晚）
+
+三包配套发布：`commhub-server@0.9.0-preview.36/.37`、`agent-node@2.5.0-preview.40/.42`、`agent-network@2.3.0-preview.54–.58`。
+
+- **stop/delete 收敛**（#1286 三件套）：daemon 侧 ack 全链路留痕、hub 侧 `ack_stop_request` 六出口埋点、卡死的 deleting 记录可 `force` 重派（>5 分钟陈旧判据）
+- **claude-code-cli 节点日志**（#1345）：stdio proxy 把日志双写进 `.anet/nodes/<alias>/logs/`（UTC 日期文件），该模式首次可按 alias 读节点日志；含 stop 竞态防护（节点目录被拆除后绝不复活）
+- **callCommHub 超时**（#1357）：30s `AbortSignal.timeout`，hub 挂起不再静默吞掉 doorbell
+- **daemon 能力可见性**：`runtimes_supported` 放开到 7 种（#1376）、创建失败原因四类错误码上报（#1377）、hub `lifecycle_controllable` 标志（#1374）配合桌面端按钮置灰（app#197/#200——三个 TUI 共存 runtime 进入建节点向导，零 key 跟随宿主登录）
+- **agent 主动推送**：`send_desktop_message` 文档化（guide/channels）
+
+---
+
 ## BTW 精确任务边界——Hub preview（2026-08-28）
 
 `commhub-server@0.9.0-preview.34` 为任务记录增加可选的 `thread_id` / `turn_id`，并在 REST 与 MCP 任务投影中返回它们。Hub 只接受节点对已消费任务上报的、归属一致且不冲突的边界；旧节点和历史任务继续兼容，缺失时明确保持为空，不做猜测或回填。配套的 `agent-node@2.5.0-preview.39` 与 `agent-network@2.3.0-preview.53` 将在 Hub 发布后按依赖顺序跟进。

--- a/docs-site/docs/en/changelog.md
+++ b/docs-site/docs/en/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Reliability sprint: stop/delete convergence + node logs + timeout guard — preview (2026-08-28 evening)
+
+Coordinated release: `commhub-server@0.9.0-preview.36/.37`, `agent-node@2.5.0-preview.40/.42`, `agent-network@2.3.0-preview.54–.58`.
+
+- **stop/delete convergence** (#1286 trio): daemon-side ack tracing, hub-side six-exit instrumentation for `ack_stop_request`, stuck `deleting` rows re-dispatchable with `force` (5-minute staleness criterion)
+- **claude-code-cli node logs** (#1345): the stdio proxy now mirrors every log line into `.anet/nodes/<alias>/logs/` (UTC-dated files) — per-alias node logs exist for this runtime for the first time; includes a stop-race guard (a torn-down node dir is never resurrected)
+- **callCommHub timeout** (#1357): 30s `AbortSignal.timeout` — a hung hub can no longer silently swallow doorbells
+- **daemon capability visibility**: `runtimes_supported` widened to 7 (#1376), four-class creation-failure codes (#1377), hub `lifecycle_controllable` flag (#1374) pairing with desktop button disabling (app#197/#200 — the three TUI co-presence runtimes join the create wizard, zero-key, following the host login)
+- **agent-initiated push**: `send_desktop_message` documented (guide/channels)
+
+---
+
 ## Exact BTW task boundary — Hub preview (2026-08-28)
 
 `commhub-server@0.9.0-preview.34` adds optional `thread_id` / `turn_id` fields to task records and returns them through REST and MCP task projections. The Hub accepts a boundary only when the consuming node reports it for an owned task without conflict. Older nodes and historical tasks remain compatible; absent boundaries stay explicitly absent and are never guessed or backfilled. The paired `agent-node@2.5.0-preview.39` and `agent-network@2.3.0-preview.53` will follow after the Hub is published, in dependency order.


### PR DESCRIPTION
今天 7 个 npm 版本的聚合 changelog 条目（中英对称，插在顶部）：

- commhub-server `.36/.37`、agent-node `.40/.42`、agent-network `.54–.58`
- 覆盖 #1286 三件套 / #1345 节点日志+stop竞态 / #1357 callCommHub 超时 / #1374+#1376+#1377 daemon 可见性 / app#197+#200 客户端半边 / send_desktop_message 文档化

纯文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)