### PR TITLE
fix(hub): broadcast delivery set + real inbox_count on retry/reassign (closes #1440)

### DIFF
--- a/server/src/inbox-count-sse.test.ts
+++ b/server/src/inbox-count-sse.test.ts
@@ -300,5 +300,11 @@ describe("#1440 broadcast delivery set", () => {
     // message_ids covers only the recipients that actually got a row:
     // RECV + OTHER + SENDER, never STOPPED.
     expect(res.message_ids).toHaveLength(3);
+    // #1440 ③ — `recipients` counted candidates, not deliveries, so it
+    // disagreed with the documented invariant
+    // ("message_ids.length === recipients", docs-site/docs/api/rest.md)
+    // exactly when a node was skipped. 4 sessions, 3 delivered.
+    expect(res.recipients).toBe(res.message_ids.length);
+    expect(res.recipients).toBe(3);
   });
 });

--- a/server/src/inbox-count-sse.test.ts
+++ b/server/src/inbox-count-sse.test.ts
@@ -26,6 +26,8 @@ const OWNER = "u_inboxcount_owner";
 const RECV = "peer-inboxcount-recv";   // receives messages/replies
 const OTHER = "peer-inboxcount-other"; // second broadcast recipient
 const SENDER = "peer-inboxcount-send";
+// #1440 ① — a broadcast target the lifecycle guard skips.
+const STOPPED = "peer-inboxcount-stopped";
 const ALIASES = [RECV, OTHER, SENDER];
 
 type ToolHandler = (args: any, extra?: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
@@ -61,6 +63,18 @@ function seed() {
       [`res_${alias}`, alias, `node_${alias}`, NET],
     );
   }
+  // A session that broadcast will select as a target, but whose node is
+  // NOT active — assertNodeActive skips it, so it gets no inbox row.
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+     VALUES (?1, ?2, ?2, ?3, ?4, datetime('now'), datetime('now'), 'stopped')`,
+    [`node_${STOPPED}`, STOPPED, NET, `host-${STOPPED}`],
+  );
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+    [`res_${STOPPED}`, STOPPED, `node_${STOPPED}`, NET],
+  );
 }
 
 beforeEach(() => { cleanup(); seed(); });
@@ -251,5 +265,40 @@ describe("#1440 new_task inbox_count on requeue paths", () => {
     // 2 seeded on the new assignee + the row reassign just wrote.
     expect(evt.inbox_count).toBe(3);
     expect(evt.inbox_count).toBe(pendingInboxCount(RECV, NET));
+  });
+});
+
+// #1440 ① — the broadcast push loop walked every candidate target,
+// including the ones assertNodeActive had just skipped. Those nodes
+// were told "you have a broadcast" while their inbox got no row for it.
+// Before #1439 the hardcoded `inbox_count: 1` hid this: everyone got
+// the same digit, so a spurious event was indistinguishable from a real
+// one.
+describe("#1440 broadcast delivery set", () => {
+  test("a lifecycle-skipped node gets no inbox row AND no broadcast event", async () => {
+    const activeReader = await subscribe(OTHER);
+    const stoppedReader = await subscribe(STOPPED);
+
+    const tools = buildHandlers(SENDER);
+    const res = await call(tools.broadcast, { message: "all hands", network_id: NET });
+
+    // The active recipient is served — this proves the broadcast ran, so
+    // the absence checked below is "not sent", not "not yet sent"
+    // (pushEvent is synchronous inside the handler).
+    const activeEvt = await readFrame(activeReader);
+    expect(activeEvt.type).toBe("broadcast");
+
+    // The skipped node has no row...
+    const rows = db.get<{ cnt: number }>(
+      "SELECT COUNT(*) AS cnt FROM inbox WHERE session_name = ?1 AND type = 'broadcast'",
+      STOPPED,
+    );
+    expect(rows?.cnt).toBe(0);
+    // ...and must therefore receive no event announcing one.
+    await expect(readFrame(stoppedReader, 300)).rejects.toThrow(/no SSE frame/);
+
+    // message_ids covers only the recipients that actually got a row:
+    // RECV + OTHER + SENDER, never STOPPED.
+    expect(res.message_ids).toHaveLength(3);
   });
 });

--- a/server/src/inbox-count-sse.test.ts
+++ b/server/src/inbox-count-sse.test.ts
@@ -131,12 +131,12 @@ function seedUnacked(alias: string, n: number, type = "message") {
   }
 }
 
-function makeTask(from: string, to: string, content: string): string {
+function makeTask(from: string, to: string, content: string, status = "delivered"): string {
   const id = uuidv4();
   db.run(
     `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, network_id)
