### PR TITLE
feat(daemon): #1417 daemon 退回纯程序节点（第一步：去 LLM 外壳）

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1905,6 +1905,14 @@ function buildCodexWakeDeps(): CodexWakeDeps {
 }
 
 async function runGoalSchedulerTick() {
+  // #1417 — A host_supervisor daemon is a pure-program node and must never run
+  // an LLM turn. A goal wake calls processTask (an LLM turn), so a daemon must
+  // not tick the scheduler — even if it was armed at boot as an agent and then
+  // hot-promoted to host_supervisor (RFC-024), or held active goals from before
+  // promotion. Checked live here (not just at boot) so promotion takes effect at
+  // once. The inbox guard blocks *new* daemon goals; this blocks *existing* ones
+  // from ever firing.
+  if (isDaemonPureProgramNode(fileConfig.role)) return;
   if (goalTickRunning) return;
   goalTickRunning = true;
   try {
@@ -6521,9 +6529,12 @@ import("./runtime/fetch-attachment.js").then(({ startAttachmentCacheSweeper }) =
   log(`[attachment-cache] sweeper started (hourly tick, 24h TTL, dir=${cacheDir})`);
 }).catch((e: any) => warn(`attachment-cache sweeper import failed: ${e?.message || e}`));
 
-if (goalsSchedulerEnabled) {
+if (goalsSchedulerEnabled && !isDaemonPureProgramNode(fileConfig.role)) {
   setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);
   runGoalSchedulerTick().catch(() => {});
+} else if (goalsSchedulerEnabled && isDaemonPureProgramNode(fileConfig.role)) {
+  // host_supervisor daemon: pure-program node, scheduler intentionally not armed.
+  log(`[goals] scheduler suppressed — host_supervisor daemon runs no LLM turns`);
 }
 
 // RFC-025 M2/M3 — loops HTTP MCP server for codex-sdk + grok-build-acp.

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -100,6 +100,7 @@ import {
 } from "./runtime/grok-build-acp/resume-hint";
 import { CurrentAliasResolver } from "./runtime/current-alias";
 import { delegationTargetExists } from "./runtime/delegation-precheck";
+import { isDaemonPureProgramNode, daemonProgramReply } from "./runtime/daemon-program-node";
 import { grokCliDenyPaths } from "./runtime/grok-cli-deny-paths";
 import {
   isRateLimitOrQuotaError,
@@ -5094,6 +5095,21 @@ async function processInbox() {
           messageType: msgType,
         }));
         await ackAndRecordConsumed(msg, "skipped");
+        return;
+      }
+
+      // #1417 — A host_supervisor daemon is a pure-program node: node
+      // lifecycle (create/stop/restart/delete/probe) arrives as structured
+      // SSE doorbells handled without a model. A free-text task reaching the
+      // inbox means the daemon was addressed as if it were an agent. Answer
+      // deterministically and return BEFORE processTask, so the lazy
+      // claude-agent-sdk import inside processWithClaude is never reached —
+      // the daemon process stays model-free.
+      if (isDaemonPureProgramNode(fileConfig.role)) {
+        const replyText = daemonProgramReply(ALIAS);
+        log(`← [${from}] (host_supervisor: free-text task answered by program, no LLM turn) ${content.slice(0, 80)}`);
+        await deliverReplyReliably(from, replyText, logicalTaskId, false);
+        await ackAndRecordConsumed(msg, "daemon-program");
         return;
       }
 

