### PR TITLE
docs(#1188): SkillHub 页加「从命令行浏览」（anet skill CLI）

### DIFF
--- a/docs-site/docs/en/skillhub/index.md
+++ b/docs-site/docs/en/skillhub/index.md
@@ -18,6 +18,19 @@ Published versions are immutable. Content corrections should use a new version.
 The build regenerates the catalog, and `skillhub:check` rejects stale or
 manually edited catalog output.
 
+## Browse from the command line
+
+With `@sleep2agi/agent-network` installed you can browse the public SkillHub straight
+from a terminal (it reads the same `/skillhub/catalog.json`, no login needed):
+
+```bash
+anet skill ls              # list every public skill: slug / name / description / version
+anet skill show <slug>     # print a skill's SKILL.md (verified against content_sha256 on download)
+```
+
+`anet doctor` also reports one line on whether the SkillHub catalog is reachable and how many skills it has.
+Point at a different catalog (e.g. a private mirror) with the `ANET_SKILL_CATALOG_URL` env var.
+
 [How to contribute a public skill →](/en/skillhub/contribute)
 
 <PublicSkillHub lang="en" />

--- a/docs-site/docs/skillhub/index.md
+++ b/docs-site/docs/skillhub/index.md
@@ -16,6 +16,19 @@ Skill 的 `slug`、`version`、许可证、发布者、标签、`content_sha256`
 公开版本不可原地覆盖；内容修订应发布新版本。构建时会重新生成 catalog，
 `skillhub:check` 会拒绝过期或手工改写的 catalog。
 
+## 从命令行浏览
+
+装了 `@sleep2agi/agent-network` 就能直接从终端浏览公共 SkillHub（读的是同一个
+`/skillhub/catalog.json`，无需登录）：
+
+```bash
+anet skill ls              # 列出所有公开 Skill：slug / 名称 / 描述 / 版本
+anet skill show <slug>     # 打印某个 Skill 的 SKILL.md（下载按 content_sha256 校验）
+```
+
+`anet doctor` 也会顺带报一行 SkillHub 目录是否可达、有多少个 Skill。
+指向别的 catalog（如私有镜像）：设环境变量 `ANET_SKILL_CATALOG_URL`。
+
 [如何投稿公共 Skill →](/skillhub/contribute)
 
 <PublicSkillHub lang="zh" />


### PR DESCRIPTION
公共 SkillHub 页没提 `anet skill` CLI；#1426 让 doctor 指向 `anet skill ls` 后，文档需接住。zh+en 各加一节 anet skill ls/show 用法（含 sha256 校验 + ANET_SKILL_CATALOG_URL）。只加散文+代码块无新链接。与 #1426 配套的 #1188 docs 一环。