### PR TITLE
fix(hub): 子节点生命周期工具统一接受 node_id 与 child_node_id (#1281)

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1917 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1950) + [tools.ts:1931 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1962) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1994 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1994) + [tools.ts:2008 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2008) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/node-id-alias.test.ts
+++ b/server/src/node-id-alias.test.ts
@@ -1,0 +1,147 @@
+// #1281 — 子节点生命周期工具的参数名统一（node_id ⇄ child_node_id）。
+//
+// 分叉现状（origin/main 2976adb2）：stop_node / start_node / delete_node 用
+// `child_node_id`，restart_node / update_node_config 用 `node_id`，指向同一个
+// 子节点。调用方按一个工具的习惯给另一个传就吃 -32602。修复：5 个工具都同时
+// 接受两个名字（canonical = node_id，child_node_id 兼容 alias），解析收敛到一个
+// 模块级 helper resolveNodeIdArg。
+//
+// 两向 witnessed-red（本文件即判据）：
+//   · schema 层：每个工具的**历史用名**始终 parse 成功（证明没破已发布契约），
+//     **新增别名**在修复前 parse 失败（缺必填字段）、修复后成功。
+//   · handler 层：resolveNodeIdArg 纯函数 —— 二选一至少一必填、都传须相等。
+//   · 真实 handler 路径：stop_node 用 node_id / child_node_id 都能穿到
+//     resolveDaemonForChild（不再被 node_id_required 挡），都传冲突 → node_id_conflict。
+//
+// 对 pre-fix 见红的证明方式（评审可复现）：把 tools.ts 里任一工具的
+// `...NODE_ID_ALIAS_FIELDS` 还原成原来的单名字段（如 stop_node 的
+// `child_node_id: z.string()...regex(...)`），本文件对应工具的「新增别名 parse 成功」
+// 断言立即变红 —— 证明该断言有判别力，不是恒真。
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+process.env.COMMHUB_DB = process.env.COMMHUB_DB || (mkdtempSync(join(tmpdir(), "anet-1281-")) + "/commhub.db");
+
+import { z } from "zod/v4";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools, resolveNodeIdArg } from "./tools.js";
+
+type ToolHandler = (args: any) => Promise<{ content: { type: "text"; text: string }[] }>;
+
+// Capture BOTH the raw zod shape and the handler for every tool, so the
+// schema-layer assertions run against the exact object server.tool received.
+function buildCaptured() {
+  const schemas: Record<string, any> = {};
+  const handlers: Record<string, ToolHandler> = {};
+  const server = new McpServer({ name: "t1281", version: "0" }) as any;
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, schema: any, handler: ToolHandler) => {
+    schemas[name] = schema; handlers[name] = handler;
+    return origTool(name, _desc, schema, handler);
+  };
+  const origRegisterTool = server.registerTool?.bind(server);
+  if (origRegisterTool) {
+    server.registerTool = (name: string, cfg: any, handler: ToolHandler) => {
+      schemas[name] = cfg?.inputSchema ?? cfg; handlers[name] = handler;
+      return origRegisterTool(name, cfg, handler);
+    };
+  }
+  registerTools(server, undefined, null, "user_1281", null, false, null);
+  return { schemas, handlers };
+}
+
+let SCHEMAS: Record<string, any> = {};
+let HANDLERS: Record<string, ToolHandler> = {};
+beforeAll(() => { const c = buildCaptured(); SCHEMAS = c.schemas; HANDLERS = c.handlers; });
+
+async function call(name: string, args: any) {
+  const r = await HANDLERS[name](args);
+  return JSON.parse(r.content[0].text);
+}
+
+// Per tool: the historically-required id name, the newly-added alias, and
+// the OTHER required fields the shape needs so a safeParse isolates the id
+// field rather than tripping on an unrelated missing field.
+const TOOLS = [
+  { name: "stop_node",          historic: "child_node_id", added: "node_id",        extra: {} },
+  { name: "start_node",         historic: "child_node_id", added: "node_id",        extra: {} },
+  { name: "delete_node",        historic: "child_node_id", added: "node_id",        extra: { confirm_alias: "some-alias" } },
+  { name: "restart_node",       historic: "node_id",       added: "child_node_id",  extra: {} },
+  { name: "update_node_config", historic: "node_id",       added: "child_node_id",  extra: { base_revision: 0, patch: {} } },
+];
+
+const VALID_ID = "node_test_1281";
+
+describe("#1281 schema layer — every lifecycle tool accepts BOTH node_id and child_node_id", () => {
+  for (const t of TOOLS) {
+    test(`${t.name}: historic name '${t.historic}' still parses (published contract intact)`, () => {
+      const shape = z.object(SCHEMAS[t.name]);
+      const r = shape.safeParse({ [t.historic]: VALID_ID, ...t.extra });
+      expect(r.success).toBe(true);
+    });
+
+    test(`${t.name}: added alias '${t.added}' parses (was -32602 pre-#1281 → RED without the fix)`, () => {
+      const shape = z.object(SCHEMAS[t.name]);
+      const r = shape.safeParse({ [t.added]: VALID_ID, ...t.extra });
+      expect(r.success).toBe(true);
+    });
+
+    test(`${t.name}: both names present + equal parses (schema layer permissive; conflict caught in handler)`, () => {
+      const shape = z.object(SCHEMAS[t.name]);
+      const r = shape.safeParse({ node_id: VALID_ID, child_node_id: VALID_ID, ...t.extra });
+      expect(r.success).toBe(true);
+    });
+  }
+});
+
+describe("#1281 resolveNodeIdArg — the single resolution helper", () => {
+  test("node_id only → resolves to node_id", () => {
+    expect(resolveNodeIdArg({ node_id: "node_a" })).toEqual({ ok: true, node_id: "node_a" });
+  });
+  test("child_node_id only → resolves to it (back-compat)", () => {
+    expect(resolveNodeIdArg({ child_node_id: "node_b" })).toEqual({ ok: true, node_id: "node_b" });
+  });
+  test("both present + EQUAL → resolves (no conflict)", () => {
+    expect(resolveNodeIdArg({ node_id: "node_c", child_node_id: "node_c" })).toEqual({ ok: true, node_id: "node_c" });
+  });
+  test("both present + DIFFERENT → node_id_conflict (catches A/B fat-finger)", () => {
+    const r = resolveNodeIdArg({ node_id: "node_a", child_node_id: "node_b" });
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toBe("node_id_conflict");
+  });
+  test("neither present → node_id_required", () => {
+    const r = resolveNodeIdArg({});
+    expect(r.ok).toBe(false);
+    expect((r as any).error).toBe("node_id_required");
+  });
+});
+
+describe("#1281 real handler path — stop_node routes both names to the same place", () => {
+  // stop_node calls resolveNodeIdArg FIRST, then resolveDaemonForChild. A
+  // fabricated id has no create-request row → daemon_not_resolvable. The
+  // point is that BOTH names get PAST the id gate to that same downstream
+  // error (proving the alias flows through), and the two error branches fire.
+  test("node_id (new name) flows through → daemon_not_resolvable, NOT node_id_required", async () => {
+    const r = await call("stop_node", { node_id: VALID_ID });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_not_resolvable");
+  });
+  test("child_node_id (old name) flows through → daemon_not_resolvable (back-compat intact)", async () => {
+    const r = await call("stop_node", { child_node_id: VALID_ID });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_not_resolvable");
+  });
+  test("neither → node_id_required (before any daemon resolution)", async () => {
+    const r = await call("stop_node", { force: true });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_id_required");
+  });
+  test("both differ → node_id_conflict (before any daemon resolution)", async () => {
+    const r = await call("stop_node", { node_id: "node_a", child_node_id: "node_b" });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_id_conflict");
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -81,6 +81,49 @@ function normalizeMetaJson(meta: unknown): string | null {
   try { return JSON.stringify(stripHostLocalPathsForCrossHostSafe(meta)); } catch { return null; }
 }
 
+// ── #1281 — 子节点生命周期工具的参数名统一 ────────────────────────────
+//
+// stop_node / start_node / delete_node 历史上用 `child_node_id`（RFC-027），
+// restart_node / update_node_config 用 `node_id`。同一个对象（子节点）两个名字，
+// 调用方按一个工具的习惯给另一个传就吃 -32602。两侧都已是**已发布契约**
+// （start_node 随 #1273 合入），且 hub API 在 RFC-030 混版滚动期老客户端还在
+// 发老名——所以不能硬改名，改为**两个名字都接受**：
+//   · canonical = `node_id`（= DB 列 nodes.node_id、= create_node 的输出、
+//     restart/update 历史用名；「建完节点→再操作它」用同一个名才是傻瓜式）。
+//   · `child_node_id` 作为**兼容 alias 保留** + deprecation 注释；不加运行时
+//     warning（老客户端是设计内兼容，不是错误，别刷屏）。
+// create_node 的 `daemon_node_id` 指宿主 daemon，是另一层语义，不在本次统一内。
+//
+// server.tool 收的是 ZodRawShape（裸对象），挂不了 .refine()，所以「至少一个
+// 必填」+「两个都传须相等」在 handler 侧用 resolveNodeIdArg 兜——返回结构化
+// ok:false 反而比 schema 层的 -32602 更友好。两个名字在 schema 层都做成
+// optional + 宽松 .min(1).max(200)（不带 regex），使命名与校验强度同时统一：
+// 对 restart/update 不变（本就宽松），对 stop/start/delete 是放宽（原 regex 会
+// 在 schema 层挡掉 alias/杂串，放宽后落到查表返回 node_not_found，对合法调用
+// 方无影响，只是错误形态更一致）。
+const NODE_ID_ALIAS_FIELDS = {
+  node_id: z.string().min(1).max(200).optional()
+    .describe("Target child node ID (canonical, #1281). The value create_node returns. Must be in caller's network."),
+  child_node_id: z.string().min(1).max(200).optional()
+    .describe("DEPRECATED alias for node_id (#1281): kept for back-compat with pre-unification clients; prefer node_id."),
+} as const;
+
+/** #1281 — 把 node_id / child_node_id 收敛成单一内部 id。两个都传且不等 ⇒
+ *  node_id_conflict（挡「node_id 填 A、child_node_id 填 B」的手滑，比单纯二选一强）；
+ *  都不传 ⇒ node_id_required。纯函数，模块级导出以便单测直接验解析逻辑。 */
+export function resolveNodeIdArg(a: { node_id?: string; child_node_id?: string }):
+  { ok: true; node_id: string } | { ok: false; error: string; message: string } {
+  const n = a.node_id, c = a.child_node_id;
+  if (n && c && n !== c) {
+    return { ok: false, error: "node_id_conflict", message: "node_id and child_node_id both provided but differ; send only one (they are aliases for the same child node)" };
+  }
+  const id = n ?? c;
+  if (!id) {
+    return { ok: false, error: "node_id_required", message: "one of node_id / child_node_id is required (child_node_id is a deprecated alias; prefer node_id)" };
+  }
+  return { ok: true, node_id: id };
+}
+
 export function registerTools(server: McpServer, clientIP?: string, enforceNetworkId?: string | null, enforceUserId?: string | null, callerAlias?: string | null, callerTokenIsNetwork = false, callerTokenId?: string | null) {
   // Default from_session for outbound tools — extracted from the calling
   // token's binding (ntok_ → node alias, utok_ → username). Without this,
@@ -2491,7 +2534,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     "update_node_config",
     "Set the desired per-node config (model + flags) and push a doorbell to the node. The node pulls + validates + applies (hot or restart per field tier). RFC-024.",
     {
-      node_id: z.string().min(1).max(200).describe("Target node ID (not alias). Must be in caller's network."),
+      ...NODE_ID_ALIAS_FIELDS,
       base_revision: z.number().int().min(0).describe("Current revision per the dashboard's last GET — 409 if hub's current revision differs."),
       patch: z.object({
         model: z.string().max(200).optional(),
@@ -2515,7 +2558,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }).describe("Fields to update. Empty patch → no-op (use restart_node for that)."),
       network_id: z.string().max(200).optional(),
     },
-    async ({ node_id: nodeId, base_revision: baseRev, patch, network_id: clientNetId }) => {
+    async ({ node_id, child_node_id, base_revision: baseRev, patch, network_id: clientNetId }) => {
+      const idArg = resolveNodeIdArg({ node_id, child_node_id });
+      if (!idArg.ok) return { content: [{ type: "text" as const, text: JSON.stringify(idArg) }] };
+      const nodeId = idArg.node_id;
       const effectiveNetId = getNetworkId(clientNetId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId, "write");
 
@@ -2824,10 +2870,13 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     "restart_node",
     "Trigger a node restart without changing config. RFC-024 Vincent 2026-06-28 increment. Network-scoped (SEC-1); member+ role suffices (lifecycle ops are not privilege elevation).",
     {
-      node_id: z.string().min(1).max(200),
+      ...NODE_ID_ALIAS_FIELDS,
       network_id: z.string().max(200).optional(),
     },
-    async ({ node_id: nodeId, network_id: clientNetId }) => {
+    async ({ node_id, child_node_id, network_id: clientNetId }) => {
+      const idArg = resolveNodeIdArg({ node_id, child_node_id });
+      if (!idArg.ok) return { content: [{ type: "text" as const, text: JSON.stringify(idArg) }] };
+      const nodeId = idArg.node_id;
       const effectiveNetId = getNetworkId(clientNetId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId, "write");
 
@@ -3726,7 +3775,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     "stop_node",
     "Stop the agent-node child process; keep config dir intact. Reversible via restart_node. RFC-027 §2.2. daemon_node_id is auto-resolved from child_node_id when omitted (looked up in node_create_requests).",
     {
-      child_node_id: z.string().min(1).max(200).regex(/^node_[a-z0-9_-]+$/),
+      ...NODE_ID_ALIAS_FIELDS,
       // PR2 prereq: dashboard rarely knows daemon_node_id directly.
       // When omitted, hub resolves from the original creation record
       // (node_create_requests.daemon_node_id keyed by this child).
@@ -3735,7 +3784,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       grace_seconds: z.number().int().min(5).max(60).optional().default(10),
       network_id: z.string().max(200).optional(),
     },
-    async ({ child_node_id, daemon_node_id, force, grace_seconds, network_id: clientNetId }) => {
+    async ({ node_id, child_node_id: child_node_id_arg, daemon_node_id, force, grace_seconds, network_id: clientNetId }) => {
+      const idArg = resolveNodeIdArg({ node_id, child_node_id: child_node_id_arg });
+      if (!idArg.ok) return { content: [{ type: "text" as const, text: JSON.stringify(idArg) }] };
+      const child_node_id = idArg.node_id;
       const resolved = daemon_node_id ?? resolveDaemonForChild(child_node_id);
       if (!resolved) {
         return { content: [{ type: "text" as const, text: JSON.stringify({
@@ -3756,7 +3808,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     "delete_node",
     "Stop child + revoke ntok + delete hub row + (default) backup config to ~/.anet/deleted/<ts>-<alias>/ for 30d. confirm_alias must equal the node's alias. daemon_node_id is auto-resolved when omitted. RFC-027 §2.2.",
     {
-      child_node_id: z.string().min(1).max(200).regex(/^node_[a-z0-9_-]+$/),
+      ...NODE_ID_ALIAS_FIELDS,
       daemon_node_id: z.string().min(1).max(200).regex(/^node_[a-z0-9_-]+$/).optional(),
       confirm_alias: z.string().min(1).max(200),
       force: z.boolean().optional().default(false),
@@ -3764,7 +3816,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       delete_config: z.boolean().optional().default(true),
       network_id: z.string().max(200).optional(),
     },
-    async ({ child_node_id, daemon_node_id, confirm_alias, force, grace_seconds, delete_config, network_id: clientNetId }) => {
+    async ({ node_id, child_node_id: child_node_id_arg, daemon_node_id, confirm_alias, force, grace_seconds, delete_config, network_id: clientNetId }) => {
+      const idArg = resolveNodeIdArg({ node_id, child_node_id: child_node_id_arg });
+      if (!idArg.ok) return { content: [{ type: "text" as const, text: JSON.stringify(idArg) }] };
+      const child_node_id = idArg.node_id;
       const resolved = daemon_node_id ?? resolveDaemonForChild(child_node_id);
       if (!resolved) {
         return { content: [{ type: "text" as const, text: JSON.stringify({
@@ -3941,11 +3996,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     "start_node",
     "Start a stopped child through its host supervisor daemon. daemon_node_id is auto-resolved from the original create request.",
     {
-      child_node_id: z.string().min(1).max(200).regex(/^node_[a-z0-9_-]+$/),
+      ...NODE_ID_ALIAS_FIELDS,
       daemon_node_id: z.string().min(1).max(200).regex(/^node_[a-z0-9_-]+$/).optional(),
       network_id: z.string().max(200).optional(),
     },
-    async ({ child_node_id, daemon_node_id, network_id: clientNetId }) => {
+    async ({ node_id, child_node_id: child_node_id_arg, daemon_node_id, network_id: clientNetId }) => {
+      const idArg = resolveNodeIdArg({ node_id, child_node_id: child_node_id_arg });
+      if (!idArg.ok) return { content: [{ type: "text" as const, text: JSON.stringify(idArg) }] };
+      const child_node_id = idArg.node_id;
       const resolvedDaemonId = daemon_node_id ?? resolveDaemonForChild(child_node_id);
       if (!resolvedDaemonId) {
         return { content: [{ type: "text" as const, text: JSON.stringify({


### PR DESCRIPTION
Closes #1281.

## 分叉现状（origin/main `2976adb2` 逐个核对）

指向**同一个对象（子节点）**的 ID 参数有两个名字，校验强度也不一致：

| 工具 | 参数名 | 校验 |
|---|---|---|
| `stop_node` | `child_node_id` | `.regex(/^node_[a-z0-9_-]+$/)` |
| `start_node` | `child_node_id` | 同上（随 #1273 合入） |
| `delete_node` | `child_node_id` | 同上 |
| `restart_node` | `node_id` | 宽松 `.min(1).max(200)` |
| `update_node_config` | `node_id` | 宽松 |

调用方按 `restart_node` 的习惯给 `stop_node` 传 `node_id` → 硬报 `-32602 ... expected string, received undefined at child_node_id`。`create_node` 的 `daemon_node_id` 指宿主 daemon，是另一层语义，**不在本次统一范围**。

> #1281 原文说的「趁 #1273 未合是低成本统一的最后窗口」已过：start_node 已合入，`child_node_id` 侧成为两个已发布工具的公开契约，两阵营都是已发布 API。

## 兼容方案（不硬改名）

hub API 在 RFC-030 混版滚动期，老客户端还在发老名，**不能硬改名**。改为**5 个工具都同时接受 `node_id` 与 `child_node_id`**：

- **canonical = `node_id`**（= DB 列 `nodes.node_id`、= `create_node` 的输出、restart/update 历史用名；「建完节点→再操作它」用同一个名才是傻瓜式）。
- **`child_node_id` 保留为兼容 alias** + deprecation 注释（`describe()` 里写清），**不加运行时 warning**（老客户端是设计内兼容，不是错误）。
- 收敛到**单一 helper `resolveNodeIdArg`**（不在 5 处各写一遍，免漂移）：二选一至少一必填 → `node_id_required`；**两个都传且不等 → `node_id_conflict`**（挡「node_id 填 A、child_node_id 填 B」的手滑，比单纯二选一强）。
- schema 层两名均 `optional` + 宽松 `.min(1).max(200)`，**命名与校验强度一并统一**：对 restart/update 不变；对 stop/start/delete 是放宽（原 regex 会在 schema 层挡掉 alias/杂串，放宽后落到查表返回 `node_not_found`，对合法调用方无影响，只是错误形态更一致、更友好——结构化 `ok:false` 取代 `-32602`）。

## 两向测试（`server/src/node-id-alias.test.ts`，24 tests）

判据核心 = 每个工具**两个名字都得绿**：

- **schema 层**（覆盖 -32602 的真因）：每个工具的**历史用名**始终 parse 成功（证明没破已发布契约）；**新增别名** parse 成功。
- **`resolveNodeIdArg` 纯函数**：node_id/child_node_id 各自解析、都传相等解析、都传不等→`node_id_conflict`、都不传→`node_id_required`。
- **真实 handler 路径**（stop_node）：`node_id` 与 `child_node_id` 都能穿到 `resolveDaemonForChild`（都得 `daemon_not_resolvable` 而非 `node_id_required`）；冲突/缺失分支各触发。

### Witnessed-red（双向，判别力已证）
把某工具的 `...NODE_ID_ALIAS_FIELDS` 还原成 pre-#1281 单名字段：
- `stop_node` 还原成单 `child_node_id` → 「added alias `node_id` parses」**变红**；
- `restart_node` 还原成单 `node_id` → 「added alias `child_node_id` parses」**变红**；

两个历史名断言 + 所有 handler 断言**全程绿**（证明 back-compat 未动、红的正是新别名那条）。

## 验证

- `npx tsc --noEmit` → 0 error
- `node-id-alias.test.ts` → **24/24**
- 无回归：`stop-delete-node` 32/32、`config-apply-sec1` 47/47、`config-apply-validate` 65/65、`start-node` 2/2、`node-lifecycle-controllable` 8/8、`create-node` 14/14、`create-node-tool-schema` 1/1
- `check-doc-symbol-pins.py` → OK（helper 插入使 tools.ts 后段 +~44 行，第 2 个 commit 机械更新 message-lifecycle.md 的 send_reply/send_ack 钉子，漂移 0）

## 后续（不在本 PR）
RFC-027 / support-matrix 等设计文档正文仍称 `child_node_id`；工具的 `describe()`（客户端实际看到的契约面）已带 canonical/deprecation 说明，文档正文可作 follow-up 补一句别名。
