### PR TITLE
fix(#1430): published-pins 验证器抽取扩到 PAIRED_*，消除零覆盖假红

### DIFF
--- a/scripts/verify-published-pins.sh
+++ b/scripts/verify-published-pins.sh
@@ -31,6 +31,11 @@ declare -A SRC=()
 while IFS='=' read -r k v; do [ -n "${k:-}" ] && SRC["$k"]="$v"; done < <(
   { grep -hoE 'const PINNED_[A-Z_]+ *= *"[^"]+"' "$ROOT/agent-network/bin/cli.ts" 2>/dev/null
     grep -hoE 'const OPENCODE_[A-Z_]*VERSION *= *"[^"]+"' "$ROOT/agent-network/src/opencode-agent-node-pair.ts" 2>/dev/null
+    # 🔴 #1430: 也抽 PAIRED_* —— 它们是 `export const PAIRED_AGENT_NODE_VERSION = "..."`
+    #    的字符串字面量,tsc 会把值原样写进 .d.ts(literal type),已发布产物里可读。
+    #    此前只抽 PINNED_SERVER_VERSION(非导出、只在混淆 cli.js、读不到)⇒ 覆盖恒 0 ⇒
+    #    rc=3 零覆盖把真漂移(如 published 钉 .47、源码 .48)也一起掩盖了。
+    grep -hoE 'const PAIRED_AGENT_(NODE|NETWORK)_VERSION *= *"[^"]+"' "$ROOT/agent-network/src/opencode-agent-node-pair.ts" 2>/dev/null
   } | sed -E 's/const ([A-Z_]+) *= *"([^"]+)"/\1=\2/'
 )
 


### PR DESCRIPTION
verify-published-pins.sh 只抽 PINNED_SERVER_VERSION（读不到混淆产物）⇒ 覆盖恒 0 ⇒ rc=3 零覆盖连红多天+掩盖真漂移。修：也抽 PAIRED_*（在 .d.ts 可读）。见证：修复版现跑抓到真漂移 rc=1（published .60 钉 .47/.60，源码 .48/.61），非零覆盖。**待 agent-network@.61（#1431）发布后再合**（否则 main published-pins 会为这个真漂移短暂报 rc=1）；.61 发布后即 rc=0。关联 #1430。