### PR TITLE
fix(#1385): stop socket 残留窗口 3s→10s + age 诊断

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9600,15 +9600,29 @@ Stop a running agent node.
     console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained and PID was not signalled.`);
     process.exit(1);
   }
-  const socketDeadline = Date.now() + 3_000;
+  // #1385 — the 3s window red-flagged healthy-but-slow socket teardown on
+  // busy CI runners (4 distinct stop scenarios, all green on main, all red
+  // only under PR-peak load). 10s keeps the gate hard (a leaked listener
+  // still fails) while no longer punishing a runner for being slow; the
+  // per-residual age line below tells "slow teardown" apart from a real
+  // leak when it DOES fire.
+  const SOCKET_RESIDUAL_WINDOW_MS = 10_000;
+  const socketDeadline = Date.now() + SOCKET_RESIDUAL_WINDOW_MS;
   let socketResiduals = nodeSocketResiduals(resolved.profile);
   while (socketResiduals.length > 0 && Date.now() < socketDeadline) {
     await new Promise(r => setTimeout(r, 100));
     socketResiduals = nodeSocketResiduals(resolved.profile);
   }
   if (socketResiduals.length > 0) {
-    console.error(`[anet] STOP_TIMEOUT: authoritative local resources survived for "${displayName}"; hub was not notified offline.`);
-    for (const residual of socketResiduals) console.error(`[anet]    residual ${residual.kind}: ${residual.detail}`);
+    console.error(`[anet] STOP_TIMEOUT: authoritative local resources survived for "${displayName}" after ${SOCKET_RESIDUAL_WINDOW_MS}ms; hub was not notified offline.`);
+    for (const residual of socketResiduals) {
+      let age = "unknown-age";
+      try {
+        const m = residual.detail.match(/(\S+\.sock)/);
+        if (m) age = `${Math.round(Date.now() - lstatSync(m[1]).mtimeMs)}ms old`;
+      } catch {}
+      console.error(`[anet]    residual ${residual.kind}: ${residual.detail} (${age}) — an old-mtime socket that outlives the window is a real leak; a fresh one means teardown was still in flight.`);
+    }
     process.exit(1);
   }
   await withLifecycleLock(resolved.id, () => {

--- a/agent-network/src/stop-socket-window.test.ts
+++ b/agent-network/src/stop-socket-window.test.ts
@@ -1,0 +1,24 @@
+// #1385 — pin the stop socket-residual window. cli.ts is a side-effecting
+// entrypoint, so the invariant is pinned against source text: the window
+// constant exists at 10s and the deadline is derived from it (not a bare
+// 3_000 that quietly reverts).
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("#1385 stop socket residual window", () => {
+  const src = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+  test("window constant is 10s and feeds the deadline", () => {
+    expect(src).toContain("const SOCKET_RESIDUAL_WINDOW_MS = 10_000;");
+    expect(src).toContain("Date.now() + SOCKET_RESIDUAL_WINDOW_MS");
+    // the old hard-coded window must be gone from the stop path
+    const stopIdx = src.indexOf("SOCKET_RESIDUAL_WINDOW_MS");
+    const tail = src.slice(stopIdx, stopIdx + 2000);
+    expect(tail).not.toContain("Date.now() + 3_000");
+  });
+
+  test("residual line carries the age diagnostic (slow-teardown vs leak)", () => {
+    expect(src).toContain("an old-mtime socket that outlives the window is a real leak");
+  });
+});


### PR DESCRIPTION
## 问题

#1385 追踪的 stop 类红今晚 4 次 4 场景（legacy-reload/fallback/resumed + qa-cli-01 另族），全部只在 PR 高峰 CI 上出现，main 独跑 6 连绿。读判据代码（bin/cli.ts stop 出口）确认：只校验 tmux/进程/pidfile/**socket 残留（3 秒硬窗口）**——3s 在慢 runner 上把「teardown 还在进行」判成「泄漏」。

## 改动（一处 + 测试）

- `SOCKET_RESIDUAL_WINDOW_MS = 10_000` 取代裸 `3_000`；门的宽严不变（超窗仍 exit 1）
- 残留行追加 socket 的 mtime age——下次真红时能一眼区分「停得慢」（fresh socket）与「真泄漏」（老 socket 挺过整个窗口）
- 源锚定测试 2 条（常量存在且喂 deadline、age 诊断文案存在、旧 3_000 不得回潜）

## 证据链

- main 最近 6 次 test225 全绿（含 #1386 后 2 次）；红全在 PR 并发高峰
- 机制此前一版分析（sink TOCTOU）已在 #1385 自我更正——本 PR 按读实的判据代码修

Refs #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)