-     VALUES (?1, ?2, ?3, 'normal', 'delivered', ?4, 'reply', datetime('now'), ?5)`,
-    [id, from, to, content, NET],
+     VALUES (?1, ?2, ?3, 'normal', ?4, ?5, 'reply', datetime('now'), ?6)`,
+    [id, from, to, status, content, NET],
   );
   return id;
 }
@@ -211,5 +211,45 @@ describe("SSE inbox_count", () => {
     const evt = await readFrame(reader);
     // 3 acked rows contribute nothing; only the new one is outstanding.
     expect(evt.inbox_count).toBe(1);
+  });
+});
+
+// #1440 ② — `retry_task` and `reassign_task` re-queue a task and push
+// `new_task`, but both shipped a hardcoded `inbox_count: 1` while the
+// hub already knew the real number. Same defect family as the
+// `broadcast` case above; same gate discipline — the expected counts
+// here are 3, so a hardcoded 1 cannot satisfy them.
+describe("#1440 new_task inbox_count on requeue paths", () => {
+  test("retry_task carries the real unacked count, not a hardcoded 1", async () => {
+    seedUnacked(RECV, 2);
+    const taskId = makeTask(SENDER, RECV, "flaky job", "failed");
+    const reader = await subscribe(RECV);
+
+    const tools = buildHandlers(SENDER);
+    const res = await call(tools.retry_task, { task_id: taskId, network_id: NET });
+    expect(res.ok).toBe(true);
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_task");
+    // 2 seeded + the re-queued task row.
+    expect(evt.inbox_count).toBe(3);
+    expect(evt.inbox_count).toBe(pendingInboxCount(RECV, NET));
+  });
+
+  test("reassign_task carries the NEW assignee's real unacked count", async () => {
+    seedUnacked(RECV, 2);
+    const taskId = makeTask(SENDER, OTHER, "moved job");
+    const reader = await subscribe(RECV);
+
+    const tools = buildHandlers(SENDER);
+    const res = await call(tools.reassign_task, { task_id: taskId, new_alias: RECV, network_id: NET });
+    expect(res.ok).toBe(true);
+    expect(res.reassigned_to).toBe(RECV);
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_task");
+    // 2 seeded on the new assignee + the row reassign just wrote.
+    expect(evt.inbox_count).toBe(3);
+    expect(evt.inbox_count).toBe(pendingInboxCount(RECV, NET));
   });
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2550,6 +2550,9 @@ return Bun.serve({
       if (body.filter_status) { sql += " AND status = ?"; params.push(body.filter_status); }
       const targets = db.all<{ alias: string; node_id: string | null; network_id: string | null }>(sql, ...params);
       const ids: string[] = [];
+      // #1440 ① — mirrors the MCP handler: push to the recipients that
+      // actually got an inbox row, not to every candidate target.
+      const delivered: Array<{ alias: string; netId: string | null }> = [];
       for (const t of targets) {
         // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.2a REST site
         // 2/2). Broadcast skips non-active recipients silently per its
@@ -2564,9 +2567,10 @@ return Bun.serve({
           [id, t.alias, t.node_id ?? null, body.message, t.network_id]
         );
         ids.push(id);
+        delivered.push({ alias: t.alias, netId: t.network_id });
       }
-      for (const t of targets) {
-        pushEvent(t.alias, { type: "broadcast", inbox_count: pendingInboxCount(t.alias, t.network_id) }, t.network_id);
+      for (const d of delivered) {
+        pushEvent(d.alias, { type: "broadcast", inbox_count: pendingInboxCount(d.alias, d.netId) }, d.netId);
       }
       return withCors(req, Response.json({ ok: true, recipients: targets.length, message_ids: ids }));
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2572,7 +2572,7 @@ return Bun.serve({
       for (const d of delivered) {
         pushEvent(d.alias, { type: "broadcast", inbox_count: pendingInboxCount(d.alias, d.netId) }, d.netId);
       }
-      return withCors(req, Response.json({ ok: true, recipients: targets.length, message_ids: ids }));
+      return withCors(req, Response.json({ ok: true, recipients: ids.length, message_ids: ids }));
     }
 
     // ── REST: tmux capture-pane ──

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2398,7 +2398,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({ ok: true, recipients: targets.length, message_ids: ids }),
+            text: JSON.stringify({ ok: true, recipients: ids.length, message_ids: ids }),
           },
         ],
       };

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2366,26 +2366,32 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       const targets = db.all<{ alias: string; node_id: string | null; network_id: string | null }>(sql, ...params);
       const ids: string[] = [];
+      // #1440 ① — the push loop must walk the recipients that actually
+      // got an inbox row, not every candidate target. Walking `targets`
+      // announced a broadcast to nodes the lifecycle guard had just
+      // skipped, i.e. nodes with nothing to fetch.
+      const delivered: Array<{ alias: string; netId: string | null }> = [];
 
       for (const t of targets) {
         // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 6/6).
         // Broadcast skips non-active recipients silently rather than
         // failing the entire send — broadcast semantics are best-effort
         // per-recipient and a stopped node simply gets nothing.
-        const lc = assertNodeActive(t.alias, effectiveNetId ?? t.network_id ?? null);
+        const netId = effectiveNetId ?? t.network_id ?? null;
+        const lc = assertNodeActive(t.alias, netId);
         if (!lc.ok) continue;
         const id = uuidv4();
         db.run(
           `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
            VALUES (?1, ?2, ?3, 'broadcast', 'normal', ?4, 'hub', ?5)`,
-          [id, t.alias, t.node_id ?? null, message, effectiveNetId ?? t.network_id ?? null]
+          [id, t.alias, t.node_id ?? null, message, netId]
         );
         ids.push(id);
+        delivered.push({ alias: t.alias, netId });
       }
 
-      for (const t of targets) {
-        const netId = effectiveNetId ?? t.network_id ?? null;
-        pushEvent(t.alias, { type: "broadcast", inbox_count: pendingInboxCount(t.alias, netId) }, netId);
+      for (const d of delivered) {
+        pushEvent(d.alias, { type: "broadcast", inbox_count: pendingInboxCount(d.alias, d.netId) }, d.netId);
       }
 
       return {

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2034,7 +2034,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, "retry");
       // SSE push (unconditional — channel is keyed by alias, not network)
-      pushEvent(task.to_name, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session }, effectiveNetId ?? task.network_id ?? null);
+      pushEvent(task.to_name, { type: "new_task", inbox_count: pendingInboxCount(task.to_name, effectiveNetId ?? task.network_id ?? null), priority: task.priority, from: from_session }, effectiveNetId ?? task.network_id ?? null);
       pushNetworkObserverEvent(effectiveNetId ?? task.network_id ?? null, { type: "new_task", task_id, from: from_session, to: task.to_name, status: "delivered", priority: task.priority });
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, retried_to: task.to_name }) }],
@@ -2248,7 +2248,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           [newInboxId, task_id, reassignedAlias, newNodeId, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]);
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, `reassign: ${oldAlias} → ${reassignedAlias}`);
-      pushEvent(reassignedAlias, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session, ...(canonical.renamed ? { renamed_from: new_alias } : {}) }, effectiveNetId ?? task.network_id ?? null);
+      pushEvent(reassignedAlias, { type: "new_task", inbox_count: pendingInboxCount(reassignedAlias, effectiveNetId ?? task.network_id ?? null), priority: task.priority, from: from_session, ...(canonical.renamed ? { renamed_from: new_alias } : {}) }, effectiveNetId ?? task.network_id ?? null);
       pushNetworkObserverEvent(effectiveNetId ?? task.network_id ?? null, { type: "new_task", task_id, from: from_session, to: reassignedAlias, status: "delivered", priority: task.priority });
       return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, reassigned_from: oldAlias, reassigned_to: reassignedAlias, ...(canonical.renamed ? { renamed_from: new_alias, renamed_to: reassignedAlias } : {}) }) }] };
     }


