### PR TITLE
chore(release): agent-network 2.3.0-preview.61 —— 配对补 PAIRED=agent-node.48，消除 pin 漂移

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.60",
+  "version": "2.3.0-preview.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.60",
+      "version": "2.3.0-preview.61",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.60",
+  "version": "2.3.0-preview.61",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.60";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.61";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.48";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.60 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.61 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.60` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.61` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.60 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.61 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.60`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.61`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.61.md
+++ b/docs/tests/release-v2.3.0-preview.61.md
@@ -1,0 +1,36 @@
+# @sleep2agi/agent-network 2.3.0-preview.61 — release notes
+
+配对补发：把 npx 通道钉的 agent-node 版本从 `.47` 更新到 **`.48`**，与 main 源码的
+`PAIRED_AGENT_NODE_VERSION` 一致。
+
+## 为什么
+
+上一版 agent-node@2.5.0-preview.48（grok 换模型崩修复）发版时 bump 了源码里的
+`PAIRED_AGENT_NODE_VERSION` → .48，但**没有配对补发 agent-network** —— 于是已发布的
+`agent-network@2.3.0-preview.60` 的 `PAIRED_AGENT_NODE_VERSION` 仍是 `.47`，与源码漂移
+（published-pins 门本应报，但那门另有零覆盖 bug，见 #1430）。本版补齐配对。
+
+功能影响：codex / opencode 的 npx 通道现在钉 agent-node@.48（含最新修复）；grok/claude
+通道用全局安装的 agent-node，不受此钉影响。**无新增 agent-network 代码，仅版本 + 配对钉。**
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.61 @sleep2agi/agent-node@2.5.0-preview.48
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.61
+```
+
+## 本版包含
+
+- 配对钉更新：PAIRED_AGENT_NODE_VERSION .47 → .48（消除 published-pins 漂移）
+
+## Verification
+
+- sync-pinned-versions.sh --apply 同步 package.json + lock + pair 文件（PAIRED_AGENT_NETWORK_VERSION=.61、PAIRED_AGENT_NODE_VERSION=.48）
+- getting-started version-claim 戳 zh+en 同步 .61；check-doc-version-claims --package agent-network --version 2.3.0-preview.61 通过


### PR DESCRIPTION
agent-node@.48 发版时 bump 了源码 PAIRED→.48 但没配对补 agent-network ⇒ published agent-network@.60 仍钉 .47（.d.ts 实测），与源码漂移。本 PR 补发 .61（PAIRED_AGENT_NODE_VERSION=.48）消漂移。sync 脚本 + getting-started 戳 zh+en→.61（gate4 过）。无新增代码。关联 #1430。