--- a/agent-node/src/runtime/daemon-program-node.test.ts
+++ b/agent-node/src/runtime/daemon-program-node.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  HOST_SUPERVISOR_ROLE,
+  daemonProgramReply,
+  isDaemonPureProgramNode,
+} from "./daemon-program-node";
+
+// #1417 — de-LLM the daemon. These lock in the decision that keeps a
+// host_supervisor daemon from ever running an LLM turn for a free-text task,
+// plus the deterministic reply it sends instead.
+describe("daemon-program-node (#1417)", () => {
+  test("only an exact host_supervisor role is a pure-program node", () => {
+    expect(isDaemonPureProgramNode("host_supervisor")).toBe(true);
+    expect(isDaemonPureProgramNode(HOST_SUPERVISOR_ROLE)).toBe(true);
+  });
+
+  test("every other role falls through to the runtime path", () => {
+    // Exact-value match only: agent/leader/empty/undefined/null and any
+    // differently-cased or near-miss string must NOT be treated as a daemon,
+    // or a normal agent could be silenced into never running the model.
+    for (const role of [
+      "agent",
+      "leader",
+      "supervisor",
+      "Host_Supervisor",
+      "HOST_SUPERVISOR",
+      "host-supervisor",
+      " host_supervisor",
+      "host_supervisor ",
+      "",
+      undefined,
+      null,
+    ]) {
+      expect(isDaemonPureProgramNode(role as any)).toBe(false);
+    }
+  });
+
+  test("program reply names the alias, states no model, and is deterministic", () => {
+    const r = daemonProgramReply("TM基建牛");
+    expect(r).toContain("TM基建牛");
+    expect(r).toContain("host_supervisor");
+    // It must not leave the sender expecting an AI answer.
+    expect(r).toMatch(/不运行大模型/);
+    expect(r).toMatch(/无 AI|不会调用 AI/);
+    // Names the lifecycle commands the daemon actually serves.
+    expect(r).toContain("创建");
+    expect(r).toContain("删除");
+    // Pure function of the alias — stable across calls (no clock/randomness).
+    expect(daemonProgramReply("TM基建牛")).toBe(r);
+    // Different alias → different, correctly-addressed reply.
+    expect(daemonProgramReply("daemon-2")).toContain("daemon-2");
+  });
+});

--- a/agent-node/src/runtime/daemon-program-node.ts
+++ b/agent-node/src/runtime/daemon-program-node.ts
@@ -5,12 +5,18 @@
 // probe — driven by structured SSE doorbells (RFC-026 create_node, RFC-027
 // stop_node, RFC-028 probe_provider) that never touch a model.
 //
-// The one path that could still drag a model into the daemon is its inbox:
-// if a *free-text* task lands there (someone sent the daemon a message as if
-// it were an agent), the normal node would run an LLM turn (processTask →
-// processWithClaude → `await import("@anthropic-ai/claude-agent-sdk")`). That
-// import is lazy, so short-circuiting free-text tasks here means a daemon
-// process never loads or runs an LLM at all.
+// Two paths could still drag a model into the daemon; both are gated on this
+// same predicate in cli.ts:
+//   1. The inbox: a *free-text* task (someone messaged the daemon as if it were
+//      an agent) would otherwise run an LLM turn (processTask → processWithClaude
+//      → `await import("@anthropic-ai/claude-agent-sdk")`). The inbox guard
+//      short-circuits it before processTask.
+//   2. The goal scheduler: a goal wake also calls processTask. runGoalSchedulerTick
+//      early-returns for a daemon, and the tick is not armed at boot for one —
+//      so even a node hot-promoted agent→host_supervisor (RFC-024) with
+//      pre-existing active goals stops running LLM turns from promotion onward.
+// The claude-agent-sdk import is lazy, so with both paths gated a node born and
+// kept as host_supervisor never loads or runs an LLM.
 //
 // Kept as a small, unit-tested module rather than an inline check inside the
 // big CLI script so the "a daemon never invokes the runtime" guarantee has a

