### PR TITLE
docs(grok): grok-tui 页入库(纠偏版) + copresence 状态更新（中英）

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -108,6 +108,7 @@ export default withMermaid(defineConfig({
             items: [
               { text: 'Preview 说明', link: '/preview/' },
               { text: 'Grok 人机共存 TUI', link: '/guide/grok-copresence' },
+              { text: 'Grok 共存 TUI（grok-build-cli）', link: '/guide/grok-tui' },
               { text: 'Codex TUI 人机共存', link: '/guide/codex-copresence' },
             ]
           },
@@ -212,6 +213,7 @@ export default withMermaid(defineConfig({
             items: [
               { text: 'Preview overview', link: '/en/preview/' },
               { text: 'Grok Co-presence TUI', link: '/en/guide/grok-copresence' },
+              { text: 'Grok Co-presence TUI (grok-build-cli)', link: '/en/guide/grok-tui' },
               { text: 'Codex TUI Co-presence', link: '/en/guide/codex-copresence' },
             ]
           },

--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -1,6 +1,10 @@
-# Grok Co-presence TUI (not released)
+# Grok Co-presence TUI
 
-::: danger Not currently available
+::: tip Status update (verified in production, 2026-08-29)
+The danger block below captures the 2026-08-18 qualification state and is **outdated**: the `grok-build-cli` co-presence path now works end to end — on a Mac mini with npm-installed `anet 2.3.0-preview.43` + the global `agent-node` (grok `1.0.5 (5115b46bc909)`, on the verified list), creating the node, entering the shared TUI via `anet grok attach`, and receiving an answer to an injected network task in 19 seconds. For current usage see [Grok Co-presence TUI (grok-build-cli)](/en/guide/grok-tui). The historical warnings are preserved below for the record.
+:::
+
+::: danger Old state as of 2026-08-18 (archived)
 Do not follow older instructions for the `grok-build-cli` runtime path — do not run `anet node create ... --runtime grok-build-cli`.
 
 🔴 **Correction (measured 2026-08-18)**: this page used to say `anet grok attach` is "not included in npm `latest` or `preview`". The second half does not hold. Running the real published binaries:

--- a/docs-site/docs/en/guide/grok-tui.md
+++ b/docs-site/docs/en/guide/grok-tui.md
@@ -1,0 +1,125 @@
+# Grok Co-presence TUI
+
+`grok-build-cli` gives one Agent Network node ownership of the only real Grok TUI. You enter that same interface from another terminal with `anet grok attach`, while CommHub tasks queue into the same session. Human input has priority and network tasks run FIFO.
+
+::: warning Experimental (available on the preview channel)
+Co-presence now ships on the npm preview channel (verified with `@sleep2agi/agent-network@2.3.0-preview.59` + `@sleep2agi/agent-node@2.5.0-preview.43`). It does not replace `grok-build-acp`. Co-presence only accepts **verified grok builds**: `0.2.93 (f00f96316d)` and `1.0.5 (5115b46bc909)`; anything else is rejected.
+:::
+
+## Prerequisites
+
+- Linux, macOS, or WSL with Node.js, Bun, and the native `node-pty` dependency
+- Grok Build CLI installed and logged in
+- A clone of the Agent Network repository
+
+```bash
+grok --version
+# Must be: grok 0.2.93 (f00f96316d)
+
+grok
+# Complete login in the UI on first use, then exit
+```
+
+## Build from source
+
+Run from the repository root:
+
+```bash
+cd agent-node
+bun install
+npm run build
+cd ../agent-network
+bun install
+npm run build
+cd ..
+```
+
+The remaining commands on this page must use the CLI you just built, not npm stable's global `anet`. In bash/zsh, define a function scoped to the current shell and point it at the matching agent-node:
+
+```bash
+export ANET_SOURCE=/absolute/path/to/agent-orchestra
+export ANET_AGENT_NODE_BIN="$ANET_SOURCE/agent-node/dist/cli.js"
+anet() { bun "$ANET_SOURCE/agent-network/dist/bin/cli.js" "$@"; }
+
+anet --help | grep grok-build-cli
+# Output should include grok-build-cli and `anet grok attach` help
+```
+
+## Start and attach
+
+Start the Hub and log in as described in [Getting Started](/en/guide/getting-started), then use two terminals:
+
+```bash
+# Terminal 1: create and keep the node running
+anet node create grok-demo --runtime grok-build-cli
+anet node start grok-demo
+```
+
+The TUI is ready when this marker appears:
+
+```text
+[grok-copresence] ...; attach with anet grok attach grok-demo
+```
+
+```bash
+# Terminal 2: enter the same live TUI
+anet grok attach grok-demo
+```
+
+Press `Ctrl-]` in the attached terminal to detach that terminal only; the node and Grok session keep running. Only one human terminal may be attached at a time.
+
+Network work is visibly injected as:
+
+```text
+[Agent Network/from=<sender>/task=<task-id>] <message>
+```
+
+Ordinary human conversation stays local. Only an explicit delegation such as `send_task reviewer inspect the current changes` dispatches work to Agent Network.
+
+## Stop and resume
+
+Stop the node normally:
+
+```bash
+anet node stop grok-demo
+```
+
+The next `anet node start grok-demo` resumes the same `grokCliSession`. The runtime never silently falls back to headless mode or guesses another session. If the process crashes during a network turn, that task fails instead of being replayed across a possible side-effect boundary.
+
+## Legacy headless mode
+
+To launch a separate non-interactive Grok process for each network task:
+
+```bash
+anet node create grok-headless --runtime grok-build-cli --grok-headless
+```
+
+Headless nodes cannot use `anet grok attach`. Existing profiles without `grokCopresence: true` retain their old behavior and are not migrated automatically.
+
+## Troubleshooting
+
+### Version mismatch
+
+Run `grok --version`. Co-presence only accepts the exact builds on the verified list (currently `0.2.93 (f00f96316d)` and `1.0.5 (5115b46bc909)`). Install a listed build before starting; do not bypass the gate. On 1.0.5, sandbox and leader mode are mutually exclusive — the runtime adjusts its launch flags per version automatically.
+
+### An existing bare grok session cannot join co-presence
+
+Sessions created in plain `grok` (sandbox=off) **cannot** be resumed into a co-presence node: the runtime enforces a sandbox profile and grok refuses cross-profile resume (`cannot resume this session under sandbox profile … it was created with 'off'`), with no supported way to disable the sandbox. Pinning such a session into `grokCliSession` yields repeated `Grok recovery TUI exited before recovery drain` (diagnosability follow-up: [#1400](https://github.com/sleep2agi/agent-network/issues/1400)). Instead let the node create a fresh sandboxed session (drop the pinned id, or use `--new-session`); the old session stays intact and can still be viewed with `grok --resume <id>`.
+
+### `Installed agent-node does not support grok-build-cli`
+
+The command found npm stable agent-node, or `ANET_AGENT_NODE_BIN` points to the wrong file. Rebuild `agent-node` and set the variable to the absolute path of its `dist/cli.js`.
+
+### attach says it requires a TTY
+
+Run `anet grok attach` directly in an interactive terminal. Pipes, redirected input/output, and non-interactive CI are unsupported.
+
+### attach says the node is legacy headless
+
+That profile does not enable co-presence. Create a new `grok-build-cli` node; do not copy or guess private socket paths.
+
+### Permission prompts
+
+Only the attached human handles approval prompts. The runtime never selects permanent approval and blocks TUI commands that would change the shared approval policy. At an approval screen, use Enter for allow-once or `Ctrl-C` to reject/cancel.
+
+For implementation details, security boundaries, and Docker verification, see the [complete Grok Build runtime guide](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md).

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -1,6 +1,10 @@
-# Grok 人机共存 TUI（未发布）
+# Grok 人机共存 TUI
 
-::: danger 当前不可用
+::: tip 状态更新（2026-08-29 生产实测）
+下面的 danger 块记录的是 2026-08-18 的验收状态，**已过时**：`grok-build-cli` 共存路径现已端到端跑通 —— macmini 上用 npm 安装的 `anet 2.3.0-preview.43` + 全局 `agent-node`（grok `1.0.5 (5115b46bc909)`，验证清单内）创建节点、`anet grok attach` 进入共享 TUI、网络任务注入并 19 秒收到回答。当前用法见 [Grok 共存 TUI（grok-build-cli）](/guide/grok-tui)。历史告诫保留如下供追溯。
+:::
+
+::: danger 2026-08-18 时点的旧状态（保留存档）
 `grok-build-cli` 这条 runtime 路径**不要照旧文档使用** —— 不要执行 `anet node create ... --runtime grok-build-cli`。
 
 🔴 **更正(2026-08-18 实测)**:原文写「`anet grok attach` 尚未进入 `latest` 或 `preview`」,**后半句不成立**。用真包跑二进制:

--- a/docs-site/docs/guide/grok-tui.md
+++ b/docs-site/docs/guide/grok-tui.md
@@ -1,0 +1,125 @@
+# Grok 共存 TUI
+
+`grok-build-cli` 让一个 Agent Network 节点持有唯一的真实 Grok TUI。你从另一个终端用 `anet grok attach` 进入同一界面；CommHub 网络任务也会排队进入同一会话。人类输入优先，网络任务按 FIFO 执行。
+
+::: warning 实验能力（preview 通道可用）
+共存能力已随 npm preview 通道发布（实测 `@sleep2agi/agent-network@2.3.0-preview.59` + `@sleep2agi/agent-node@2.5.0-preview.43` 可用）。它不会替代 `grok-build-acp`。共存只接受**已验证的 grok build**：`0.2.93 (f00f96316d)` 与 `1.0.5 (5115b46bc909)`；清单外的版本会拒绝启动。
+:::
+
+## 前置检查
+
+- Linux、macOS 或 WSL；已安装 Node.js、Bun 和原生 `node-pty` 依赖
+- Grok Build CLI 已安装并完成登录
+- 已 clone Agent Network 仓库
+
+```bash
+grok --version
+# 必须是：grok 0.2.93 (f00f96316d)
+
+grok
+# 首次使用时按界面完成登录，然后退出
+```
+
+## 构建源码
+
+在仓库根目录执行：
+
+```bash
+cd agent-node
+bun install
+npm run build
+cd ../agent-network
+bun install
+npm run build
+cd ..
+```
+
+本页后续命令必须调用刚构建的 CLI，而不是 npm stable 的全局 `anet`。在 bash/zsh 中可定义一个仅对当前 shell 有效的函数，并显式指定刚构建的 agent-node：
+
+```bash
+export ANET_SOURCE=/绝对路径/agent-orchestra
+export ANET_AGENT_NODE_BIN="$ANET_SOURCE/agent-node/dist/cli.js"
+anet() { bun "$ANET_SOURCE/agent-network/dist/bin/cli.js" "$@"; }
+
+anet --help | grep grok-build-cli
+# 应能看到 grok-build-cli 和 `anet grok attach` 帮助
+```
+
+## 启动与连接
+
+先按[上手指南](/guide/getting-started)启动 Hub 并登录。然后使用两个终端：
+
+```bash
+# 终端 1：创建并持续运行节点
+anet node create grok-demo --runtime grok-build-cli
+anet node start grok-demo
+```
+
+看到以下提示说明 TUI 已准备好：
+
+```text
+[grok-copresence] ...; attach with anet grok attach grok-demo
+```
+
+```bash
+# 终端 2：连接到同一个 live TUI
+anet grok attach grok-demo
+```
+
+在 attach 终端按 `Ctrl-]` 只会断开当前终端，不会停止节点或 Grok 会话。同一时间只允许一个人类终端连接；第二个连接会被拒绝。
+
+网络任务会在 TUI 中以以下形式出现：
+
+```text
+[Agent Network/from=<发送者>/task=<任务 ID>] <消息>
+```
+
+普通的人类对话不会自动发送到 Agent Network。只有明确的委派指令（例如 `给 reviewer 发任务: 检查当前改动`）才会触发派发。
+
+## 停止与恢复
+
+用正常的节点命令停止：
+
+```bash
+anet node stop grok-demo
+```
+
+再次 `anet node start grok-demo` 会恢复同一 `grokCliSession`。运行时不会静默切换到 headless，也不会猜测另一个会话。若进程在网络任务执行中崩溃，该任务会失败而不会自动重放，避免重复副作用。
+
+## 旧 headless 模式
+
+如需每个网络任务单独启动无界面 Grok 进程：
+
+```bash
+anet node create grok-headless --runtime grok-build-cli --grok-headless
+```
+
+headless 节点不能使用 `anet grok attach`。缺少 `grokCopresence: true` 的旧 profile 也会保留原行为，不会自动迁移。
+
+## 常见问题
+
+### 提示版本过旧或版本不匹配
+
+运行 `grok --version`。共存只接受已验证清单里的精确 build（当前为 `0.2.93 (f00f96316d)` 与 `1.0.5 (5115b46bc909)`）；装到清单内版本后再启动，不要绕过版本检查。1.0.5 上 sandbox 与 leader 模式互斥，运行时会自动按版本调整启动参数，无需手工干预。
+
+### 已有的裸 grok 会话不能直接变共存
+
+在普通 `grok`（sandbox=off）里创建的会话**无法** resume 进共存节点：共存运行时强制沙箱档，grok 会拒绝跨档 resume（`cannot resume this session under sandbox profile … it was created with 'off'`），且刻意不提供关闭沙箱的通道。把已有会话 pin 进 `grokCliSession` 会反复得到 `Grok recovery TUI exited before recovery drain`（诊断改进见 [#1400](https://github.com/sleep2agi/agent-network/issues/1400)）。做法：让节点新建沙箱内会话（不 pin 旧 id，或 `--new-session`）；旧会话原样保留，仍可用 `grok --resume <id>` 单独查看。
+
+### `Installed agent-node does not support grok-build-cli`
+
+你正在调用 npm stable 的 agent-node，或 `ANET_AGENT_NODE_BIN` 指向错误。重新构建 `agent-node`，并把该变量设为 `dist/cli.js` 的绝对路径。
+
+### attach 提示不是 TTY
+
+`anet grok attach` 必须直接在交互式终端运行，不能通过 pipe、重定向或非交互 CI 执行。
+
+### attach 提示节点是 legacy headless
+
+该 profile 没有启用共存模式。创建新的 `grok-build-cli` 节点；不要直接复制 socket 路径或猜测配置。
+
+### 权限确认
+
+权限弹窗只由已连接的人类处理。运行时不会替你选择永久允许，并会阻止改变共享审批策略的 TUI 命令。审批界面只使用 Enter（单次允许）或 `Ctrl-C`（拒绝/取消）。
+
+实现、安全边界和 Docker 验证细节见[完整 Grok Build Runtime 说明](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)。

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -73,9 +73,9 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > 所以 R367 没有、也不该把它们清掉。代价是:**latest 或 preview 一发布,它们立刻变成假的**,
 > 而且是危险的那种假 —— 会告诉用户一道已经存在的安全 preflight 不存在。
 >
-> 逐次发版必须重新核对的位置(**38 个路径**,下表 38 行 = 38 个文件 ——
+> 逐次发版必须重新核对的位置(**40 个路径**,下表 40 行 = 40 个文件 ——
 > 不要把 zh/en 合成一行数,分母数错会漏核。
-> 这张表的分母被修正过三次:7 → 8 → 12 → 14 → 38。**加新的信道断言时,同时把它加进这张表**,
+> 这张表的分母被修正过三次:7 → 8 → 12 → 14 → 40。**加新的信道断言时,同时把它加进这张表**,
 > 否则下一个人照着一份"看起来完整"的清单去核,漏掉的那几页永远不会被发现):
 >
 > | 文件 | 行 | 断言 |
@@ -84,6 +84,8 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > | `docs-site/docs/en/guide/getting-started.md` | 19–20 | 同上(英文) |
 > | `docs-site/docs/troubleshooting/is-this-node-alive.md` | 见门输出 | #895 stdout 假报「`2.3.0-preview.40` 起已修」——修复版本钉死在断言里,promote latest 时核对 latest 是否已含 #895 |
 > | `docs-site/docs/en/troubleshooting/is-this-node-alive.md` | 见门输出 | 同上(英文) |
+> | `docs-site/docs/guide/grok-tui.md` | 见门输出 | 共存已在 preview 通道(钉 2.3.0-preview.59 / 2.5.0-preview.43 实测)——发版时核对仍真 |
+> | `docs-site/docs/en/guide/grok-tui.md` | 见门输出 | 同上(英文) |
 > | `docs-site/docs/deploy/clean-server.md` | 21–22 | 同上 |
 > | `docs-site/docs/en/deploy/clean-server.md` | 21–22 | 同上(英文) |
 > | `docs-site/docs/troubleshooting.md` | 29、37 | preview 有 preflight / latest 没有 |

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -147,10 +147,15 @@ broken=$(printf '%s' "$out" | sed -nE 's/^broken_pins=([0-9]+)$/\1/p')
 # CI 上先红("预期扫 119 …,实际 121")我才来抬,顺序是对的:
 # 🔴 **先让它红,再抬分母**。反过来(先抬数再加文件)等于让门永远追不上,
 #    而那种「把数改小让门变绿」的动作按本文件已有的红线看待。
-[[ "$files" -eq 121 ]] || fail "预期扫 121 个文档文件(= git ls-files 的结果),实际 $files"
+# 2026-08-29:121 → 123。grok-tui 使用指南首次入库(中英各一份):
+#     docs-site/docs/guide/grok-tui.md
+#     docs-site/docs/en/guide/grok-tui.md
+# 仍然**只有 `files` 变了**,`uniq` 仍 11、`occ` 仍 28(两页都没有 #L 源码行号 pin)。
+# CI 上先红("预期扫 121 …,实际 123")我才来抬,顺序是对的。
+[[ "$files" -eq 123 ]] || fail "预期扫 123 个文档文件(= git ls-files 的结果),实际 $files"
 [[ "$uniq"  -eq 11  ]] || fail "预期 11 个唯一 pin,实际 $uniq"
 [[ "$occ"   -eq 28 ]] || fail "预期 28 处原始出现,实际 $occ"
-echo "  OK  walk 路径与 git 路径给出同一份清单(119 文件 / 11 唯一 pin / 28 处)"
+echo "  OK  walk 路径与 git 路径给出同一份清单($files 文件 / $uniq 唯一 pin / $occ 处)"
 
 # ---------------------------------------------------------------------------
 # L1 — 干净树上必须绿


### PR DESCRIPTION
今晚 TMWork 共存节点实战（TM苹果狗 端到端 19s 回包）暴露的三处文档问题一并解决：

1. **guide/grok-tui 从未入库**（一直是主检出的未跟踪文件）——本 PR 首次提交，并先修正两处过时断言：「仅源码可用」→ 已随 npm preview 发布（macmini 实测全局 anet `2.3.0-preview.43`）；「严格 0.2.93」→ 验证清单现含 `1.0.5 (5115b46bc909)`（源码 `GROK_COPRESENCE_VERIFIED_BUILDS`，1.0.5 sandbox/leader 互斥由运行时自适配）
2. **新增关键 caveat**：sandbox=off 的既有裸会话无法 resume 进共存（grok 硬拒），只能新沙箱会话 —— #1400 里被「recovery drain」吞掉的真错误
3. **guide/grok-copresence 的「当前不可用」danger 块（2026-08-18）已被今晚生产实测推翻** —— 顶部加 2026-08-29 状态更新指向新页，旧告诫存档保留
4. 侧栏注册 grok-tui；两新页登记 RELEASE-SOP 信道断言清单（本地两门已绿）

按内容搜过重复 PR：grok-tui / verified builds ⇒ 零命中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)