### PR TITLE
fix(release-gate): gate2 自发版豁免（server .38 被自己的 pin 卡死）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,6 +474,15 @@ jobs:
             echo "audit $var=$ver → $pkg"
             audited=$((audited+1))
             audited_names="$audited_names $var"
+            # 🔴 自发版豁免:pin 指向的恰好是**本次 run 正在发的那个包版本**时,
+            #    「还没上 npm」不是缺陷而是时序必然 —— 本 run 的 publish job 就是
+            #    要把它发出去。没有这条豁免,「bump 包版本 + 改 PINNED」放进同一个
+            #    PR 会让该包的发版 run 被自己的 pin 卡死(2026-08-29 server .38 实撞,
+            #    run 33187647703)。豁免范围极窄:包名与版本都必须精确等于本次发的。
+            if [ "$pkg" = "@sleep2agi/${{ needs.build-tarball.outputs.package }}" ] && [ "$ver" = "${{ needs.build-tarball.outputs.version }}" ]; then
+              echo "  ↳ self-release exemption: $pkg@$ver 正是本次 run 要发的 —— publish job 负责让它上 npm"
+              continue
+            fi
             if ! npm view "$pkg@$ver" version > /dev/null 2>&1; then
               echo "::error::$var=$ver not published on npm for $pkg"
               missing=$((missing+1))


### PR DESCRIPTION
## 问题

#1395 把「server bump `.38`」和「PINNED→`.38`」放进同一个 PR。server 的发版 run（`33187647703`）checkout 的 main 已含新 pin，gate2 审计「pin 必须已发布」——而 `.38` 正是本次要发的——鸡生蛋卡死（四门中 gate2 独红，publish skipped）。

这正是发版链顺序纪律（先发 server → 再改 pin）防的坑；本 PR 让这个形态不再是死路。

## 修法（gate2 一处）

审计循环里加**窄豁免**：`pkg`+`ver` 都精确等于本次 run 正在发的（`needs.build-tarball.outputs`）时跳过——本 run 的 publish job 就是要把它发出去。其余 pin 照旧硬审，零命中拒绝通过的防恒真机制不动。

合并后重派 server `.38`（→ npm 实物 → 链上 agent-node `.43` → CLI `.59`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)