### PR TITLE
feat(#1188): anet doctor 暴露 SkillHub 目录（rollout surfacing）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -15416,6 +15416,21 @@ async function doctorCommand() {
     info(".mcp.json", "not found in current directory");
   }
 
+  // #1188 — surface SkillHub in `anet doctor` so it is discoverable, not just a
+  // page that exists. Reuses loadSkillCatalog (network → cache fallback). Non-
+  // fatal: an unreachable catalog is a warning, never a doctor failure.
+  try {
+    const { catalog, sourceUrl, fromCache, cachedAt } = await loadSkillCatalog(false);
+    const nSkills = catalog.skills?.length ?? 0;
+    if (fromCache) {
+      info("SkillHub catalog", `${nSkills} skill(s) (cached${cachedAt ? ` ${cachedAt}` : ""}; ${sourceUrl}) — browse: anet skill ls`);
+    } else {
+      check("SkillHub catalog", true, `${nSkills} skill(s) available (${sourceUrl}) — browse: anet skill ls`);
+    }
+  } catch (e: any) {
+    warning("SkillHub catalog", `unreachable (${e?.message || e}); set ANET_SKILL_CATALOG_URL or check network — browse: anet skill ls`);
+  }
+
   // 6. Telegram channel env (silent token loss is a known foot-gun)
   const tgEnv = join(home, ".claude", "channels", "telegram", ".env");
   if (existsSync(tgEnv)) {


### PR DESCRIPTION
SkillHub 已建好（注册/审阅/目录/`anet skill`），但 `anet doctor` 不提它。本 PR 加一行 SkillHub 目录检查（复用 loadSkillCatalog，网络→缓存兜底，非致命）。验证：bun build rc=0；`anet skill ls` 实跑可达 6 个技能，doctor 行用同一函数。#1188 的 doctor/status surfacing 一环。