### PR TITLE
docs(grok-tui): TUI 内 /model 换模型 + 旧会话 resume 移植法

### DIFF
--- a/docs-site/docs/en/guide/grok-tui.md
+++ b/docs-site/docs/en/guide/grok-tui.md
@@ -86,6 +86,15 @@ anet node stop grok-demo
 
 The next `anet node start grok-demo` resumes the same `grokCliSession`. The runtime never silently falls back to headless mode or guesses another session. If the process crashes during a network turn, that task fails instead of being replayed across a possible side-effect boundary.
 
+## Switching models inside the co-presence TUI
+
+The co-presence TUI is **one input box shared by a human and the agent**: every keystroke you type reaches the agent's session, so leading-slash commands are blocked as a class by default (palette completion could turn a short prefix + Enter into `/always-approve`, bypassing the approval gate). There are two safe ways to change the model:
+
+- **Type `/model <model>` right in the TUI** (agent-node `2.5.0-preview.45`+): a pristine `/model <id>` line is **proxied out-of-band** — the keystrokes are still cancelled (the slash palette never sees an Enter), the switch runs through the guarded entry, and the result is printed straight into the TUI (`[anet] 已代为切换模型 → <model>`). Extra tokens, a bare `/model`, or a line touched by arrow-key edits are not proxied and stay blocked.
+- **From another terminal: `anet grok model <node> <model>`** — works on any version, even while attached; the session restarts on the new model.
+
+Run `anet grok attach` from the node's working directory (nodes resolve by cwd, see [#1402](https://github.com/sleep2agi/agent-network/issues/1402)).
+
 ## Legacy headless mode
 
 To launch a separate non-interactive Grok process for each network task:
