### PR TITLE
fix(grok-copresence): attach 连上强制重绘消除黑屏 (#1412)

### DIFF
--- a/agent-node/src/runtime/grok-copresence/attach.test.ts
+++ b/agent-node/src/runtime/grok-copresence/attach.test.ts
@@ -150,6 +150,32 @@ describe("Grok co-presence local attach server", () => {
     expect(server.clientAttached).toBe(true);
   });
 
+  it("arms a one-shot redraw for a terminal client but never for a control connection (#1412)", async () => {
+    const { socketPath } = temporarySocket();
+    const events: string[] = [];
+    const resized = deferred<void>();
+    const server = await startServer(socketPath, {
+      onTerminalAttached: () => { events.push("terminal-attached"); },
+      onResize: (cols, rows) => { events.push(`resize:${cols}x${rows}`); resized.resolve(); },
+    });
+
+    // First client is the terminal: onTerminalAttached fires after hello and
+    // BEFORE its first resize (it rides the same serialized arbiter queue).
+    const terminal = await connect(socketPath);
+    await terminal.frames.next(); // hello
+    terminal.socket.write(`${JSON.stringify({ type: "resize", cols: 100, rows: 30 })}\n`);
+    await resized.promise;
+    expect(events).toEqual(["terminal-attached", "resize:100x30"]);
+
+    // Second client is a control connection: it must never arm a redraw.
+    const control = await connect(socketPath);
+    expect(await control.frames.next()).toMatchObject({ type: "hello", role: "control" });
+    await Bun.sleep(50);
+    expect(events.filter((e) => e === "terminal-attached")).toHaveLength(1);
+
+    void server;
+  });
+
   it("fails closed when an inbound frame exceeds the configured bound", async () => {
     const { socketPath } = temporarySocket();
     const server = await startServer(socketPath, {

--- a/agent-node/src/runtime/grok-copresence/attach.ts
+++ b/agent-node/src/runtime/grok-copresence/attach.ts
@@ -53,6 +53,16 @@ export interface GrokCopresenceAttachServerOptions {
   onInput: (data: Buffer) => void | Promise<void>;
   /** Receives validated dimensions. The arbiter remains the sole PTY owner. */
   onResize: (cols: number, rows: number) => void | Promise<void>;
+  /**
+   * Fires once, after a terminal client's `hello` is sent, before any of its
+   * input/resize frames (#1412). grok does not repaint its screen when a new
+   * client attaches, so a client that connects while the TUI is idle sees a
+   * blank screen. The runtime uses this to arm a one-shot redraw on the
+   * client's first resize (a resize jitter forces grok to repaint).
+   *
+   * Terminal role only: control connections never own the screen.
+   */
+  onTerminalAttached?: () => void | Promise<void>;
   onDetach?: (reason: GrokCopresenceAttachDetachReason) => void | Promise<void>;
   /**
    * Receives a requested model id (issue #879).
@@ -369,6 +379,14 @@ class AttachServer implements GrokCopresenceAttachServer {
       role: client.role,
     })) {
       this.releaseDisconnected(client);
+      return;
+    }
+
+    // Arm the one-shot redraw (#1412) through the same serialized arbiter
+    // queue as input/resize, so it lands before the client's first resize is
+    // processed — never on a control connection.
+    if (client.role === "terminal" && this.options.onTerminalAttached) {
+      this.enqueueCallback(client, () => this.options.onTerminalAttached!(), 0);
     }
   }
 

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -975,6 +975,8 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   private currentModel?: string;
   /** Set only while a `switchModel()` re-spawn is the reason the TUI exited. */
   private modelSwitchInFlight: string | null = null;
+  /** Set when a terminal client attaches; consumed on its first resize to force a one-shot grok repaint (#1412). */
+  private pendingRedrawOnResize = false;
   /**
    * argv of the most recent spawn, kept so a model switch can be checked
    * against what actually reached the process rather than against a second
@@ -1344,6 +1346,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         sessionId: this.sessionId,
         onInput: (data) => this.onHumanInput(data),
         onResize: (cols, rows) => this.onResize(cols, rows),
+        onTerminalAttached: () => { this.pendingRedrawOnResize = true; },
         onDetach: () => this.onHumanDetach(),
         onSetModel: (model) => this.onAttachSetModel(model),
       });
@@ -2298,7 +2301,21 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   }
 
   private onResize(cols: number, rows: number): void {
-    try { this.pty?.resize(cols, rows); } catch (error) {
+    try {
+      this.pty?.resize(cols, rows);
+      // One-shot redraw for a freshly attached terminal (#1412). grok does not
+      // repaint on attach, and a plain resize to the client's own size is a
+      // no-op that raises no SIGWINCH — so an idle TUI stays blank. A one-row
+      // jitter forces grok to repaint the full screen (verified: ~14KB of
+      // redraw output). Do it only on the first resize after attach, and only
+      // if the PTY is still ours.
+      if (this.pendingRedrawOnResize && this.pty) {
+        this.pendingRedrawOnResize = false;
+        const jitterRows = rows > 1 ? rows - 1 : rows + 1;
+        this.pty.resize(cols, jitterRows);
+        this.pty.resize(cols, rows);
+      }
+    } catch (error) {
       this.warn(`[grok-copresence] resize failed: ${errorMessage(error)}`);
     }
   }


### PR DESCRIPTION
## 修 attach 黑屏（#1412），Vincent 今晚反复卡在这

**现象**：`anet grok attach` 连上后终端黑屏（只有光标），用户以为"没连上/这不是 TUI"。

**根因**（实机 + 读码坐实）：① grok 不在新客户端 attach 时重画屏幕；② 客户端连上发的初始 resize 若等于当前 PTY 尺寸是 no-op，不触发 SIGWINCH，grok 不重画。于是 idle TUI 对新 attach 黑屏。「拖动窗口改大小」能出界面，正因那是真 resize。

**修复**：attach.ts 在 terminal 客户端 `hello` 后经同一串行 arbiter 队列触发 `onTerminalAttached`；runtime 据此在该客户端**首次 resize** 时做一次一行抖动（`resize(cols, rows-1)` → `resize(cols, rows)`）强制 grok 全量重画。control 连接永不触发。**不碰任何安全机制**，与 #1413（换模型崩）互相独立、可先行合入。

**实机验证**（连 attach.sock 观察 grok 输出字节）：
| 动作 | grok 输出 |
|---|---|
| 连上不动 | 0 B（黑屏根因）|
| 同尺寸 resize（no-op）| 0 B（第二根因）|
| **一行抖动** | **14606 B 全量重画** ✅ |

**测试**：attach.test 14/14（新增 terminal 触发 / control 不触发）、runtime.test 66/66 无回归、build 通过。

Refs #1412（此 PR 只修黑屏；detach 残留旧画面、换模型崩 #1413 另修）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
