### PR TITLE
feat(grok-copresence): TUI 内精确 /model <id> 代执行——仍取消按键、带外走 switchModel (#879)

### DIFF
--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -2121,6 +2121,14 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         // The text is already visible in Grok's editor. Cancel it locally
         // instead of submitting a slash command that would pre-authorize a
         // later network turn.
+        //
+        // Exactly one command is proxied instead of merely blocked: a pristine
+        // `/model <id>` line (#879). Read it BEFORE the audit reset below; the
+        // keystrokes are still cancelled either way, so the TUI's slash
+        // palette never sees an Enter and cannot complete the prefix into
+        // something else — the switch runs out-of-band via switchModel(),
+        // the same guarded entry `anet grok model` uses.
+        const proxiedModel = this.matchExactHumanModelCommand();
         const blockRoute = this.humanComposerLeadingSlash
           ? "slash command"
           : "edited line (arrow/Home/End/Delete make the editor contents unverifiable; press Ctrl+U to clear and retype)";
@@ -2129,7 +2137,15 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         if (this.arbitration.phase === "human_editing") {
           this.transition({ type: "human_input_cancelled" });
         }
-        this.warnBlockedPermissionModeChange(blockRoute);
+        if (proxiedModel !== null) {
+          this.log(`[grok-copresence] in-TUI /model proxied out-of-band (#879): ${proxiedModel}`);
+          // Runs synchronously up to switchModel's first await, so its
+          // idle-phase check happens before scheduleNetworkIfIdle() below can
+          // hand the turn to a network task.
+          void this.proxyHumanModelSwitch(proxiedModel);
+        } else {
+          this.warnBlockedPermissionModeChange(blockRoute);
+        }
         if (offset < input.length) {
           // Same-frame bytes are not a new, intentional composer action.
           this.attach?.broadcastStatus({
@@ -2199,6 +2215,55 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         this.humanComposerAuditUnsafe = true;
       }
     }
+  }
+
+  /**
+   * The single slash command the human composer proxies instead of blocking
+   * (#879): a pristine `/model <id>` line.
+   *
+   * "Pristine" is load-bearing. The audit mirror only equals the editor's
+   * contents while no unmodelled edit happened, so any taint/unsafe/overflow
+   * state disqualifies the line — those fall through to the generic block.
+   * Exactly one operand is accepted; the id itself is re-validated by
+   * `normalizeGrokModelSwitchRequest` before it can reach argv.
+   */
+  private matchExactHumanModelCommand(): string | null {
+    if (!this.humanComposerLeadingSlash) return null;
+    if (
+      this.humanComposerAuditTainted
+      || this.humanComposerAuditUnsafe
+      || this.humanComposerAuditOverflow
+    ) return null;
+    const match = /^\s*\/model[ \t]+(\S+)[ \t]*$/.exec(this.humanComposerAudit);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * Run a human-typed `/model <id>` through the same guarded out-of-band
+   * entry the attach transport uses, and answer in the TUI itself — the
+   * person who typed it is watching the terminal, not the status stream.
+   */
+  private async proxyHumanModelSwitch(model: string): Promise<void> {
+    let decision: GrokModelSwitchResult;
+    try {
+      decision = await this.switchModel(model);
+    } catch (error) {
+      const message = errorMessage(error);
+      this.warn(`[grok-copresence] in-TUI /model switch to ${model} failed: ${message}`);
+      this.attach?.broadcastOutput(`\r\n[anet] 模型未切换（failed）：${message}\r\n`);
+      this.attach?.broadcastStatus({ ...this.attachStatus(), modelSwitch: { ok: false, code: "failed", message } });
+      return;
+    }
+    if (decision.ok) {
+      this.log(`[grok-copresence] model switch accepted: ${decision.model}`);
+      this.attach?.broadcastOutput(
+        `\r\n[anet] 已代为切换模型 → ${decision.model}（${decision.route === "hot" ? "热切换" : "重启续会话"}）\r\n`,
+      );
+    } else {
+      this.warn(`[grok-copresence] model switch refused (${decision.code}): ${decision.message}`);
+      this.attach?.broadcastOutput(`\r\n[anet] 模型未切换（${decision.code}）：${decision.message}\r\n`);
+    }
+    this.attach?.broadcastStatus({ ...this.attachStatus(), modelSwitch: decision });
   }
 
   private isForbiddenHumanModeCommand(): boolean {

--- a/agent-node/src/runtime/grok-copresence/slash-gate.test.ts
+++ b/agent-node/src/runtime/grok-copresence/slash-gate.test.ts
@@ -60,21 +60,25 @@ describe("Grok copresence human-side slash gate (2026-08-15 snapshot)", () => {
     });
   });
 
-  test("/model is cancelled like other TUI slash commands and points to anet grok model", async () => {
-    await withHumanTui(async ({ fixture, input, terminalOutput, statusWarnings }) => {
+  test("a pristine /model <id> is cancelled at the TUI but proxied out-of-band (#879)", async () => {
+    await withHumanTui(async ({ fixture, input, terminalOutput }) => {
       input.write("/model grok-4-fast\r");
-      await waitFor(() => terminalOutput.join("").includes(SLASH_TUI_NOTICE));
+      await waitFor(() => terminalOutput.join("").includes("已代为切换模型 → grok-4-fast"));
 
+      // The keystrokes are still cancelled — the TUI's slash palette never
+      // sees an Enter, so completion cannot turn the prefix into anything.
       expect(fixture.writes.join("")).toBe("/model grok-4-fast\x03");
-      expect(fixture.acpModelSwitchCalls).toEqual([]);
+      // The switch went through the same guarded entry `anet grok model` uses.
+      expect(fixture.acpModelSwitchCalls).toHaveLength(1);
+      expect(fixture.acpModelSwitchCalls[0]?.params?.modelId).toBe("grok-4-fast");
       expect(fixture.spawnedArgs).toHaveLength(1);
-      expect(fixture.warnings).toEqual([`[grok-copresence] slash command ${BLOCK_SUFFIX}`]);
-      expect(statusWarnings).toContain(`slash command ${BLOCK_SUFFIX}`);
-      expect(terminalOutput.join("")).toContain(SLASH_TUI_NOTICE);
+      // A proxied switch is not a blocked command: no block warning is raised.
+      expect(fixture.warnings).toEqual([]);
+      expect(terminalOutput.join("")).not.toContain(SLASH_TUI_NOTICE);
     });
   });
 
-  test("/model never falls through to restart+resume from the TUI slash gate", async () => {
+  test("a proxied /model falls back to restart+resume when ACP refuses (#879)", async () => {
     await withHumanTui(async ({ fixture, input, terminalOutput }) => {
       fixture.acpModelSwitch = async () => {
         const error = new Error("incompatible-agent: model requires new session");
@@ -83,12 +87,42 @@ describe("Grok copresence human-side slash gate (2026-08-15 snapshot)", () => {
       };
 
       input.write("/model grok-4.5\r");
-      await waitFor(() => terminalOutput.join("").includes(SLASH_TUI_NOTICE));
+      await waitFor(() => terminalOutput.join("").includes("已代为切换模型 → grok-4.5"), 5_000);
+      await waitFor(() => fixture.spawnedArgs.length === 2, 5_000);
 
       expect(fixture.writes.join("")).toBe("/model grok-4.5\x03");
+      const respawn = fixture.spawnedArgs[1];
+      expect(respawn[respawn.indexOf("--model") + 1]).toBe("grok-4.5");
+      // 🔴 The conversation has to survive the restart route.
+      expect(respawn).toContain("--resume");
+      expect(respawn).not.toContain("--session-id");
+    });
+  });
+
+  test("/model with extra tokens is NOT proxied and stays blocked", async () => {
+    await withHumanTui(async ({ fixture, input, terminalOutput }) => {
+      input.write("/model grok-4.5 --yolo\r");
+      await waitFor(() => terminalOutput.join("").includes(SLASH_TUI_NOTICE));
+
       expect(fixture.acpModelSwitchCalls).toEqual([]);
       expect(fixture.spawnedArgs).toHaveLength(1);
       expect(fixture.warnings).toEqual([`[grok-copresence] slash command ${BLOCK_SUFFIX}`]);
+    });
+  });
+
+  test("a bare /model and a /model-prefixed command are NOT proxied", async () => {
+    await withHumanTui(async ({ fixture, input, terminalOutput }) => {
+      input.write("/model\r");
+      await waitFor(() => terminalOutput.join("").includes(SLASH_TUI_NOTICE));
+      input.write("/models grok-4.5\r");
+      await waitFor(() => fixture.warnings.length === 2);
+
+      expect(fixture.acpModelSwitchCalls).toEqual([]);
+      expect(fixture.spawnedArgs).toHaveLength(1);
+      expect(fixture.warnings).toEqual([
+        `[grok-copresence] slash command ${BLOCK_SUFFIX}`,
+        `[grok-copresence] slash command ${BLOCK_SUFFIX}`,
+      ]);
     });
   });
 


### PR DESCRIPTION
## 背景

Vincent 2026-08-30 实操反馈：共存 TUI 里打 `/model` 只得到禁用提示，追问「为什么 codex 可以 grok 不行」。#879 的带外通道（`anet grok model`）已在 main，但用户在 TUI 里的第一反应仍是 `/model`。

## 方案

人类 composer 提交拦截处只放行**一条**代理路径：行首 `/model` + 恰好一个操作数 + 审计镜像 pristine（未 taint/unsafe/overflow）。命中时：

- 按键仍照旧取消（Ctrl-C）——TUI 斜杠面板永远收不到 Enter，**补全攻击面为零**；
- 改为调用既有 `switchModel()`（与 attach set-model 同一入口：slug 校验、busy/unchanged 拒绝、热切换失败回退 restart+resume、argv delta 断言）；
- 结果经 broadcastOutput 直接答在 TUI 里（成功/拒绝/失败各一行）。

其余斜杠行为逐字不变：`/always-approve` SECURITY 用例未动，多参数、裸 `/model`、`/models` 前缀均不代理、照旧拦截。

## 测试

- slash-gate.test.ts 18/18（4 个新/改用例：代理成功、ACP 拒绝时 restart+resume 且 `--resume` 无 `--session-id`、多参数不代理、裸 /model 与 /models 不代理）
- runtime.test.ts 66/66；composer-tainted-diagnostics + allowlist-near-miss + model-switch 50/50

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
