### PR TITLE
docs(readme): 快速开始瘦身——坑位警告与版本考古移入 docs 专页

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,15 +43,13 @@ anet node start my-bot
 
 Verify the Hub is up: `curl http://127.0.0.1:9200/health` should return JSON containing `"ok":true`.
 
-> **⚠️ Check that the node really started — don't rely on `anet node start`'s stdout `✅`**: `exit 0` plus a printed `✅ node "…" started detached (tmux session live)` does **not** mean the node came up. On **versions predating [#895](https://github.com/sleep2agi/agent-network/pull/895)** (**fixed as of `2.3.0-preview.40`**; #895 landed 2026-08-17 and ships in preview.40) the detached path can lie. Real check: `tmux has-session -t "=<alias>"` returns 0 (**the `=` is required** — a bare alias is a prefix match and can go green on the wrong session). For bulk launches use `anet project up`; its exit code is trustworthy since [#896](https://github.com/sleep2agi/agent-network/pull/896) (also shipping in `2.3.0-preview.40`).
+> Not sure the node **really** started? See the evidence table in [Is this node alive?](https://anet.sh/en/troubleshooting/is-this-node-alive).
 
 Open `http://localhost:3000` and dispatch work from the Dashboard.
 
 The default administrator account is `admin` / `anethub`. **Any public deployment must run `anet passwd` immediately after login** — otherwise anyone who scans the port can walk in.
 
-> **Since `@sleep2agi/agent-network@2.2.22-preview.4`** (2026-06-28, PR [#264](https://github.com/sleep2agi/agent-network/pull/264) fixing [#261](https://github.com/sleep2agi/agent-network/issues/261) P0-2), preview builds print a **one-time random password** on the first `anet hub start` — shown once (save it right then); the first login forces a password change.
->
-> **The stable `@latest` (currently `2.2.21`) and older `preview ≤ 2.2.22-preview.3` still ship with the fixed default `admin` / `anethub`** — run `anet passwd` right after logging in.
+> Initial-password differences across versions: see [Versioning](https://anet.sh/en/guide/versioning).
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,13 @@ anet node start my-bot
 
 验证 Hub 起来了：`curl http://127.0.0.1:9200/health` 返回的 JSON 应包含 `"ok":true`。
 
-> **⚠️ 判断节点真起来 —— 别只看 `anet node start` 的 stdout `✅`**：`exit 0` + 打印 `✅ node "…" started detached (tmux session live)` **不代表节点真起来**。**含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（**`2.3.0-preview.40` 起已修**；#895 于 2026-08-17 合入，随 preview.40 发布）在 detached 场景可能假报。真判据：`tmux has-session -t "=<alias>"` 返回 0（**`=` 必须**，裸名字是前缀匹配会误报绿）。批量场景用 `anet project up`，其退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样随 `2.3.0-preview.40` 发布）。
+> 节点是否**真的**起来了？判据表见 [这个节点还活着吗](https://anet.sh/troubleshooting/is-this-node-alive)。
 
 打开 `http://localhost:3000`，从 Dashboard 给 Agent 派任务。
 
 默认管理员用户名是 `admin`，初始密码是 `anethub`。**任何公网部署都必须登录后立即运行 `anet passwd` 改密**，否则被扫到端口就能进。
 
-> **自 `@sleep2agi/agent-network@2.2.22-preview.4`**（2026-06-28, PR [#264](https://github.com/sleep2agi/agent-network/pull/264) 修 [#261](https://github.com/sleep2agi/agent-network/issues/261) P0-2）**起**，预览版 `@preview` 首次 `anet hub start` 打印**一次性随机密码**（只显示这一次，请当场保存；首次登录会强制改密）。
->
-> **stable `@latest`（当前 `2.2.21`）与更早的 preview `≤ 2.2.22-preview.3` 仍是固定默认 `admin` / `anethub`** —— 登录后必须立即 `anet passwd`。
+> 各版本的初始密码差异见 [版本号体系](https://anet.sh/guide/versioning)。
 
 ## 能做什么
 

--- a/docs-site/docs/en/guide/versioning.md
+++ b/docs-site/docs/en/guide/versioning.md
@@ -35,3 +35,10 @@ Agent Network uses two parallel version-number schemes. First-time readers often
 
 - [Upgrade Guide](/en/guide/upgrade) — cross-version migration / breaking changes
 - [Changelog](/en/changelog) — full change log
+
+## Initial admin password by version
+
+- **preview `>= 2.2.22-preview.4`** (2026-06-28, PR [#264](https://github.com/sleep2agi/agent-network/pull/264) fixing [#261](https://github.com/sleep2agi/agent-network/issues/261)): the first `anet hub start` prints a **one-time random password** — shown once, save it right then; the first login forces a password change.
+- **stable `@latest` (`2.2.21`) and preview `<= 2.2.22-preview.3`**: fixed default `admin` / `anethub` — run `anet passwd` immediately after login.
+
+Any internet-facing deployment must run `anet passwd` right after login, regardless of version.

--- a/docs-site/docs/en/troubleshooting/is-this-node-alive.md
+++ b/docs-site/docs/en/troubleshooting/is-this-node-alive.md
@@ -87,3 +87,12 @@ It does not say *why* something broke, and it offers no self-healing. There is c
 built-in crash recovery at the node level (the Hub has a watchdog; nodes do not) — see
 [issue #534](https://github.com/sleep2agi/agent-network/issues/534). The "still reports idle after
 failing" row is [issue #811](https://github.com/sleep2agi/agent-network/issues/811).
+
+## The stdout `✅` from `anet node start` doesn't count either
+
+`exit 0` plus a printed `✅ node "…" started detached (tmux session live)` does **not** mean the node came up.
+Versions predating [#895](https://github.com/sleep2agi/agent-network/pull/895) (fixed as of `2.3.0-preview.40`) can lie on the detached path.
+
+**Real check**: `tmux has-session -t "=<alias>"` returns 0 — **the `=` is required**; a bare alias is a prefix match and can go green on the wrong session.
+
+For bulk launches use `anet project up`; its exit code is trustworthy since [#896](https://github.com/sleep2agi/agent-network/pull/896) (also `2.3.0-preview.40`).

--- a/docs-site/docs/guide/versioning.md
+++ b/docs-site/docs/guide/versioning.md
@@ -35,3 +35,10 @@ Agent Network 有两套版本号并行使用，第一次看可能困惑。这页
 
 - [升级指南](/guide/upgrade) —— 跨版本迁移 / 不兼容变更
 - [Changelog](/changelog) —— 完整变更日志
+
+## 初始管理员密码的版本差异
+
+- **preview `≥ 2.2.22-preview.4`**（2026-06-28，PR [#264](https://github.com/sleep2agi/agent-network/pull/264) 修 [#261](https://github.com/sleep2agi/agent-network/issues/261)）：首次 `anet hub start` 打印**一次性随机密码**，只显示这一次，请当场保存；首次登录强制改密。
+- **stable `@latest`（`2.2.21`）与 preview `≤ 2.2.22-preview.3`**：固定默认 `admin` / `anethub`，登录后必须立即 `anet passwd` 改密。
+
+任何公网部署，无论哪个版本，都必须登录后立即 `anet passwd`。

--- a/docs-site/docs/troubleshooting/is-this-node-alive.md
+++ b/docs-site/docs/troubleshooting/is-this-node-alive.md
@@ -88,3 +88,12 @@ commhub_send_task(alias="<节点>", task="收到请只回一句 `git rev-parse -
 [issue #534](https://github.com/sleep2agi/agent-network/issues/534)；
 「失败后仍报 idle」那一格见
 [issue #811](https://github.com/sleep2agi/agent-network/issues/811)。
+
+## `anet node start` 的 stdout ✅ 也不算数
+
+`exit 0` + 打印 `✅ node "…" started detached (tmux session live)` **不代表节点真起来**。
+含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本（`2.3.0-preview.40` 起已修）在 detached 场景可能假报。
+
+**真判据**：`tmux has-session -t "=<alias>"` 返回 0——**`=` 必须**，裸名字是前缀匹配，会在错误的会话上误报绿。
+
+批量场景用 `anet project up`，其退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896)（同随 `2.3.0-preview.40`）起可信。

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -73,15 +73,17 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > 所以 R367 没有、也不该把它们清掉。代价是:**latest 或 preview 一发布,它们立刻变成假的**,
 > 而且是危险的那种假 —— 会告诉用户一道已经存在的安全 preflight 不存在。
 >
-> 逐次发版必须重新核对的位置(**14 个路径**,下表 14 行 = 14 个文件 ——
+> 逐次发版必须重新核对的位置(**38 个路径**,下表 38 行 = 38 个文件 ——
 > 不要把 zh/en 合成一行数,分母数错会漏核。
-> 这张表的分母被修正过三次:7 → 8 → 12 → 14。**加新的信道断言时,同时把它加进这张表**,
+> 这张表的分母被修正过三次:7 → 8 → 12 → 14 → 38。**加新的信道断言时,同时把它加进这张表**,
 > 否则下一个人照着一份"看起来完整"的清单去核,漏掉的那几页永远不会被发现):
 >
 > | 文件 | 行 | 断言 |
 > |---|---|---|
 > | `docs-site/docs/guide/getting-started.md` | 19–20 | latest `2.2.21` 裸崩 / preview `2.3.0-preview.x` 被拦 |
 > | `docs-site/docs/en/guide/getting-started.md` | 19–20 | 同上(英文) |
+> | `docs-site/docs/troubleshooting/is-this-node-alive.md` | 见门输出 | #895 stdout 假报「`2.3.0-preview.40` 起已修」——修复版本钉死在断言里,promote latest 时核对 latest 是否已含 #895 |
+> | `docs-site/docs/en/troubleshooting/is-this-node-alive.md` | 见门输出 | 同上(英文) |
 > | `docs-site/docs/deploy/clean-server.md` | 21–22 | 同上 |
 > | `docs-site/docs/en/deploy/clean-server.md` | 21–22 | 同上(英文) |
 > | `docs-site/docs/troubleshooting.md` | 29、37 | preview 有 preflight / latest 没有 |


### PR DESCRIPTION
Vincent 反馈 README 首页乱七八糟（截图圈的就是快速开始里的 #895 stdout 警告大块 + 两段初始密码版本考古）。

## 改法（内容零丢失，只挪位置）
- **README.md / README.en.md**：快速开始只留 5 条命令 + `curl /health` 验证 + 两行短链接
- **#895/#896「节点真起来」判据** → `troubleshooting/is-this-node-alive`（该页本就是按可信度排序的活性判据表，正是它的家）
- **#264/#261 初始密码版本差异** → `guide/versioning` 新增「初始管理员密码的版本差异」小节
- README 保留一行安全红线：公网部署必须立即 `anet passwd`
- 中英文四处同步

按内容搜过重复 PR：关键词 readme 快速开始 / is-this-node-alive ⇒ 零命中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)