### PR DESCRIPTION
Closes #1440. Base `origin/main` = eee60874（#1439 的合入点 —— helper `pendingInboxCount()` 已在 main）。

**三个 commit，一格一个，可以独立丢掉任意一个：**

| commit | 格 | 改动 |
|---|---|---|
| `fd55cdac` | ② | `retry_task` / `reassign_task` 的 `new_task` 用真实计数 |
| `a36681fe` | ① | broadcast 只推给**真的写了 inbox 行**的收件人 |
| `acb1e49c` | ③ | broadcast 的 `recipients` 数投递数，不数候选数 |

✅ **按内容搜过**（开 PR 前）：
```
gh pr list --state all --search "inbox_count"   ⇒ 命中 #1439(已合,本 PR 的前置)
gh pr list --state all --search "broadcast"     ⇒ 零命中(除 #1439)
gh issue list --state all --search "recipients" ⇒ 零命中
```

---

## ② `retry_task` / `reassign_task` — 硬编码 1 换成真实计数

两处都在**重新入队一条任务**后推 `new_task`，而 payload 里写死 `inbox_count: 1`。与 #1439 修掉的 `broadcast` 是同一族缺陷，helper 已在，各是一行。

## ① broadcast 推给了**根本没收到消息**的节点

两个 handler（MCP `tools.ts` / REST `server.ts`）都是「第一个循环写 inbox 行，第二个循环再遍历一遍 `targets` 推事件」。而生命周期闸在第一个循环里 `continue` 掉了非 active 节点 —— 于是**那些节点没有 inbox 行，却收到一条 `broadcast` 事件**：一个宣告不存在的消息的通知。

