### PR TITLE
fix(anet): node stop 不再把「进程先退了」当失败 —— ps→birth 之间的 TOCTOU(#1422)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -36,6 +36,7 @@ import {
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
+import { processVanished, resolveOwnedRoots } from "../src/owned-roots";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -9450,11 +9451,13 @@ Stop a running agent node.
       if (roots.length === 0) {
         const legacy = findNodeProcessesByAlias(displayName);
         if (legacy === null) throw new Error("NODE_PROCESS_TABLE_UNAVAILABLE");
-        roots = legacy.map(pid => {
-          const birth = processBirth(pid);
-          if (!birth) throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
-          return { pid, birth, role: "agent" as const };
-        });
+        // #1422 — `ps` 拿到 pid 与读 `/proc/<pid>/stat` 之间有一个窗口:进程可能
+        // 已经退出。旧代码把「读不到 birth」一律当致命错误,于是 `anet node stop`
+        // 以 exit(1) 结束(test225 报 `node stop failed for <X>`)。
+        // 🔴 那不是失败 —— **stop 的目的就是让进程没了**,「它在我读它之前先退了」
+        // 正是想要的结果。resolveOwnedRoots 只放过**确证已消失**的(processVanished
+        // 仅在 ESRCH 时为真),进程仍在却读不到 birth 依旧抛。
+        roots = resolveOwnedRoots(legacy, { birth: processBirth, vanished: (pid) => processVanished(pid) });
       }
       stopProcesses = snapshotOwnedProcessTree(roots);
       writeLifecycleOwner(resolved.id, {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9444,7 +9444,18 @@ Stop a running agent node.
       const prior = readLifecycleOwner(resolved.id);
       stopGeneration = prior?.generation || randomUUID();
       let roots = prior?.processes || [];
-      if (roots.some(p => !p.birth)) throw new Error("NODE_OWNER_BIRTH_UNAVAILABLE");
+      // 🔴 这一条与下面 alias-fallback 支里的 NODE_OWNER_BIRTH_UNAVAILABLE 是**两件事**,
+      // 原先共用同一句错误 —— 于是 CI 上只看错误文本分不出是哪一种,#1422 的定位
+      // 因此走过弯路。两者的成因完全不同:
+      //   本条(RECEIPT):**收据里已记录**的某个 process 缺 birth 字段 —— 是持久化
+      //     记录不完整,与当前进程是否存活无关。
+      //   下面那条(带 `: pid=<n>`):ps 发现之后**现在读不到** /proc/<pid>/stat ——
+      //     多半是那个 pid 已经退出(#1422 的 TOCTOU)。
+      // 分开命名,让 CI 输出自身就能回答「是哪一种」。
+      const missingBirth = roots.filter(p => !p.birth).map(p => p.pid);
+      if (missingBirth.length > 0) {
+        throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE_RECEIPT: pids=${missingBirth.join(",")}`);
+      }
       // One-time migration for pre-receipt generations: discover by alias only
       // while holding stop-intent, then freeze exact identities. Reaping never
       // rescans by alias, so a later same-name generation cannot be adopted.

--- a/agent-network/src/owned-roots.test.ts
+++ b/agent-network/src/owned-roots.test.ts
@@ -1,0 +1,66 @@
+// #1422 — 见红先于见绿。这三组分别钉住:
+//   ① 进程在 ps 与读 birth 之间消失 ⇒ **不再是失败**(旧行为:throw → node stop failed)
+//   ② 进程仍在、birth 读不到       ⇒ **仍然 throw**(不能因为放宽而吞掉真问题)
+//   ③ vanished 只在**确证**时为 true(ESRCH),权限不足不算消失
+import { describe, expect, test } from "bun:test";
+import { processVanished, resolveOwnedRoots } from "./owned-roots";
+
+const errno = (code: string) => Object.assign(new Error(code), { code });
+
+describe("#1422 resolveOwnedRoots — ps→birth 之间的 TOCTOU", () => {
+  test("读得到 birth 的照收", () => {
+    const roots = resolveOwnedRoots([11, 12], {
+      birth: (pid) => `birth-${pid}`,
+      vanished: () => false,
+    });
+    expect(roots).toEqual([
+      { pid: 11, birth: "birth-11", role: "agent" },
+      { pid: 12, birth: "birth-12", role: "agent" },
+    ]);
+  });
+
+  test("① 进程在两步之间消失 ⇒ 跳过,不抛 —— 这正是 stop 想要的结果", () => {
+    const roots = resolveOwnedRoots([21, 22], {
+      birth: (pid) => (pid === 22 ? null : `birth-${pid}`),
+      vanished: (pid) => pid === 22,
+    });
+    expect(roots).toEqual([{ pid: 21, birth: "birth-21", role: "agent" }]);
+  });
+
+  test("全部消失 ⇒ 空列表,仍不抛", () => {
+    expect(resolveOwnedRoots([31, 32], { birth: () => null, vanished: () => true })).toEqual([]);
+  });
+
+  test("② 进程仍在、birth 读不到 ⇒ 仍然抛,且带上 pid", () => {
+    expect(() =>
+      resolveOwnedRoots([41], { birth: () => null, vanished: () => false }),
+    ).toThrow("NODE_OWNER_BIRTH_UNAVAILABLE: pid=41");
+  });
+
+  test("🔴 放宽只对『确证消失』生效:同一批里既有消失的也有仍在的 ⇒ 仍抛", () => {
+    expect(() =>
+      resolveOwnedRoots([51, 52], {
+        birth: () => null,
+        vanished: (pid) => pid === 51, // 51 确证消失,52 仍在
+      }),
+    ).toThrow("NODE_OWNER_BIRTH_UNAVAILABLE: pid=52");
+  });
+});
+
+describe("#1422 processVanished — 正向判定,不是『读失败就假设没了』", () => {
+  test("kill 成功 ⇒ 进程在", () => {
+    expect(processVanished(61, () => {})).toBe(false);
+  });
+
+  test("ESRCH ⇒ 确证不存在", () => {
+    expect(processVanished(62, () => { throw errno("ESRCH"); })).toBe(true);
+  });
+
+  test("🔴 EPERM ⇒ 存在但无权限,**不算消失**", () => {
+    expect(processVanished(63, () => { throw errno("EPERM"); })).toBe(false);
+  });
+
+  test("🔴 未知错误 ⇒ 保守当作存在", () => {
+    expect(processVanished(64, () => { throw errno("EIO"); })).toBe(false);
+  });
+});

--- a/agent-network/src/owned-roots.ts
+++ b/agent-network/src/owned-roots.ts
@@ -1,0 +1,67 @@
+// #1422 — `anet node stop` 的 TOCTOU:`ps` 拿到 pid 之后、读 `/proc/<pid>/stat`
+// 之前,进程可能已经退出。旧代码把「读不到 birth」一律当成致命错误:
+//
+//   const birth = processBirth(pid);
+//   if (!birth) throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
+//
+// 于是 `anet node stop` 以 exit(1) 结束,test225 报 `node stop failed for <X>`。
+// 🔴 但那根本不是失败:**stop 的目的就是让进程没了**,而「进程在我读它之前
+// 先退了」正是想要的结果。
+//
+// 与 #1339 同族不同处:那次是加锁与写 owner.json 之间的窗口被报成
+// NODE_LIFECYCLE_LOCK_CORRUPT。共同机制是「两步之间的窗口,第二步失败被报成
+// 一个更严重的错误」。
+//
+// 🔴 判据只放过**确证已消失**的,不放过「读不到就当没了」——后者会把真正的
+// stop 回归一起吞掉,而松判据的错误方向永远是「没问题」。
+
+export type OwnedRootRole = "agent";
+
+export interface OwnedRoot {
+  pid: number;
+  birth: string;
+  role: OwnedRootRole;
+}
+
+export interface OwnedRootProbes {
+  /** 进程这一代的出生时刻;读不到返回 null(可能已退出,也可能无权限)。 */
+  birth(pid: number): string | null;
+  /** 🔴 只有**确证**进程不存在时返回 false。无权限等一律视为存在。 */
+  vanished(pid: number): boolean;
+}
+
+/** 把 `ps` 发现的 pid 列表冻结成 owned roots。
+ *
+ * · 读得到 birth              ⇒ 收下
+ * · 读不到、且**确证已消失**  ⇒ 跳过(stop 想要的结果,不是错误)
+ * · 读不到、进程仍在          ⇒ throw(权限等真问题,不放过)
+ */
+export function resolveOwnedRoots(pids: number[], probes: OwnedRootProbes): OwnedRoot[] {
+  const roots: OwnedRoot[] = [];
+  for (const pid of pids) {
+    const birth = probes.birth(pid);
+    if (birth) {
+      roots.push({ pid, birth, role: "agent" });
+      continue;
+    }
+    if (probes.vanished(pid)) continue;
+    throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
+  }
+  return roots;
+}
+
+/** 🔴 正向判定「进程确实没了」,而不是「读失败就假设没了」。
+ *
+ * `kill(pid, 0)` 不送信号,只做存在性与权限探测:
+ *   · ESRCH  ⇒ 确证不存在
+ *   · EPERM  ⇒ 存在,只是不属于本用户
+ *   · 其他   ⇒ 保守当作存在(判据只在**确证**时放行)
+ */
+export function processVanished(pid: number, kill: (p: number, s: number) => void = process.kill.bind(process)): boolean {
+  try {
+    kill(pid, 0);
+    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code === "ESRCH";
+  }
+}

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -160,6 +160,20 @@ fail_with_private_log() {
     mode=$(stat -c %a "$path" 2>/dev/null || printf unknown)
   fi
   log "diagnostic: private raw log retained until cleanup (bytes=$bytes mode=$mode)"
+  # 🔴 原始日志保持 600 私有;这里只多暴露**一个错误码**,因为 CI 上看不到那份
+  # 日志时,红话里只有 "node stop failed for <X>",既定位不到成因、也分不清是
+  # 同一族的哪一种(NODE_OWNER_BIRTH_UNAVAILABLE 在 cli.ts 里有三个产生点)。
+  #
+  # 白名单而非黑名单:只吃 anet 自己的错误码形状(全大写+下划线),其余一个
+  # 字节不打。凭据不是这个形状 —— utok_/ntok_ 是小写前缀,base64/hex 带混合
+  # 大小写或 /+= —— 都不匹配。
+  #
+  # ⚠️ pattern 故意保持通用,不收窄到几个已知码:**这一格的价值正在于它能打出
+  # 「意料之外的码」**。如果真凶根本不在我们猜的那一族里,只有通用 pattern 会说出来。
+  if [ -e "$path" ]; then
+    code=$(grep -oE '^\[anet\] [A-Z][A-Z0-9_]+' "$path" 2>/dev/null | head -1)
+    log "diagnostic: private log first anet error code: ${code:-<none matched>}"
+  fi
   fail "$message"
 }
 


### PR DESCRIPTION
> 🔴 **本 PR 不关闭 #1422**(refs #1422)。它修的是 `#1422` 根因分析中确认的 TOCTOU 那一支,
> 但 **test225 的真凶尚未证实** —— 详见文末「定性更新」。#1422 保持 OPEN。

**根因在产品侧的 TOCTOU,不在 ratchet** —— 所以选 (a) 根治。

## 根因:`ps` 拿到 pid 与读 `/proc/<pid>/stat` 之间的窗口

`stopCommand` 在 lifecycle 收据还没写出来时(`roots.length === 0`)走 alias 发现:

```js
const legacy = findNodeProcessesByAlias(displayName);   // ① ps 拿到 pid
roots = legacy.map(pid => {
  const birth = processBirth(pid);                      // ② 再读 /proc/<pid>/stat
  if (!birth) throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
});
} catch (e) { console.error(…); process.exit(1); }
```

`processBirth` 把一切读取错误 `catch` 成 `null`。**①与②之间进程若退出 ⇒ throw ⇒ `exit(1)` ⇒ 套件报 `node stop failed for <X>`。**

这解释了 issue 里的两个现象:

- **竞态与场景无关** ⇒ 所以 `legacy-reload` / `fallback` 等多个子场景都中
- **窗口极窄** ⇒ 所以偶发

而 `known-failures` **baseline=0** 让一次偶发就判死 —— issue 说的"概率 flaky 变成确定红"。

🔴 **但它根本不是失败**:`stop` 的目的就是让进程没了,而"**进程在我读它之前先退了**"正是想要的结果。

### 与 #1339 同族,不同处

| | 窗口 | 被报成 |
|---|---|---|
| #1339(已修) | 加锁与写 `owner.json` 之间 | `NODE_LIFECYCLE_LOCK_CORRUPT` |
| **本 PR** | `ps` 拿到 pid 与 `processBirth` 之间 | `NODE_OWNER_BIRTH_UNAVAILABLE` |

**共同机制:两步之间的窗口,第二步失败被报成一个更严重的错误。**

## 为什么选 (a) 而不是改 ratchet

改判据等于**给产品缺陷登记豁免**;而且 issue 自己指出了代价 —— 一旦登记进 baseline,**将来真有 stop 回归落在同族签名上,会被当成"又是那个 flaky,重跑就好"而漏掉**。

## 修法

新增 `agent-network/src/owned-roots.ts`(依赖可注入的纯函数):

| 情形 | 处置 |
|---|---|
| 读得到 birth | 收下 |
| 读不到、**确证已消失** | **跳过,不算错** |
| 读不到、进程仍在 | **仍然 throw** |

🔴 **判据只放过"确证"消失的,不是"读失败就假设没了"** —— 后者会把真 stop 回归一起吞掉,而松判据的错误方向永远是"没问题"。

因此 `processVanished` **只在 `kill(pid,0)` 抛 `ESRCH` 时为真**;`EPERM`(存在但无权限)与未知错误**都当作存在**。

## witnessed-red(行为级,不是源码文本匹配)

同目录既有的 `stop-socket-window.test.ts` 用 `expect(src).toContain(…)` 钉源码文本。那验得了"文本在不在",**验不了"行为对不对"**,所以没有照抄那个模式,而是把逻辑抽成可注入依赖的纯函数来测行为。

```
变异 = 退回旧行为(读不到 birth 就一律 throw)
  6 pass / 3 fail
    (fail) ① 进程在两步之间消失 ⇒ 跳过,不抛
    (fail) 全部消失 ⇒ 空列表,仍不抛
    (fail) 🔴 放宽只对『确证消失』生效
  ⇒ 红的正是钉「消失不算失败」的三条;
    验「仍在就要抛」的两条**保持绿** —— 说明放宽没有波及它们。

未变异:9 pass 0 fail
```

## 边界与未做

- **未起 test225 整套 Docker**:本机盘仅 19G,是硬约束(镜像会饿死在跑的容器)。实际收敛效果由 CI 验证。
- `agent-network` 全量单测 **689 pass 0 fail**;基线 `main` 为 **680 / 79 文件**,差值恰为本次新增的 1 文件 9 用例。
- 中途出现过 3 个加载失败(`Cannot find module '@larksuiteoapi/node-sdk'`),是该 worktree 依赖未装全,**与本改动无因果** —— 重装后归零。这一条写在这里是因为**"我这边红了"和"我改红了"是两件事**,必须拿未改动的 main 做对照才分得开。



---

## 定性更新(2026-08-29,合并前)

本 PR 起初被当作 #1422 的解。**它不是**,原因是一个我们直到追查后期才戳穿的前提:

🔴 **我们从头到尾没有看见过 test225 那次失败的真实错误码** —— 只因为红话文本像,就假设它属于
`NODE_OWNER_BIRTH_UNAVAILABLE` 那一族。而追查显示该错误在 `cli.ts` 有**三个产生点**,其中:

- **B**(本 PR 所修的 TOCTOU):test225 的节点由 `anet node start` 启动、**会写 lifecycle 收据**,
  于是 `roots.length > 0`,**根本走不到**这一支;
- **C**(`snapshotOwnedProcessTree`):产品在那里**已经**把 `Z` / `ENOENT` / `ESRCH` 正确归为 `gone`,
  只有真异常才抛,不像本次红的成因。

⇒ **B 的修复是真实的代码改进,但够不到 test225 那条红。**

因此本 PR 的定性调整为两件事:

1. **修 #1422 根因分析中的 TOCTOU-B**(有独立价值:`ps`→`/proc` 之间进程退出不该算 stop 失败);
2. 🔴 **给 test225 装上真因诊断** —— 白名单式错误码摘要。`STOP_LOG_DIR` 不在 `ARTIFACT_DIR` 下,
   CI 的 `docker cp` 取不到那份 mode=600 日志,所以真实错误码**从来没到过 CI**。
   这一格进 main 后,**之后任何 PR 上的 test225 flake 都会把真实错误码打出来**。

**#1422 保持 OPEN**,等下一次 flake 打出真码后再单独定位真凶。

⚠️ 已知边界:本 PR 那一轮 CI 的 test225 是 **SUCCESS**,但那是 **flaky 未触发的运气绿,不是修复绿**。
不拿它当"test225 已修好"的证据。
