### PR TITLE
fix(#1402): grok attach 找不到节点时给可行动提示，不再误导去 create

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5812,7 +5812,22 @@ async function grokCommand() {
   }
   const resolved = resolveNodeRef(ref);
   if (!resolved) {
-    console.error(`Node "${ref}" not found. Create it first: anet node create ${ref} --runtime grok-build-cli`);
+    // #1402 — attach resolves nodes by the CURRENT directory's .anet/nodes.
+    // The old message ("Create it first") was actively harmful: the node the
+    // user wants to attach is usually already created in its project directory
+    // and online, so following "create" builds a duplicate or collides on the
+    // tmux / attach session. Explain the cwd-scoped resolution instead, show
+    // what IS visible here, and only mention create as a guarded last resort.
+    const visibleHere = listProfileIds();
+    console.error(`[anet] 在当前目录找不到节点 "${ref}"。`);
+    console.error(`[anet] anet grok attach 按**当前目录**的 .anet/nodes 解析节点（cwd=${process.cwd()}）。`);
+    if (visibleHere.length) {
+      console.error(`[anet] 这里可见的节点：${visibleHere.join(", ")}`);
+    } else {
+      console.error(`[anet] 当前目录的 .anet/nodes 下没有任何节点。`);
+    }
+    console.error(`[anet] 若它是在别的项目目录创建的（attach 的常见情况），先 cd 到那个目录再 attach。`);
+    console.error(`[anet] 用 anet node ls 看当前目录能见的节点；只有确认它确实还不存在，才用：anet node create ${shellQuote(ref)} --runtime grok-build-cli`);
     process.exit(1);
   }
   const { id: nodeId, profile } = resolved;


### PR DESCRIPTION
Fixes #1402（缺陷②：报错误导）

## 问题

Vincent 实操：在 `~` 下 `anet grok attach TM苹果狗`（节点存在且在线，只是在别的项目目录）得到：
```
Node "TM苹果狗" not found. Create it first: anet node create TM苹果狗 --runtime grok-build-cli
```
照做会**建出重复节点**或**撞 tmux/attach session 冲突**——一个措辞不准的报错教用户做危险的事。

## 改动（message-only，零共享解析器改动、零网络）

`grok attach` 解析失败（`resolveNodeRef` 返回 null）时，把报错换成可行动、不危险的版本：
- 说清「按**当前目录**的 `.anet/nodes` 解析」+ 打印 cwd
- 列出当前目录**可见**的节点（`listProfileIds`），让用户看到解析范围
- 指引：若在别的项目目录创建的（attach 常见情况），先 `cd` 过去再 attach
- `create` 仅作「确认确实不存在才用」的最后手段保留

## 见证（临时空目录，`resolveNodeRef` 在任何 hub/TTY 接触前失败 → 零生产风险）

```
[anet] 在当前目录找不到节点 "TM苹果狗"。
[anet] anet grok attach 按**当前目录**的 .anet/nodes 解析节点（cwd=/tmp/...）。
[anet] 当前目录的 .anet/nodes 下没有任何节点。
[anet] 若它是在别的项目目录创建的（attach 的常见情况），先 cd 到那个目录再 attach。
[anet] 用 anet node ls 看当前目录能见的节点；只有确认它确实还不存在，才用：anet node create 'TM苹果狗' --runtime grok-build-cli
```
`rc=1`；`bun build bin/cli.ts` rc=0。

## 范围

本 PR 只修缺陷②（Vincent 撞到的危险报错）。**缺陷①**（attach 只按 cwd 解析，理想应兜底查
全局/hub 在线列表 alias 唯一命中即用）留作后续——它要 hub 协助 + 触碰 attach 流程，风险更大，
`nodesDir()` 目前无全局注册表，单独评估更稳妥。#1402 保持 open 跟踪缺陷①。