🔴 **而这个缺陷在 #1439 之前是被那个硬编码 `1` 遮住的**：所有人都拿到同一个数字，假事件与真事件不可分。#1439 换成真实计数之后它才露出来 —— 而事件本身仍然是假的：**没有任何新东西到达**。

改法：第一个循环收集实际投递的收件人，第二个循环只走那一份。**闸、SQL、计数都没动。**

## ③ `recipients` 数的是候选，不是投递 —— 而文档已经把语义钉死了

两个 handler 都返回 `recipients: targets.length`，而 `message_ids` 里只有真正写成功的那些。一旦有节点被跳过，两者就对不上，而这与仓库文档**明写的不变量**矛盾：

```
docs-site/docs/api/rest.md:1537       `message_ids.length === recipients`
docs-site/docs/api/mcp-tools.md:728   `message_ids` 长度 = `recipients`
```

⇒ **所以这不是给这个字段换语义，是把文档早就规定的语义还回去。** 仓库内既有调用方断言的是 `recipients >= 1`（`tests/qa-hub-13-server-health-agents` / `qa-hub-10-network-scope-regressions`），仍然成立。

⚠️ 它单独成一个 commit，是因为它是三格里唯一**改变 API 响应值**的：若 review 认为该另走一条，`git revert acb1e49c` 就够，其余两格不受影响。

---

## 判据：断言一条都没写 `=== 1`

沿用 #1439 的纪律 —— 预置未读行把期望值顶到 **3**，硬编码的 1 满足不了；①那条断言的是**一帧都收不到**。

**Witnessed-red（每格分别 stash 掉自己的源码改动、只留测试跑）：**
```
② retry_task      expected 3, received 【1】          ← 当场抓住硬编码
② reassign_task   expected 3, received 【1】
① 被跳过的节点     expected promise that rejects,
                  received promise that 【resolved】  ← 它真的收到了那条假事件
③ recipients      expected 3, received 【4】          ← 把被跳过的那个也数了
```

**改动后：**
- `server/src/inbox-count-sse.test.ts` → **7 pass / 0 fail**
- 服务端全量（canonical runner）→ **87 files · 1090 pass · 0 fail**

①那条断言「收不到帧」用的是超时，但**先读到 active 收件人的那一帧**才去检查缺席 —— 因为 `pushEvent` 在 handler 内是同步的，所以那是「没发」，不是「还没发」。

## 未做 / 边界
```
· 未在本地跑 tsc --noEmit(仓库没装 tsc,CI 的 Windows job 会跑)⇒ 不替 CI 宣称类型干净
· 未跑 Docker E2E ⇒ 同 #1439,这一格由合入者把关
· 未碰生命周期闸、未动 pending 的 SQL、未改 schema、未碰生产
· 我不合这个 PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
