### PR TITLE
chore(release): agent-node 2.5.0-preview.48 —— grok 换模型崩溃修复 (#1416)

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.60";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.47";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.48";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.47",
+  "version": "2.5.0-preview.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.47",
+      "version": "2.5.0-preview.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.47",
+  "version": "2.5.0-preview.48",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.48.md
+++ b/docs/tests/release-v2.5.0-preview.48.md
@@ -1,0 +1,40 @@
+# @sleep2agi/agent-node 2.5.0-preview.48 — release notes
+
+这一版修掉 **grok 共存节点换模型时崩溃**（PR #1416，修 #1413）——Vincent 亲历、且此前
+「grok-tui 做得差」抱怨的那件事之一。
+
+- grok 换模型时会 rotate/truncate 它的 `chat_history.jsonl`；tail 跟随器看到文件缩小到
+  offset 之下会判为篡改、节点 fatal 自毁。本版在换模型窗口内 **re-arm（重锚）JSONL tail**，
+  把这一次轮转当作预期、recover 而非自毁。
+- 独立复核发现的**热路径窗口关太早**风险（grok 若先 ack、几毫秒后才轮转，仍会崩）也已修：
+  换模型窗口加 3s 宽限，迟到的轮转仍 recover-by-rearm；防篡改不变式（窗口外截断仍 fatal）保留。
+- 新增两个见证测试：#1413 同步截断 recover、#1416 review「ack 后轮转」走 poll-fallback recover。
+
+🔴 **真机说明**：单测用真实 SafeJsonlTail 读真截断文件（非 mock），且 #1413 崩溃证据表明 grok
+是 truncate（不是 rename）——修复正好覆盖。真机 grok 1.0.5 端到端复验仍建议补，但本版对
+当前会崩的状态是净改善、且不削弱防篡改。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.60 @sleep2agi/agent-node@2.5.0-preview.48
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.48
+anet node stop <grok节点>
+anet node start <grok节点>
+# 之后 attach 里换模型不再崩
+```
+
+## 本版包含
+
+- `5a2578df` grok 共存换模型 re-arm JSONL tail + 热路径宽限（#1416，修 #1413）
+
+## Verification
+
+- 独立复核 A–D PASS + HIGH 项（热路径窗口）已修+测；全量 grok-copresence runtime.test.ts 68 pass
+- witnessed-red 已见（还原同步清窗口 → 「ack 后轮转」测试节点自毁）


### PR DESCRIPTION
带出 #1416（grok 共存换模型 re-arm JSONL tail + 热路径宽限，修 #1413 节点自毁）。sync-pinned-versions.sh 同步 agent-node→.48 + PAIRED。agent-node 无 version-claim 戳（gate4 不涉及）。合入后触发 release.yml 发 agent-node@2.5.0-preview.48 preview。