### PR TITLE
fix(#1390): node create --resume 推断 claude-code-cli，不再静默丢弃 flag

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -35,6 +35,7 @@ import {
   type SessionInfo,
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
+import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -5331,6 +5332,31 @@ async function createCommand(idOverride?: string) {
         saveGlobal(gc);
       }
     } catch {}
+  }
+
+  // #1390 — --resume / --resume-latest imply claude-code-cli. The create
+  // command used to gate its whole session-binding block on
+  // runtime===claude-code-cli, so `anet node create X --resume <id>` WITHOUT
+  // an explicit --runtime silently dropped --resume AND left the node on the
+  // default claude-agent-sdk (user asked for A, got B). Decision extracted to
+  // resolveRuntimeForResume (unit-tested, hub-free): infer claude-code-cli when
+  // runtime is unset, fail loud on an explicit conflicting runtime.
+  {
+    const decision = resolveRuntimeForResume({
+      resume: opts.resume,
+      resumeLatest: opts["resume-latest"] === "true",
+      session: opts.session,
+      explicitRuntime: opts.runtime ? normalizeRuntime(opts.runtime) : "",
+    });
+    if (decision.conflictError) {
+      console.error(`[anet] ❌ ${decision.conflictError}`);
+      console.error(`[anet]    去掉 --runtime（会自动推断为 claude-code-cli），或去掉 --resume`);
+      process.exit(1);
+    }
+    if (decision.inferredRuntime) {
+      opts.runtime = decision.inferredRuntime;
+      console.log(`[anet] --resume 推断 runtime=${decision.inferredRuntime}`);
+    }
   }
 
   // #115 — bind an existing Claude session at create time (claude-code-cli only).

--- a/agent-network/src/resume-runtime-infer.test.ts
+++ b/agent-network/src/resume-runtime-infer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRuntimeForResume, CLAUDE_CODE_CLI } from "./resume-runtime-infer";
+
+// #1390 — --resume implies claude-code-cli. These pin the create-time
+// inference: the flag must never be silently dropped, and must never leave
+// the node on the default claude-agent-sdk runtime.
+describe("resolveRuntimeForResume (#1390)", () => {
+  test("--resume with no explicit runtime → infers claude-code-cli", () => {
+    const r = resolveRuntimeForResume({ resume: "abc-123" });
+    expect(r.inferredRuntime).toBe(CLAUDE_CODE_CLI);
+    expect(r.conflictError).toBeUndefined();
+  });
+
+  test("--resume-latest with no explicit runtime → infers claude-code-cli", () => {
+    const r = resolveRuntimeForResume({ resumeLatest: true });
+    expect(r.inferredRuntime).toBe(CLAUDE_CODE_CLI);
+  });
+
+  test("--resume with explicit claude-code-cli → no change (already right)", () => {
+    const r = resolveRuntimeForResume({ resume: "abc", explicitRuntime: CLAUDE_CODE_CLI });
+    expect(r.inferredRuntime).toBeUndefined();
+    expect(r.conflictError).toBeUndefined();
+  });
+
+  test("--resume with a conflicting explicit runtime → loud conflict, not silent drop", () => {
+    const r = resolveRuntimeForResume({ resume: "abc", explicitRuntime: "claude-agent-sdk" });
+    expect(r.inferredRuntime).toBeUndefined();
+    expect(r.conflictError).toContain("claude-agent-sdk");
+    expect(r.conflictError).toContain(CLAUDE_CODE_CLI);
+  });
+
+  test("no resume flag → no inference (leaves default runtime alone)", () => {
+    expect(resolveRuntimeForResume({})).toEqual({});
+    expect(resolveRuntimeForResume({ explicitRuntime: "codex-sdk" })).toEqual({});
+    // bare --resume with no value (opts.resume === "true") is not a resume request
+    expect(resolveRuntimeForResume({ resume: "true" })).toEqual({});
+  });
+
+  test("an already-resolved session skips inference (interactive picker path)", () => {
+    // When opts.session is already set, the binding was resolved elsewhere and
+    // this decision must stay out of the way.
+    expect(resolveRuntimeForResume({ resume: "abc", session: "sess-1" })).toEqual({});
+  });
+});

