### PR TITLE
fix(hub): ship a real inbox_count on new_message / new_reply / broadcast

### DIFF
--- a/server/src/inbox-count-sse.test.ts
+++ b/server/src/inbox-count-sse.test.ts
@@ -1,0 +1,215 @@
+// SSE `inbox_count` contract for the message-shaped events.
+//
+// Background: `new_task` has shipped a real unacked count since #1304,
+// but `new_message` / `new_reply` carried NO count at all and
+// `broadcast` carried a hardcoded `inbox_count: 1`. A client that
+// renders "N new" from the SSE payload therefore never moved for plain
+// messages and replies, and showed a constant 1 for broadcasts.
+//
+// Gate discipline: every assertion below expects a count that is NOT 1
+// (pre-seeded unacked rows push the expected value to 2 or 3). A
+// hardcoded `1` — the exact defect being fixed — fails these tests
+// rather than passing them. Asserting `=== 1` would have been a fake
+// gate that the old code satisfied.
+//
+// Run: COMMHUB_DB=/tmp/inbox-count-sse.db bun test src/inbox-count-sse.test.ts
+
+import { afterAll, beforeEach, afterEach, describe, expect, test } from "bun:test";
+import { db, uuidv4 } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+import { __resetSSEClientsForTest, createSSEStream } from "./push.js";
+import { pendingInboxCount } from "./inbox-count.js";
+
+const NET = "net_inboxcount";
+const OWNER = "u_inboxcount_owner";
+const RECV = "peer-inboxcount-recv";   // receives messages/replies
+const OTHER = "peer-inboxcount-other"; // second broadcast recipient
+const SENDER = "peer-inboxcount-send";
+const ALIASES = [RECV, OTHER, SENDER];
+
+type ToolHandler = (args: any, extra?: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  for (const t of ["tasks", "inbox", "task_events"]) {
+    try { db.run(`DELETE FROM ${t} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM sessions WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [OWNER]); } catch {}
+}
+
+function seed() {
+  db.run(
+    `INSERT INTO users (user_id, username, password_hash, role, created_at)
+     VALUES (?1, ?1, 'x', 'user', datetime('now'))`,
+    [OWNER],
+  );
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET, OWNER]);
+  db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [OWNER, NET]);
+  for (const alias of ALIASES) {
+    db.run(
+      `INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+       VALUES (?1, ?2, ?2, ?3, ?4, datetime('now'), datetime('now'), 'active')`,
+      [`node_${alias}`, alias, NET, `host-${alias}`],
+    );
+    db.run(
+      `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+       VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+      [`res_${alias}`, alias, `node_${alias}`, NET],
+    );
+  }
+}
+
+beforeEach(() => { cleanup(); seed(); });
+afterEach(() => { __resetSSEClientsForTest(); });
+afterAll(cleanup);
+
+function buildHandlers(alias: string): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler;
+    return origTool(name, _desc, schema, handler);
+  };
+  registerTools(server, undefined, NET, OWNER, alias, true, null);
+  return tools;
+}
+
+async function call(handler: ToolHandler, args: any): Promise<Record<string, any>> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0].text);
+}
+
+/** Read the next SSE data frame, with a hard timeout so a silent stream
+ *  fails instead of hanging. Skips keepalive comment frames. */
+async function readFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 2_000,
+): Promise<Record<string, any>> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error(`no SSE frame within ${timeoutMs}ms`)), deadline - Date.now()),
+      ),
+    ]);
+    if (result.done) throw new Error("SSE stream ended unexpectedly");
+    buf += decoder.decode(result.value, { stream: true });
+    const sep = buf.indexOf("\n\n");
+    if (sep === -1) continue;
+    const rawFrame = buf.slice(0, sep);
+    buf = buf.slice(sep + 2);
+    const dataLine = rawFrame.split("\n").find((l) => l.startsWith("data: "));
+    if (!dataLine) continue;
+    return JSON.parse(dataLine.slice(6));
+  }
+  throw new Error(`no SSE frame within ${timeoutMs}ms`);
+}
+
+/** Subscribe and swallow the initial `connected` frame. */
+async function subscribe(alias: string) {
+  const reader = createSSEStream(alias, NET).body!.getReader();
+  await readFrame(reader);
+  return reader;
+}
+
+/** Pre-existing unacked inbox rows, so the expected count is never 1. */
+function seedUnacked(alias: string, n: number, type = "message") {
+  for (let i = 0; i < n; i++) {
+    db.run(
+      `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
+       VALUES (?1, ?2, ?3, ?4, 'normal', ?5, ?6, ?7)`,
+      [uuidv4(), alias, `node_${alias}`, type, `backlog ${i}`, SENDER, NET],
+    );
+  }
+}
+
+function makeTask(from: string, to: string, content: string): string {
+  const id = uuidv4();
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, network_id)
+     VALUES (?1, ?2, ?3, 'normal', 'delivered', ?4, 'reply', datetime('now'), ?5)`,
+    [id, from, to, content, NET],
+  );
+  return id;
+}
+
+describe("SSE inbox_count", () => {
+  test("new_message carries the recipient's real unacked count, not a hardcoded 1", async () => {
+    seedUnacked(RECV, 2);
+    const reader = await subscribe(RECV);
+
+    const tools = buildHandlers(SENDER);
+    const res = await call(tools.send_message, { alias: RECV, message: "hello", network_id: NET });
+    expect(res.ok ?? true).not.toBe(false);
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_message");
+    // 2 seeded + this one. A hardcoded 1 — or a missing field — fails here.
+    expect(evt.inbox_count).toBe(3);
+    expect(evt.inbox_count).toBe(pendingInboxCount(RECV, NET));
+  });
+
+  test("new_reply carries the reply target's real unacked count", async () => {
+    seedUnacked(RECV, 1);
+    const taskId = makeTask(RECV, SENDER, "please do the thing");
+    const reader = await subscribe(RECV);
+
+    const tools = buildHandlers(SENDER);
+    const res = await call(tools.send_reply, {
+      alias: RECV,
+      text: "done",
+      in_reply_to: taskId,
+      status: "completed",
+      network_id: NET,
+    });
+    expect(res.ok).toBe(true);
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_reply");
+    // 1 seeded + the reply row. Not 1, and not absent.
+    expect(evt.inbox_count).toBe(2);
+    expect(evt.inbox_count).toBe(pendingInboxCount(RECV, NET));
+  });
+
+  test("broadcast counts per recipient instead of shipping a constant 1", async () => {
+    // Asymmetric backlogs: if the payload were hardcoded, both
+    // recipients would report the same number. They must not.
+    seedUnacked(RECV, 2);
+    const recvReader = await subscribe(RECV);
+    const otherReader = await subscribe(OTHER);
+
+    const tools = buildHandlers(SENDER);
+    await call(tools.broadcast, { message: "all hands", network_id: NET });
+
+    const recvEvt = await readFrame(recvReader);
+    const otherEvt = await readFrame(otherReader);
+    expect(recvEvt.type).toBe("broadcast");
+    expect(otherEvt.type).toBe("broadcast");
+
+    // RECV: 2 seeded + the broadcast row. OTHER: only the broadcast row.
+    expect(recvEvt.inbox_count).toBe(3);
+    expect(otherEvt.inbox_count).toBe(1);
+    expect(recvEvt.inbox_count).not.toBe(otherEvt.inbox_count);
+  });
+
+  test("acked rows are excluded — the count tracks what is still unread", async () => {
+    seedUnacked(RECV, 3);
+    db.run("UPDATE inbox SET acked = 1 WHERE session_name = ?1 AND network_id = ?2", [RECV, NET]);
+    const reader = await subscribe(RECV);
+
+    const tools = buildHandlers(SENDER);
+    await call(tools.send_message, { alias: RECV, message: "after the catch-up", network_id: NET });
+
+    const evt = await readFrame(reader);
+    // 3 acked rows contribute nothing; only the new one is outstanding.
+    expect(evt.inbox_count).toBe(1);
+  });
+});

--- a/server/src/inbox-count.ts
+++ b/server/src/inbox-count.ts
@@ -1,0 +1,29 @@
+import { db } from "./db.js";
+
+/**
+ * Unacked inbox rows for `alias` — the number a client should show as
+ * "new". This is the count `new_task` has shipped since #1304; it is
+ * lifted here verbatim so every SSE event that carries `inbox_count`
+ * derives it the same way instead of hardcoding a digit.
+ *
+ * The SQL and its network scoping are unchanged from the `new_task`
+ * sites (tools.ts / server.ts): falsy `networkId` means "no network
+ * filter", matching both `addScope()` and the inline `if (taskNetId)`
+ * guard those sites already use.
+ *
+ * The `?? 1` fallback only fires if the COUNT itself returns no row,
+ * which SQLite does not do. It is not a default count: it is the
+ * fail-closed direction for this gate. Every caller pushes right after
+ * inserting an inbox row, so the floor is genuinely 1, and under-
+ * reporting an unread (badge says 0, a message is sitting there) is the
+ * failure this event exists to prevent.
+ */
+export function pendingInboxCount(alias: string, networkId?: string | null): number {
+  const params: any[] = [alias];
+  let sql = "SELECT COUNT(*) as cnt FROM inbox WHERE session_name = ?1 AND acked = 0";
+  if (networkId) {
+    sql += " AND network_id = ?2";
+    params.push(networkId);
+  }
+  return db.get<{ cnt: number }>(sql, ...params)?.cnt ?? 1;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit, syncScheduledRunForTask } from "./db.js";
 import { createSSEStream, createNetworkObserverStream, createUserEventStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
+import { pendingInboxCount } from "./inbox-count.js";
 import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, resolveRestWriteNetworkId, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
 import { narrowTags, parseStoredTags, validateScalarAttr } from "./node-attrs-validate.js";
@@ -2565,7 +2566,7 @@ return Bun.serve({
         ids.push(id);
       }
       for (const t of targets) {
-        pushEvent(t.alias, { type: "broadcast", inbox_count: 1 }, t.network_id);
+        pushEvent(t.alias, { type: "broadcast", inbox_count: pendingInboxCount(t.alias, t.network_id) }, t.network_id);
       }
       return withCors(req, Response.json({ ok: true, recipients: targets.length, message_ids: ids }));
     }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
 import { getSSEStats, hasSubscribers, pushEvent, pushNetworkObserverEvent, pushUserEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
+import { pendingInboxCount } from "./inbox-count.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
 import { canRestWriteNetwork, getUserNetworkIds, singleNetworkId } from "./network-scope.js";
 import {
@@ -1581,7 +1582,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       );
 
       // 同 send_task：可达性用订阅者注册表判，不用心跳时间戳猜。
-      pushEvent(targetAlias, { type: "new_message", from: from_session, message_id: id, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
+      pushEvent(targetAlias, { type: "new_message", inbox_count: pendingInboxCount(targetAlias, effectiveNetId), from: from_session, message_id: id, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
 
       const offlineReply = deliveryTargetReply(target, { message_id: id });
       if (offlineReply) {
@@ -1893,7 +1894,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
 
       const session = scopedSessionStatus(replyTargetAlias, effectiveNetId);
-      pushEvent(replyTargetAlias, { type: "new_reply", from: from_session, message_id: id, in_reply_to, status: replyStatus }, effectiveNetId);
+      pushEvent(replyTargetAlias, { type: "new_reply", inbox_count: pendingInboxCount(replyTargetAlias, effectiveNetId), from: from_session, message_id: id, in_reply_to, status: replyStatus }, effectiveNetId);
       // #461 network observer summary — ids + routing only, no reply text.
       pushNetworkObserverEvent(effectiveNetId, { type: "new_reply", task_id: in_reply_to ?? null, message_id: id, from: from_session, to: replyTargetAlias, status: replyStatus });
 
@@ -2383,7 +2384,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
 
       for (const t of targets) {
-        pushEvent(t.alias, { type: "broadcast", inbox_count: 1 }, effectiveNetId ?? t.network_id ?? null);
+        const netId = effectiveNetId ?? t.network_id ?? null;
+        pushEvent(t.alias, { type: "broadcast", inbox_count: pendingInboxCount(t.alias, netId) }, netId);
       }
 
       return {


### PR DESCRIPTION
## 按内容搜过（开 PR 前的重复工检查）

```
gh pr list --state all --search "inbox_count"  ⇒ 命中 #1304「Add desktop user push and inbox count」(MERGED 2026-08-27)
gh pr list --state all --search "pending_count" ⇒ 零命中
gh pr list --state all --search "new_message"   ⇒ 零命中
```
#1304 加的是 `new_task` 的计数 + prototype 客户端；它**没有**碰本 PR 的三种事件。⇒ 不是重复工，是补齐同一份契约的其余部分。

## 问题

`new_task` 从 #1304 起就带真实未读数，另外三种「消息形态」的 SSE 事件没有：

| 事件 | 出处 | 现状 |
|---|---|---|
| `new_message` | `tools.ts` send_message | **完全没有** `inbox_count` |
| `new_reply` | `tools.ts` send_reply | **完全没有** `inbox_count` |
| `broadcast` | `tools.ts` + `server.ts` REST | **硬编码** `inbox_count: 1` |

⇒ 任何按 SSE payload 渲染「N 条新消息」的客户端：收到**普通消息 / 回复**时计数**不动**；收到**广播**时永远显示 **1**。

🔴 而这一格值得单独说：**Hub 早就有那个数**。`/api/messages?alias=<x>` 用的就是同一张表的同一个查询（`server.ts` `SELECT COUNT(*) FROM inbox WHERE session_name=? AND acked=0`）。**所以这不是数据缺口，是 payload 缺口** —— 数算出来了，只是没放进事件里。

## 改动（payload-only）

新增 `server/src/inbox-count.ts` 一个函数 `pendingInboxCount(alias, networkId)`：把 `new_task` 现有的那条查询**原样**抬出来 —— 同一条 SQL、同一套 network scoping（falsy networkId = 不加过滤，与 `addScope()` 和 `if (taskNetId)` 两处现有写法逐字等价）。**pending 的 SQL 语义没有任何改动。**

四处调用点只往 payload 里加字段：
- `tools.ts` `new_message` / `new_reply`
- `tools.ts` broadcast 循环（per-recipient 计算）
- `server.ts` REST broadcast 循环（per-recipient 计算）

**两处现有的 `new_task` 计算刻意不动** —— 它们与新 helper 逐字等价，但本 PR 不碰能工作的路径；去重可以另开一个纯 refactor。

## 判据不是「测试通过」，是「它能不能抓到已经犯过的那一次」

`server/src/inbox-count-sse.test.ts` 从 SSE 流上读**真实字节**，而**每一条断言期望的数都不是 1** —— 预置未读行把期望值顶到 2 和 3；广播那条给两个收件人**不同的积压**，所以一个恒定 payload 无法同时满足两边。

🔴 断言 `=== 1` 会是一道**假门**：旧代码正好满足它。所以这里一条都不这么写。

**Witnessed-red（把改动 stash 掉、只留测试跑）：**
```
new_message   expected 3, received undefined     ← 字段根本不存在
new_reply     expected 2, received undefined     ← 同上
broadcast     expected 3, received 1             ← 当场抓住那个硬编码 1
acked-only    expected 1, received undefined
⇒ 0 pass / 4 fail
```
**改动后：** `4 pass / 0 fail`；服务端全量套件（canonical runner `bun run scripts/test-aggregate.ts`）**86 files · 1085 pass · 0 fail**。CI 覆盖已核：`qa.yml` 的 paths 含 `server/**`。

## ⚠️ 两格顺带发现的缺陷 —— 本 PR **不修**，登记在这里

```
① broadcast 的第二个循环遍历的是【全部 targets】,包括第一个循环里被
   assertNodeActive 跳过、【没有写入 inbox 行】的那些
   ⇒ 于是一个被跳过的节点也会收到一条 broadcast 事件
   (tools.ts 与 server.ts 两处同形)
   📌 本 PR 不改它:改了就不再是 payload-only。而本 PR 让它【不再更坏】——
      那些节点现在拿到的是自己真实的未读数,而不是假的 1
② 还有两处 new_task 仍是硬编码 inbox_count: 1
   · tools.ts (retry/redeliver 路径) · tools.ts (reassign 路径)
   ⇒ 与 broadcast 同一族缺陷,但不在本次派工范围内
   ⇒ helper 已就位,补它们各是一行
```
两条都请 review 决定是否另开 PR。

## 未做 / 边界

- ⚠️ **未跑 Docker E2E**（AGENTS.md 要求合并前过）。改动是 payload-only 且被服务端全量套件覆盖，但这一格由合入者把关。
- 客户端侧那条更健壮的做法（**收到任何事件就重读 `/api/messages?alias=` 的 `pending_count`**，而不是信 payload 里的数）是**客户端改动**，等「是哪个客户端」定下来再做 —— 与本 PR 不冲突：服务端这刀先把契约补全。
- 未碰生产、未改 DB schema、未动 pending 的 SQL 语义。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