--- a/agent-node/src/runtime/daemon-program-node.ts
+++ b/agent-node/src/runtime/daemon-program-node.ts
@@ -1,0 +1,44 @@
+// agent-node/src/runtime/daemon-program-node.ts
+//
+// #1417 — A daemon (role=host_supervisor) is a pure-program node. Its whole
+// job is deterministic node lifecycle — create / stop / restart / delete /
+// probe — driven by structured SSE doorbells (RFC-026 create_node, RFC-027
+// stop_node, RFC-028 probe_provider) that never touch a model.
+//
+// The one path that could still drag a model into the daemon is its inbox:
+// if a *free-text* task lands there (someone sent the daemon a message as if
+// it were an agent), the normal node would run an LLM turn (processTask →
+// processWithClaude → `await import("@anthropic-ai/claude-agent-sdk")`). That
+// import is lazy, so short-circuiting free-text tasks here means a daemon
+// process never loads or runs an LLM at all.
+//
+// Kept as a small, unit-tested module rather than an inline check inside the
+// big CLI script so the "a daemon never invokes the runtime" guarantee has a
+// name and a test, and so the role check is an exact-value match (not a shape
+// or case-insensitive match that a stray role string could slip through).
+
+export const HOST_SUPERVISOR_ROLE = "host_supervisor";
+
+/**
+ * True when a node must NOT run an LLM turn for free-text inbox tasks.
+ * Only an exact `host_supervisor` role qualifies; every other role (agent,
+ * leader, empty, undefined, differently-cased) falls through to the normal
+ * runtime path unchanged.
+ */
+export function isDaemonPureProgramNode(role: string | undefined | null): boolean {
+  return role === HOST_SUPERVISOR_ROLE;
+}
+
+/**
+ * Deterministic, model-free reply for a free-text task sent to a daemon.
+ * Explains what the daemon actually does and where AI help lives, so the
+ * sender is not left waiting on a turn that will never run. Pure function of
+ * the alias — no clock, no randomness — so it is stable and testable.
+ */
+export function daemonProgramReply(alias: string): string {
+  return [
+    `[${alias}] 我是 daemon（host_supervisor 守护进程节点），不运行大模型。`,
+    `我只执行结构化的节点生命周期命令：创建 / 停止 / 重启 / 删除 / 探测节点（由 Hub 下发的门铃事件驱动，全程无 AI）。`,
+    `自由文本任务我不会调用 AI 去理解。需要 AI 协助，请把任务发给一个 agent 节点，或使用 anet CLI / 客户端里的 AI 助手。`,
+  ].join("\n");
+}

--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -106,6 +106,16 @@ anet daemon up
 `dangerouslySkipPermissions` + `teammateMode`，并且能通过 hub 派生子节点。
 **只在你信得过的机器上跑它。** 要收紧就改 `.anet/nodes/daemon/config.json`。
 
