### PR TITLE
chore(release): agent-node 2.5.0-preview.46 —— attach 黑屏修复 (#1412)

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.59";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.45";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.46";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.45",
+  "version": "2.5.0-preview.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.45",
+      "version": "2.5.0-preview.46",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.45",
+  "version": "2.5.0-preview.46",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.46.md
+++ b/docs/tests/release-v2.5.0-preview.46.md
@@ -1,0 +1,30 @@
+# agent-node v2.5.0-preview.46
+
+从 main 发布，带出 preview.45 之后合入的 attach 体验修复：
+
+- **#1412**（grok 共存）：`anet grok attach` 连上后强制一次重绘，消除**黑屏**。此前 grok 不在新客户端 attach 时重画屏幕，客户端连上发的初始 resize 若等于当前 PTY 尺寸是 no-op，于是 idle 的 TUI 对新 attach 显示黑屏（用户以为"没连上/这不是 TUI"）。现在连上首次 resize 时做一行抖动强制 grok 全量重画。control 连接不受影响，不碰任何安全机制。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.46
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.46
+agent-node --version   # 期望 2.5.0-preview.46
+```
+
+grok 共存节点升级并重启后，`anet grok attach <node>` 连上即显示 TUI 界面，不再黑屏。
+
+## Verification
+
+- attach.test 14/14（新增 terminal 触发重绘 / control 不触发用例）、runtime.test 66/66 无回归
+- 实机验证（连 attach.sock 观察 grok 输出）：连上不动 0B、同尺寸 resize no-op 0B、抖动 14606B 全量重画
+- 五格门合并至 main（commit 585e917c）
+
+## 已知未修
+
+- **#1413**：restart/hot 型换模型仍会崩节点（tail 防篡改校验误判 grok 日志轮转），修复方案见 issue，本版未含。换模型请暂缓。


### PR DESCRIPTION
## 发版 agent-node 2.5.0-preview.46（preview tag，从 main）

带出 preview.45 之后合入 main 的 **#1412 attach 黑屏修复**（Vincent 今晚反复卡在"attach 上了黑屏、以为不是 TUI"）。连上首次 resize 时做一行抖动强制 grok 全量重画，实机验证 14606B 重画。control 连接不受影响、不碰安全机制。

## 改动
- `agent-node/package.json` → 2.5.0-preview.46
- `agent-node/package-lock.json`（两处，sync 脚本）
- `agent-network/src/opencode-agent-node-pair.ts` PAIRED → .46
- `docs/tests/release-v2.5.0-preview.46.md`（Install/Upgrade/Verification/已知未修 #1413）

合并后从 main dispatch `release.yml -f package=agent-node -f version=2.5.0-preview.46 -f publish=true`。

## 已知未修
#1413 换模型崩节点未含（改安全机制 + 需隔离验证，另修）。release notes 已注明换模型暂缓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
