### PR TITLE
docs(changelog): 版本集收口到 .38/.43/.59 + #1362 条目（中英）

### DIFF
--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -2,7 +2,9 @@
 
 ## 可靠性冲刺：删除收敛 + 节点日志 + 超时防线——preview（2026-08-28 晚）
 
-三包配套发布：`commhub-server@0.9.0-preview.36/.37`、`agent-node@2.5.0-preview.40/.42`、`agent-network@2.3.0-preview.54–.58`。
+三包配套发布：`commhub-server@0.9.0-preview.36–.38`、`agent-node@2.5.0-preview.40–.43`、`agent-network@2.3.0-preview.54–.59`。
+
+- **create_node 门铃补偿**（#1362，收编 #1364）：SSE 断连窗口内错过的 create_node 门铃不再永久丢失——daemon 重连后调用新 hub 工具 `list_my_pending_create_requests` 补偿派发（`.38`/`.43` 配对）
 
 - **stop/delete 收敛**（#1286 三件套）：daemon 侧 ack 全链路留痕、hub 侧 `ack_stop_request` 六出口埋点、卡死的 deleting 记录可 `force` 重派（>5 分钟陈旧判据）
 - **claude-code-cli 节点日志**（#1345）：stdio proxy 把日志双写进 `.anet/nodes/<alias>/logs/`（UTC 日期文件），该模式首次可按 alias 读节点日志；含 stop 竞态防护（节点目录被拆除后绝不复活）

--- a/docs-site/docs/en/changelog.md
+++ b/docs-site/docs/en/changelog.md
@@ -2,7 +2,9 @@
 
 ## Reliability sprint: stop/delete convergence + node logs + timeout guard — preview (2026-08-28 evening)
 
-Coordinated release: `commhub-server@0.9.0-preview.36/.37`, `agent-node@2.5.0-preview.40/.42`, `agent-network@2.3.0-preview.54–.58`.
+Coordinated release: `commhub-server@0.9.0-preview.36–.38`, `agent-node@2.5.0-preview.40–.43`, `agent-network@2.3.0-preview.54–.59`.
+
+- **create_node doorbell compensation** (#1362, absorbing #1364): doorbells missed during an SSE outage are no longer lost forever — on reconnect the daemon calls the new hub tool `list_my_pending_create_requests` and replays them (`.38`/`.43` pair)
 
 - **stop/delete convergence** (#1286 trio): daemon-side ack tracing, hub-side six-exit instrumentation for `ack_stop_request`, stuck `deleting` rows re-dispatchable with `force` (5-minute staleness criterion)
 - **claude-code-cli node logs** (#1345): the stdio proxy now mirrors every log line into `.anet/nodes/<alias>/logs/` (UTC-dated files) — per-alias node logs exist for this runtime for the first time; includes a stop-race guard (a torn-down node dir is never resurrected)


### PR DESCRIPTION
凌晨三包链（server `.38` / node `.43` / CLI `.59`）收官后，把 changelog 顶部条目的版本区间从 `.36/.37 + .40/.42 + .54–.58` 收口为最终区间，并补上 #1362 门铃补偿一行（它是今晚该条目里唯一缺的落地项）。纯文档、中英对称。

🤖 Generated with [Claude Code](https://claude.com/claude-code)