### PR TITLE
chore(release): agent-node .47 + agent-network .60 配对 —— daemon 纯程序 + grok attach + create --resume

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.59",
+  "version": "2.3.0-preview.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.59",
+      "version": "2.3.0-preview.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.59",
+  "version": "2.3.0-preview.60",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.59";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.46";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.60";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.47";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.46",
+  "version": "2.5.0-preview.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.46",
+      "version": "2.5.0-preview.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.46",
+  "version": "2.5.0-preview.47",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.3.0-preview.60.md
+++ b/docs/tests/release-v2.3.0-preview.60.md
@@ -1,0 +1,34 @@
+# @sleep2agi/agent-network 2.3.0-preview.60 — release notes
+
+两个用户面 CLI 傻瓜化修复（都是 Vincent 实操当场踩到的）：
+
+- **grok attach 找不到节点不再误导用户去 create**（PR #1419，修 #1402 缺陷②）：
+  `anet grok attach <node>` 解析失败时，旧文案 `Create it first` 会让用户建出重复节点 /
+  撞 tmux/attach session 冲突。现改为可行动提示：说清按 cwd 解析 + 打印 cwd + 列出当前目录
+  可见节点 + 指引 cd 过去；create 降为「确认不存在才用」的最后手段。
+- **node create --resume 推断 claude-code-cli，不再静默丢 flag**（PR #1420，修 #1390 ①②）：
+  `anet node create X --resume <id>`（不带 --runtime）此前 runtime 静默落成 claude-agent-sdk
+  且 --resume 值被丢弃。现在 --resume 推断 claude-code-cli（显式冲突则报错退出）。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.60 @sleep2agi/agent-node@2.5.0-preview.47
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.60
+```
+
+## 本版包含
+
+- `9e5010d0` grok attach 找不到节点给可行动提示（#1419，#1402 缺陷②）
+- `925ef793` node create --resume 推断 claude-code-cli（#1420，#1390 缺陷①②）
+
+## Verification
+
+- #1419：临时空目录见证新报错文案；`bun build` rc=0
+- #1420：纯函数 `resolveRuntimeForResume` 单测 6 pass + witnessed-red；已接线进 cli.ts；本地隔离环境见证推断消息

--- a/docs/tests/release-v2.5.0-preview.47.md
+++ b/docs/tests/release-v2.5.0-preview.47.md
@@ -1,0 +1,39 @@
+# @sleep2agi/agent-node 2.5.0-preview.47 — release notes
+
+这一版把 **daemon（host_supervisor）退回纯程序节点**：它不再为自由文本任务跑大模型
+（PR #1418，关闭 #1417）。Vincent 定的优先级——先把守护进程核心做可靠、确定性、纯程序，
+AI 操作保留不删、放后面、放客户端侧。
+
+- daemon 收到自由文本 inbox 任务时，在 `processTask`（LLM turn）**之前**拦截，返回确定性
+  回复（说明它只执行结构化生命周期命令，AI 请找 agent 节点）。`claude-agent-sdk` 是懒加载，
+  短路即意味着 daemon 进程**不加载、不运行大模型**。
+- goal 调度器同样按 role 门控（tick 实时 + boot 不武装），连热升级为 host_supervisor 的
+  节点的存量 goal 也不再跑 LLM（独审 Finding 1）。
+- 结构化门铃路径（create/stop/restart/delete/probe）**不变**，仍是纯程序。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.60 @sleep2agi/agent-node@2.5.0-preview.47
+anet node create
+```
+
+🔴 **两个包都要装**（agent-node 单装时飞书桥静默降级）。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.47
+# daemon 重启即生效
+anet daemon up
+```
+
+## 本版包含
+
+- `1e442355` daemon 退回纯程序 + goal 调度器 role 门控（#1418，关 #1417）
+
+## Verification
+
+- 独立复核 A–F 全 PASS + Finding 1（goal 调度器未门控）已修
+- `daemon-program-node.test` 含 witnessed-red（shape-match 变异→精确匹配用例变红）
+- 含兄弟 daemon 套件本地 93 pass；CI 102/102 全绿


### PR DESCRIPTION
## 配对发版：agent-node 2.5.0-preview.47 + agent-network 2.3.0-preview.60

带出 preview.46/.59 之后合入 main 的三个修复：

| 修复 | 包 | PR |
|---|---|---|
| daemon 退回纯程序节点，不再为自由文本任务跑 LLM | agent-node | #1418（关 #1417） |
| grok attach 找不到节点给可行动提示，不再误导去 create | agent-network | #1419（#1402②） |
| node create --resume 推断 claude-code-cli，不再静默丢 flag | agent-network | #1420（#1390①②） |

## 版本同步

`sync-pinned-versions.sh --apply` 同步：
- `agent-node/package.json` + lock → 2.5.0-preview.47
- `agent-network/package.json` + lock → 2.3.0-preview.60
- `opencode-agent-node-pair.ts`：PAIRED_AGENT_NODE_VERSION=.47、PAIRED_AGENT_NETWORK_VERSION=.60

## 发布路径

合入 main 后走 **GitHub Actions `release.yml`（workflow_dispatch，publish=true）**，
**preview 通道，永不 latest**；对外从 main 出（符合 CLAUDE.md 发版纪律）。

## Verification

- 三个 PR 均已独立合入 main（102/102、独审通过），本 PR 只做版本号 + release notes
- 版本 bump 由脚本（非手改）完成，pair 文件两个常量都已核对