--- a/agent-network/src/resume-runtime-infer.ts
+++ b/agent-network/src/resume-runtime-infer.ts
@@ -1,0 +1,56 @@
+// agent-network/src/resume-runtime-infer.ts
+//
+// #1390 — `--resume <id>` / `--resume-latest` imply a claude-code-cli node.
+//
+// The create command used to gate its whole session-binding block on
+// runtime===claude-code-cli, so `anet node create X --resume <id>` WITHOUT an
+// explicit `--runtime` silently dropped `--resume` AND left the node as the
+// default claude-agent-sdk — the user asked for A and got B with no warning
+// (defects ① and ②). This pure decision keeps that inference in one place so
+// it can be unit-tested without a hub.
+//
+// Contract:
+//   - resume not requested, or a session already resolved → {} (no change)
+//   - resume requested, no explicit runtime → infer claude-code-cli
+//   - resume requested, explicit runtime === claude-code-cli → {} (already right)
+//   - resume requested, explicit runtime is something else → conflictError
+//     (fail loud instead of silently ignoring the flag)
+//
+// `explicitRuntime` must already be normalized by the caller (via the CLI's
+// normalizeRuntime), or be empty/undefined when the user passed no --runtime.
+
+export interface ResumeRuntimeInput {
+  /** raw --resume value; "true" means the flag was present with no value */
+  resume?: string;
+  /** whether --resume-latest was passed */
+  resumeLatest?: boolean;
+  /** an already-resolved session id, if any (skips inference) */
+  session?: string;
+  /** normalized --runtime, or empty/undefined when the user passed none */
+  explicitRuntime?: string;
+}
+
+export interface ResumeRuntimeResult {
+  /** runtime to force onto opts when it was left to default */
+  inferredRuntime?: string;
+  /** set when an explicit non-cli runtime conflicts with --resume */
+  conflictError?: string;
+}
+
+export const CLAUDE_CODE_CLI = "claude-code-cli";
+
+export function resolveRuntimeForResume(input: ResumeRuntimeInput): ResumeRuntimeResult {
+  const resumeRequested =
+    (!!input.resume && input.resume !== "true") || input.resumeLatest === true;
+  if (!resumeRequested || input.session) return {};
+
+  const explicit = input.explicitRuntime || "";
+  if (explicit && explicit !== CLAUDE_CODE_CLI) {
+    return {
+      conflictError:
+        `--resume / --resume-latest 只适用于 ${CLAUDE_CODE_CLI}，但 --runtime=${explicit}`,
+    };
+  }
+  if (!explicit) return { inferredRuntime: CLAUDE_CODE_CLI };
+  return {};
+}


### PR DESCRIPTION
Fixes #1390 的缺陷 ①②（缺陷③另行修复，见下）

## 问题（Vincent 2026-08-28 建「通信需求马」当场踩实）

`anet node create X --resume <sid>`（不带 `--runtime`）：
- ① runtime 静默落成默认 `claude-agent-sdk`——`--resume` 明明是 claude-code-cli 的意图，用户以为建 A 拿到 B
- ② `--resume` 的值被接受却没写进 `config.session`（create 完 session 为空）

## 根因

整个「按 `--resume` 绑定 Claude session」的块被 `normalizeRuntime(opts.runtime||"claude-agent-sdk")==="claude-code-cli"` 门控。
用户不显式带 `--runtime claude-code-cli` 时，这块整段跳过 → flag 被丢、runtime 保持默认。

## 修复

决策抽成纯函数 `resolveRuntimeForResume`（`agent-network/src/resume-runtime-infer.ts`，可单测、不碰 hub）：
- `--resume`/`--resume-latest` 且未显式指定 runtime ⇒ **推断 `claude-code-cli`**
- 显式 `--runtime` 与 claude-code-cli **冲突 ⇒ 报错退出**（不再静默忽略 flag）
- 已有 session / 无 resume ⇒ 不干预（保留交互 picker 路径）

`cli.ts` 在原绑定块之前调用它、据结果设 `opts.runtime`，绑定块随之生效、session 落盘。

## 验证

- `resume-runtime-infer.test.ts` **6 pass**，**witnessed-red 已见**（把推断退回旧行为 → 2 个推断用例变红）
- `cli.ts` 已**接线**调用该函数（不是重复内联）；`bun build` rc=0
- 本地实跑（隔离 HOME + 假 session）见证打印 `[anet] --resume 推断 runtime=claude-code-cli` + `[anet] 绑定已有 Claude session: …`

## 范围

本 PR 修 ①②（create 侧根因，用户第一步就踩）。**缺陷③**（`start` 对 `--print` 失败仍写 pin、
留下必死空号 session）在 start/pin 路径，属「打印 pinned ≠ 真 pinned」家族（与 #1353「在线≠能干活」同形），
另行修复。#1390 保持 open 跟踪③。