@@ -102,9 +111,19 @@ Headless nodes cannot use `anet grok attach`. Existing profiles without `grokCop
 
 Run `grok --version`. Co-presence only accepts the exact builds on the verified list (currently `0.2.93 (f00f96316d)` and `1.0.5 (5115b46bc909)`). Install a listed build before starting; do not bypass the gate. On 1.0.5, sandbox and leader mode are mutually exclusive — the runtime adjusts its launch flags per version automatically.
 
-### An existing bare grok session cannot join co-presence
+### An existing bare grok session cannot join co-presence by default (but can be transplanted)
 
-Sessions created in plain `grok` (sandbox=off) **cannot** be resumed into a co-presence node: the runtime enforces a sandbox profile and grok refuses cross-profile resume (`cannot resume this session under sandbox profile … it was created with 'off'`), with no supported way to disable the sandbox. Pinning such a session into `grokCliSession` yields repeated `Grok recovery TUI exited before recovery drain` (diagnosability follow-up: [#1400](https://github.com/sleep2agi/agent-network/issues/1400)). Instead let the node create a fresh sandboxed session (drop the pinned id, or use `--new-session`); the old session stays intact and can still be viewed with `grok --resume <id>`.
+Sessions created in plain `grok` (sandbox=off) **cannot by default** be resumed into a co-presence node: the runtime enforces a sandbox profile and grok refuses cross-profile resume (`cannot resume this session under sandbox profile … it was created with 'off'`). Pinning such a session directly into `grokCliSession` yields repeated `Grok recovery TUI exited before recovery drain` (diagnosability follow-up: [#1400](https://github.com/sleep2agi/agent-network/issues/1400)).
+
+**Verified transplant** (keeps all history, no need to disable the sandbox, see [#1409](https://github.com/sleep2agi/agent-network/issues/1409)): the refusal only keys off the session metadata recording `created with 'off'`, so **clone** the session and flip that one field —
+
+1. Copy the old session directory (`sessions/<cwd-key>/<old-id>/`, whole tree: `chat_history.jsonl`/`events.jsonl`/`compaction/`) to a new UUID; delete the `*.lock` files.
+2. In the clone's `summary.json`, change `sandbox_profile`: `"off"` → the node's current workspace profile (like `anet-<hash>-workspace`; it is the only occurrence of that field in the tree).
+3. Point the node config's `grokCliSession` at the new id and restart the node.
+
+grok then resumes the clone cleanly; recent technical context comes back intact (early/low-frequency content may fall outside the active window due to grok's session compaction). The original session is never touched and can still be viewed with `grok --resume <old-id>`. If you prefer not to transplant, let the node create a fresh sandboxed session (drop the pinned id, or `--new-session`).
+
+> ⚠️ Don't let `auto_update` push grok off the verified list: an unverified build (e.g. `1.0.13`) makes co-presence fail with `requires a verified grok build`. Pin a verified build with `GROK_BINARY`, or disable `auto_update` in the node's private `GROK_HOME` ([#1409](https://github.com/sleep2agi/agent-network/issues/1409)).
 
 ### `Installed agent-node does not support grok-build-cli`
 

--- a/docs-site/docs/guide/grok-tui.md
+++ b/docs-site/docs/guide/grok-tui.md
@@ -86,6 +86,15 @@ anet node stop grok-demo
 
 再次 `anet node start grok-demo` 会恢复同一 `grokCliSession`。运行时不会静默切换到 headless，也不会猜测另一个会话。若进程在网络任务执行中崩溃，该任务会失败而不会自动重放，避免重复副作用。
 
+## 在共存 TUI 里换模型
+
+共存 TUI 是**人和 agent 共用同一个输入框**：你敲的每个键都直达 agent 会话，所以行首斜杠命令默认被整类拦截（补全可能把短前缀+回车变成 `/always-approve`，绕开审批闸门）。换模型有两条安全路径：
+
+- **TUI 里直接打 `/model <模型名>`**（agent-node `2.5.0-preview.45`+）：一条干净的 `/model <id>` 会被**代为执行**——按键仍被取消（斜杠面板收不到回车），换模型带外走受护入口，结果直接答在 TUI 里（`[anet] 已代为切换模型 → <模型名>`）。多参数、裸 `/model`、被方向键编辑过的行都不代理，仍照常拦截。
+- **另开终端 `anet grok model <节点> <模型名>`**：任意版本可用，attach 挂着也能切；同会话用新模型重启。
+
+`anet grok attach` 必须在节点的工作目录下执行（按 cwd 解析节点，见 [#1402](https://github.com/sleep2agi/agent-network/issues/1402)）。
+
 ## 旧 headless 模式
 
 如需每个网络任务单独启动无界面 Grok 进程：
@@ -102,9 +111,19 @@ headless 节点不能使用 `anet grok attach`。缺少 `grokCopresence: true` �
 
 运行 `grok --version`。共存只接受已验证清单里的精确 build（当前为 `0.2.93 (f00f96316d)` 与 `1.0.5 (5115b46bc909)`）；装到清单内版本后再启动，不要绕过版本检查。1.0.5 上 sandbox 与 leader 模式互斥，运行时会自动按版本调整启动参数，无需手工干预。
 
-### 已有的裸 grok 会话不能直接变共存
+### 已有的裸 grok 会话默认不能直接变共存（但可移植）
 
-在普通 `grok`（sandbox=off）里创建的会话**无法** resume 进共存节点：共存运行时强制沙箱档，grok 会拒绝跨档 resume（`cannot resume this session under sandbox profile … it was created with 'off'`），且刻意不提供关闭沙箱的通道。把已有会话 pin 进 `grokCliSession` 会反复得到 `Grok recovery TUI exited before recovery drain`（诊断改进见 [#1400](https://github.com/sleep2agi/agent-network/issues/1400)）。做法：让节点新建沙箱内会话（不 pin 旧 id，或 `--new-session`）；旧会话原样保留，仍可用 `grok --resume <id>` 单独查看。
+在普通 `grok`（sandbox=off）里创建的会话**默认无法** resume 进共存节点：共存运行时强制沙箱档，grok 会拒绝跨档 resume（`cannot resume this session under sandbox profile … it was created with 'off'`）。把已有会话直接 pin 进 `grokCliSession` 会反复得到 `Grok recovery TUI exited before recovery drain`（诊断改进见 [#1400](https://github.com/sleep2agi/agent-network/issues/1400)）。
+
+**已验证的移植做法**（保留全部历史、无需关沙箱，见 [#1409](https://github.com/sleep2agi/agent-network/issues/1409)）：拒绝的依据只是会话元数据里记着 `created with 'off'`，把会话**克隆一份**再改这一处即可绕过——
+
+1. 把旧会话目录（`sessions/<cwd-key>/<old-id>/` 全量，含 `chat_history.jsonl`/`events.jsonl`/`compaction/`）复制成一个新 UUID，删掉 `*.lock`。
+2. 改克隆件 `summary.json` 的 `sandbox_profile`：`"off"` → 节点当前的 workspace 档（形如 `anet-<hash>-workspace`，全目录仅此一处含该字段）。
+3. 节点 config 的 `grokCliSession` 指向新 id，重启节点。
+
+重启后 grok 正常 resume 克隆会话，近期技术上下文完整带回（早期/低频内容可能因 grok 的会话 compaction 落在活动窗口外）。原始旧会话全程不动，随时仍可 `grok --resume <old-id>` 单独查看。若不想移植，也可让节点新建沙箱内会话（不 pin 旧 id 或 `--new-session`）。
+
+> ⚠️ 别让 `auto_update` 把 grok 升出验证清单：升到未验证版本（如 `1.0.13`）后共存会直接报 `requires a verified grok build`。用 `GROK_BINARY` 钉住已验证 build，或在节点私有 `GROK_HOME` 关掉 `auto_update`（[#1409](https://github.com/sleep2agi/agent-network/issues/1409)）。
 
 ### `Installed agent-node does not support grok-build-cli`
 


### PR DESCRIPTION
## 把今晚两项落地沉淀进文档（Vincent 要求文档及时更新）

`docs-site/docs/guide/grok-tui.md` + en 同步：

1. **新增「在共存 TUI 里换模型」**：说明共享输入框为何默认拦斜杠，给两条安全换模型路径——TUI 里 `/model <id>` 代执行（agent-node 2.5.0-preview.45+，#1408）与 `anet grok model <node> <model>`（任意版本）。
2. **更新「裸 grok 会话变共存」**：从「不能」改为「默认拒绝、但有已验证的克隆+改 `sandbox_profile` 元数据移植法」（#1409），保历史、不关沙箱；补 `auto_update` 把 grok 升到未验证 build（如 1.0.13）会致共存起不来的告警。

均为已实测落地的行为（.45 已上 npm preview；resume 移植在 Mac TM苹果狗 节点验证过）。合并后需部署 anet.sh 使线上同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