+::: info daemon 是**纯程序**守护节点，不是会聊天的 agent
+`host_supervisor` daemon 的职责是**确定性的节点生命周期**——创建 / 停止 / 重启 / 删除 / 探测
+其它节点，全部由 Hub 下发的结构化门铃驱动（RFC-026/027/028）。它是一个纯程序执行器，
+**不会用大模型去理解你发给它的自由文本任务**。启动横幅里的 `[claude-agent-sdk]` 只是它的
+默认 runtime 标签，daemon 处理生命周期命令时并不加载大模型。
+
+所以：**要 AI 干活，请把任务发给一个真正的 agent 节点**，而不是 daemon。把自然语言任务
+（`commhub_send_task` 一段话）发给 daemon 只会让它回你「我是程序节点，请用结构化命令」。
+:::
+
 ### 3.5 让 daemon 在后台活下去 {#keep-daemon-alive}
 
 `anet daemon start` 是前台常驻进程。**如果你是 SSH 上去起的，会话一断它就没了** ——

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -110,6 +110,18 @@ To background it, see [Keeping a daemon alive](#keep-daemon-alive) below.
 **Only run one on a machine you trust to act on your behalf.** To tighten it, edit
 `.anet/nodes/daemon/config.json`.
 
+::: info A daemon is a **pure-program** supervisor, not a chat agent
+A `host_supervisor` daemon's job is **deterministic node lifecycle** — create / stop /
+restart / delete / probe other nodes — all driven by structured doorbells the hub sends
+(RFC-026/027/028). It is a plain program executor and **does not use a model to interpret
+free-text tasks** you send it. The `[claude-agent-sdk]` in the startup banner is only its
+default runtime label; the daemon does not load a model to handle lifecycle commands.
+
+So: **to get AI work done, send the task to a real agent node**, not the daemon. Sending a
+natural-language task (`commhub_send_task`) to a daemon just gets you a short reply saying
+it is a program node — use structured commands instead.
+:::
+
 ### 3.5 Keeping a daemon alive {#keep-daemon-alive}
 
 `anet daemon start` runs in the foreground. **If you started it over SSH, it dies with the


### PR DESCRIPTION
## 目标（Vincent 2026-08-29 定的优先级）

先把守护进程核心做**可靠、确定性、纯程序**；AI 操作**保留不删**、放后面、放客户端侧。
本 PR 是第一步：**让 daemon 退回纯程序节点，不再为自由文本任务跑 LLM。**

## 背景

daemon（`role=host_supervisor`）的职责是确定性节点生命周期——创建/停止/重启/删除/探测，
全部由结构化 SSE 门铃驱动（RFC-026 `create_node` / RFC-027 `stop_node` / RFC-028 `probe_provider`），
**从不碰模型**。唯一还能把模型拖进 daemon 的路径是它的 **inbox**：一条自由文本任务落进来时，
普通节点会跑一次 LLM turn（`processTask → processWithClaude → await import("@anthropic-ai/claude-agent-sdk")`）。
那个 import 是**懒加载**的（cli.ts:2165），所以在它之前短路 = daemon 进程永不加载、永不运行大模型。

## 改动

- **新增 `agent-node/src/runtime/daemon-program-node.ts`**（44 行，零外部依赖）
  - `isDaemonPureProgramNode(role)`：**精确值**匹配 `host_supervisor`（不是 shape/大小写宽松匹配——
    避免某个近似 role 字符串把一个正常 agent 误静音成永不跑模型）
  - `daemonProgramReply(alias)`：纯函数、无时钟无随机，返回一句确定性回复（说明 daemon 只执行
    结构化命令、需要 AI 请找 agent 节点或客户端助手）
- **新增 `daemon-program-node.test.ts`**：3 组断言，含 **witnessed-red**（把精确匹配换成 `includes()`
  会让「其他 role 放行」用例变红——已实测）
- **`cli.ts`**：顶层 import + 在 goal 分支与 `processTask` 之前插入 guard，命中即
  `deliverReplyReliably` + `ack` 后 `return`

结构化门铃路径**完全不变**，仍是纯程序。**本 PR 不删任何 AI 能力**——AI 翻译层按优先级放到
客户端侧、后续做。

## 验证

- `daemon-program-node.test` 3 pass；**witnessed-red 已见**（shape-match 变异→「其他 role」用例红）
- 含兄弟 daemon 套件（create-node/stop/probe）共 **93 pass**
- `cli.ts` 整图 `bun build` 仅剩 `undici` 未装报错（存量缺依赖，来自 probe-daemon.ts，与本改动无关；
  0 处提到本模块）→ 证明 wiring 编译通过
- guard 顺序已核：5108 guard → 5124 goal 分支 → 5154 processTask，命中即 return，不进 LLM

## 待补（合入前）

真机 e2e：给一个真实 daemon 发一条自由文本任务，断言 ① 收到确定性回复 ② 进程**未加载**
claude-agent-sdk（无 model 调用日志）。

## 后续（不在本 PR）

1. 补 `list/status` 结构化命令（列本机节点 + 状态，Dashboard 直接用）
2. delete/restart 幂等 + 错误机器可读（#1358 `noop_not_my_child` 卡死行）
3. AI 翻译层落客户端侧（自然语言 → 结构化命令）

Closes #1417（第一步）
