### PR TITLE
chore(release): server .38 + agent-node .43 + CLI .59（#1394 门铃补偿三包配对）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1742,7 +1742,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.37";
+const PINNED_SERVER_VERSION = "0.9.0-preview.38";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.58",
+  "version": "2.3.0-preview.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.58",
+      "version": "2.3.0-preview.59",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.58",
+  "version": "2.3.0-preview.59",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.58";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.42";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.59";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.43";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.42",
+  "version": "2.5.0-preview.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.42",
+      "version": "2.5.0-preview.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.42",
+  "version": "2.5.0-preview.43",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -62,7 +62,7 @@ set -uo pipefail
 #   内容 = #1376 放开共存 runtime(Vincent 定) + #1372/#1374/#1360/#1377
 #   回滚目标 = 生产机器上当前值(以该机器为准)
 # 2026-08-28: preview36 → preview37（跟随 PINNED;#1381 卡死行出口）
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview37"
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview38"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.58 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.59 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.58` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.59` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.58 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.59 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.58`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.59`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.38.md
+++ b/docs/tests/release-v0.9.0-preview.38.md
@@ -1,0 +1,18 @@
+# commhub-server v0.9.0-preview.38 — create_node 门铃补偿
+
+## 变更
+
+- #1394（#1362）：新 daemon-only 工具 `list_my_pending_create_requests`——SSE 断连窗口内错过的 create_node 门铃不再永久丢失（daemon 重连后调它补偿派发）。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.38
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.38
+# 生产按 deploy/hub/hub-daemon.sh 的 RUNTIME_DIR 原子切换（runtime-v40-preview38）
+```

--- a/docs/tests/release-v2.3.0-preview.59.md
+++ b/docs/tests/release-v2.3.0-preview.59.md
@@ -1,0 +1,18 @@
+# agent-network v2.3.0-preview.59 — pin 到 hub preview.38
+
+单改动：`PINNED_SERVER_VERSION` → `0.9.0-preview.38`（#1394 门铃补偿工具）。launcher RUNTIME_DIR 同步。
+
+配对：`@sleep2agi/agent-node@2.5.0-preview.43`、`@sleep2agi/commhub-server@0.9.0-preview.38`。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.59
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.59
+anet --version   # 应显示 2.3.0-preview.59
+```

--- a/docs/tests/release-v2.5.0-preview.43.md
+++ b/docs/tests/release-v2.5.0-preview.43.md
@@ -1,0 +1,18 @@
+# agent-node v2.5.0-preview.43 — SSE 重连补偿错过的 create_node
+
+## 变更
+
+- #1394（#1362）：host-supervisor daemon 在每次 SSE `connected` 后调用 hub 的 `list_my_pending_create_requests`，把 pending 的 request_id 送回既有 `handleCreateNodeDoorbell` 路径。配对 hub ≥ `0.9.0-preview.38`（旧 hub 上该调用容错降级，不影响原有门铃路径）。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.43
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.43
+# daemon 机器升级后重启 daemon;umask 0002 的机器记得 chmod go-w 修复权限
+```

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.37",
+  "version": "0.9.0-preview.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.37",
+      "version": "0.9.0-preview.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.37",
+  "version": "0.9.0-preview.38",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.37' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.38' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## 目的

把 #1394（#1362 create_node 门铃补偿）发上 npm——它是 hub+daemon 配对功能，三包一次配齐：

| 包 | 版本 | 内容 |
|---|---|---|
| commhub-server | `0.9.0-preview.38` | `list_my_pending_create_requests` 工具 |
| agent-node | `2.5.0-preview.43` | SSE connected 后补偿 pending create |
| agent-network | `2.3.0-preview.59` | PINNED→`.38` + launcher 同步 |

## 机制自动化的首次收获

`PINNED_SERVER_VERSION` 由 sync 脚本改动时，**test766 的断言第一次自动跟随**（今天白天登记进 sync-pinned-versions.sh 的机制生效）——这个坑今天不会再红第三次。

## 本地门（全过才推）

- `check-hub-launcher-pin.py` rc=0（launcher `runtime-v34-preview38` == PINNED 后缀）
- `check-doc-version-claims.py` 结构模式 + 发版模式（.59）都 rc=0
- 三份 release notes 带 Install/Upgrade（gate3）

合并后按序 dispatch：**先 server .38 → 再 agent-node .43 → 最后 agent-network .59**（发版链顺序纪律）。

生产升级 GO 的目标版本建议随之更新为 `.38`（比 .37 多门铃补偿，#1286+#1362 一次到位）——runbook 我会同步改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)