### PR TITLE
chore(release): agent-node 2.5.0-preview.45 —— /model 代执行 (#1408) + spawn-helper 自愈 (#1406)

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.59";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.44";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.45";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.44",
+  "version": "2.5.0-preview.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.44",
+      "version": "2.5.0-preview.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.44",
+  "version": "2.5.0-preview.45",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.45.md
+++ b/docs/tests/release-v2.5.0-preview.45.md
@@ -1,0 +1,27 @@
+# agent-node v2.5.0-preview.45
+
+本版从 main 发布，带出 preview.44 之后合入的两个改动：
+
+- **#1408**（grok 共存）：人类在共存 TUI 里打一条干净的 `/model <id>` 现在会被**代为执行**（按键仍取消、斜杠面板零攻击面，带外走既有 `switchModel()` 受护入口，结果直接答在 TUI）；`/always-approve` 等安全拦截逐字未变。
+- **#1406**（#1399 根治）：安装后兜底修复 node-pty `spawn-helper` 执行位，消除每次 npm 解包后 `posix_spawnp failed` 的复发。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.45
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.45
+# 验证
+agent-node --version   # 期望 2.5.0-preview.45
+```
+
+Grok 共存节点升级后，在共存 TUI 里 `/model <模型名>` 即可直接换模型；仍可用 `anet grok model <node> <model>` 从另一终端切换。
+
+## Verification
+
+- slash-gate 18/18、runtime 66/66、composer-tainted + allowlist-near-miss + model-switch 50/50（本地 bun test，见 #1408）
+- 五格门合并至 main（commit b0c1ef3a）


### PR DESCRIPTION
## 发版 agent-node 2.5.0-preview.45（preview tag，从 main）

带出 preview.44 之后合入 main 的两项：

- **#1408**：grok 共存 TUI 内干净的 `/model <id>` 代执行（按键仍取消、带外走 `switchModel()`、`/always-approve` 仍拦）。这是 Vincent 实操点名的功能。
- **#1406**：安装后兜底 node-pty `spawn-helper` 执行位，根治 #1399 每次安装必现的 `posix_spawnp failed`。

## 改动

- `agent-node/package.json` → 2.5.0-preview.45
- `agent-node/package-lock.json`（两处，`sync-pinned-versions.sh`）
- `agent-network/src/opencode-agent-node-pair.ts` PAIRED_AGENT_NODE_VERSION → 2.5.0-preview.45（同一脚本同步）
- `docs/tests/release-v2.5.0-preview.45.md`（Install / Upgrade / 本版包含 / Verification）

合并后从 main dispatch `release.yml -f package=agent-node -f version=2.5.0-preview.45 -f publish=true`，只发 preview tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
