### PR TITLE
fix(#1379): 加 npm 全局前缀候选 —— 飞书 worker 在 npx 布局下不再静默丢失

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -22,6 +22,7 @@ import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
 import { validateCodexPendingThread } from "./runtime/codex-app-server/pending-thread";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";
+import { computeFeishuWorkerCandidates } from "./feishu-worker-resolve";
 import { claudeCommhubToolAliases } from "./claude-tool-aliases";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
@@ -5484,27 +5485,14 @@ interface FeishuBridgeEnvelope {
   outboundDir?: string;
 }
 
-/**
- * Locate the agent-network feishu worker script. Search order:
- *   1. `ANET_FEISHU_WORKER_PATH` env override (explicit).
- *   2. Dev sibling checkout: agent-node and agent-network laid out as siblings.
- *   3. Installed npm package layout (worker lives in @sleep2agi/agent-network).
- */
 function resolveFeishuWorkerPath(): string | null {
-  const candidates: string[] = [];
-  if (process.env.ANET_FEISHU_WORKER_PATH) {
-    candidates.push(process.env.ANET_FEISHU_WORKER_PATH);
-  }
   const here = new URL(".", import.meta.url).pathname;
-  candidates.push(
-    // dev sibling: ../../agent-network/{dist|src}/src/im/feishu/worker.{js|ts}
-    join(here, "..", "..", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
-    join(here, "..", "..", "agent-network", "src", "im", "feishu", "worker.ts"),
-    // installed npm package (agent-network and agent-node share node_modules root)
-    join(here, "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
-    // global npm prefix layout
-    join(here, "..", "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
-  );
+  const candidates = computeFeishuWorkerCandidates({
+    here,
+    envOverride: process.env.ANET_FEISHU_WORKER_PATH,
+    npmConfigPrefix: process.env.npm_config_prefix,
+    nodeExecPath: process.execPath,
+  });
   for (const c of candidates) {
     if (existsSync(c)) return c;
   }
@@ -5538,7 +5526,8 @@ async function connectFeishu(channel: FeishuChannel): Promise<void> {
   if (!workerPath) {
     warn(
       `[feishu] worker path not found — skipping feishu channel setup. ` +
-        `Override with ANET_FEISHU_WORKER_PATH, or install @sleep2agi/agent-network so dist/src/im/feishu/worker.js is reachable.`,
+        `Override with ANET_FEISHU_WORKER_PATH, or \`npm i -g @sleep2agi/agent-network\` so dist/src/im/feishu/worker.js is reachable ` +
+        `(the resolver now checks the global npm prefix — issue #1379).`,
     );
     return;
   }

--- a/agent-node/src/feishu-worker-resolve.test.ts
+++ b/agent-node/src/feishu-worker-resolve.test.ts
@@ -1,0 +1,202 @@
+// Issue #1379: npx-layout resolution for the feishu worker path.
+//
+// The old resolver had only four candidates, all derived from `import.meta.url`
+// (i.e. the location of agent-node's own dist/cli.js). Under the *most common*
+// install pattern — `anet node start` spawns agent-node via `npx`, and the
+// operator has @sleep2agi/agent-network installed globally — all four missed:
+// npx's cache dir does not contain agent-network (agent-node's package.json
+// does not list it as a dependency), and the global-prefix candidates
+// (../../../..) do not walk out of the npx cache tree either. Feishu channel
+// then failed silently with a single WARN line.
+//
+// This test locks in the fix by exercising the pure candidate-derivation
+// function against a real temp filesystem that mimics the npx layout.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { computeFeishuWorkerCandidates } from "./feishu-worker-resolve";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function mkdTemp(): string {
+  const d = mkdtempSync(join(tmpdir(), "pr1379-feishu-"));
+  dirs.push(d);
+  return d;
+}
+
+/** Simulate `~/.npm/_npx/<hash>/node_modules/@sleep2agi/agent-node/dist/` */
+function makeNpxAgentNode(root: string): string {
+  const npx = join(root, "npm-cache", "_npx", "abcd1234", "node_modules");
+  mkdirSync(join(npx, "@sleep2agi", "agent-node", "dist"), { recursive: true });
+  return join(npx, "@sleep2agi", "agent-node", "dist") + "/";
+}
+
+/** Place `<prefix>/lib/node_modules/@sleep2agi/agent-network/dist/src/im/feishu/worker.js` */
+function placeGlobalWorker(prefix: string): string {
+  const workerPath = join(
+    prefix, "lib", "node_modules", "@sleep2agi", "agent-network",
+    "dist", "src", "im", "feishu", "worker.js",
+  );
+  mkdirSync(dirname(workerPath), { recursive: true });
+  writeFileSync(workerPath, "// fake worker\n", { mode: 0o644 });
+  return workerPath;
+}
+
+/** Old candidate set — the four candidates that shipped before #1379.
+ *  Kept as an in-test transcription so the witnessed-red does not rely
+ *  on any old-code fixture in the repo. */
+function oldFourCandidates(here: string, envOverride?: string): string[] {
+  const c: string[] = [];
+  if (envOverride) c.push(envOverride);
+  c.push(
+    join(here, "..", "..", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    join(here, "..", "..", "agent-network", "src", "im", "feishu", "worker.ts"),
+    join(here, "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    join(here, "..", "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+  );
+  return c;
+}
+
+describe("#1379 resolve feishu worker under npx layout", () => {
+  test("witnessed-red: old 4-candidate set does NOT find globally installed worker under npx", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    const globalPrefix = join(root, "usr-local");
+    const globalWorker = placeGlobalWorker(globalPrefix);
+
+    // Sanity: the worker really is on disk where we placed it.
+    expect(existsSync(globalWorker)).toBe(true);
+
+    // Old logic (the shipping bug): four candidates, none reach global prefix.
+    const oldCandidates = oldFourCandidates(here);
+    const oldResolved = oldCandidates.find((c) => existsSync(c)) ?? null;
+    expect(oldResolved).toBeNull();  // ← the red state — feishu WARN + skip
+
+    // None of the four even names the global prefix by accident.
+    for (const c of oldCandidates) {
+      expect(c.startsWith(globalPrefix)).toBe(false);
+    }
+  });
+
+  test("green: new resolver finds the global-prefix worker via npm_config_prefix", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    const globalPrefix = join(root, "usr-local");
+    const globalWorker = placeGlobalWorker(globalPrefix);
+
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: undefined,
+      npmConfigPrefix: globalPrefix,
+      nodeExecPath: undefined,
+    });
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBe(globalWorker);
+  });
+
+  test("green: new resolver finds worker via process.execPath heuristic (POSIX <prefix>/bin/node)", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    const globalPrefix = join(root, "usr-local");
+    const globalWorker = placeGlobalWorker(globalPrefix);
+    const execPath = join(globalPrefix, "bin", "node");
+    // execPath doesn't need to exist as a real binary — resolver just uses dirname()
+
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: undefined,
+      npmConfigPrefix: undefined,
+      nodeExecPath: execPath,
+    });
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBe(globalWorker);
+  });
+
+  test("green: new resolver finds worker via process.execPath heuristic (Windows-ish <prefix>/node)", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    // Windows layout: `<prefix>/node_modules/...`, no `lib/` interstitial.
+    const globalPrefix = join(root, "AppData", "Roaming", "npm");
+    const workerPath = join(
+      globalPrefix, "node_modules", "@sleep2agi", "agent-network",
+      "dist", "src", "im", "feishu", "worker.js",
+    );
+    mkdirSync(dirname(workerPath), { recursive: true });
+    writeFileSync(workerPath, "// fake worker\n", { mode: 0o644 });
+
+    // execPath = <prefix>/node.exe (dirname = <prefix>).
+    const execPath = join(globalPrefix, "node.exe");
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: undefined,
+      npmConfigPrefix: undefined,
+      nodeExecPath: execPath,
+    });
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBe(workerPath);
+  });
+
+  test("env override wins over everything", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    // Place two workers: one at explicit override, one at global prefix.
+    const explicit = join(root, "my-worker.js");
+    writeFileSync(explicit, "// explicit\n", { mode: 0o644 });
+    const globalPrefix = join(root, "usr-local");
+    placeGlobalWorker(globalPrefix);
+
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: explicit,
+      npmConfigPrefix: globalPrefix,
+      nodeExecPath: join(globalPrefix, "bin", "node"),
+    });
+    expect(candidates[0]).toBe(explicit);
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBe(explicit);
+  });
+
+  test("dev sibling checkout: `agent-node/dist/` next to `agent-network/dist/` still resolves without any global-prefix hint", () => {
+    const root = mkdTemp();
+    // Repo layout: <root>/agent-node/dist/ + <root>/agent-network/dist/src/im/feishu/worker.js
+    const here = join(root, "agent-node", "dist") + "/";
+    mkdirSync(here, { recursive: true });
+    const devWorker = join(root, "agent-network", "dist", "src", "im", "feishu", "worker.js");
+    mkdirSync(dirname(devWorker), { recursive: true });
+    writeFileSync(devWorker, "// dev\n", { mode: 0o644 });
+
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: undefined,
+      npmConfigPrefix: undefined,
+      nodeExecPath: undefined,
+    });
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBe(devWorker);
+  });
+
+  test("nothing on disk anywhere → resolver returns null (skip is still explicit)", () => {
+    const root = mkdTemp();
+    const here = makeNpxAgentNode(root);
+    // No worker anywhere.
+    const candidates = computeFeishuWorkerCandidates({
+      here,
+      envOverride: undefined,
+      npmConfigPrefix: join(root, "empty-prefix"),
+      nodeExecPath: join(root, "empty-prefix", "bin", "node"),
+    });
+    const resolved = candidates.find((c) => existsSync(c)) ?? null;
+    expect(resolved).toBeNull();
+  });
+});

--- a/agent-node/src/feishu-worker-resolve.ts
+++ b/agent-node/src/feishu-worker-resolve.ts
@@ -1,0 +1,59 @@
+// Feishu worker path resolution. Pure — no side effects, no fs reads.
+// Callers apply `existsSync` (or a test double) to the candidate list.
+//
+// Kept in its own file so the unit test does not import `cli.ts` (which
+// has side-effectful module-level boot code — hub registration, goals
+// scheduler startup, etc.). See issue #1379.
+
+import { dirname, join } from "path";
+
+/**
+ * Compute candidate paths for the agent-network feishu worker script.
+ *
+ * Search order:
+ *   1. `ANET_FEISHU_WORKER_PATH` env override (explicit).
+ *   2. Dev sibling checkout: agent-node and agent-network laid out as siblings.
+ *   3. Installed npm package layout (worker lives in @sleep2agi/agent-network).
+ *   4. Global npm prefix layouts (POSIX `<prefix>/lib/node_modules` + Windows
+ *      `<prefix>/node_modules`) — for the very common case where the user
+ *      has `@sleep2agi/agent-network` installed globally and `anet node start`
+ *      is running `agent-node` via `npx` (npx cache dir has no sibling
+ *      agent-network because agent-node's package.json does not declare it
+ *      as a dependency). Issue #1379.
+ */
+export function computeFeishuWorkerCandidates(opts: {
+  here: string;
+  envOverride?: string | undefined;
+  npmConfigPrefix?: string | undefined;
+  nodeExecPath?: string | undefined;
+}): string[] {
+  const { here, envOverride, npmConfigPrefix, nodeExecPath } = opts;
+  const candidates: string[] = [];
+  if (envOverride) candidates.push(envOverride);
+  candidates.push(
+    // dev sibling: ../../agent-network/{dist|src}/src/im/feishu/worker.{js|ts}
+    join(here, "..", "..", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    join(here, "..", "..", "agent-network", "src", "im", "feishu", "worker.ts"),
+    // installed npm package (agent-network and agent-node share node_modules root)
+    join(here, "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    // deeper node_modules layout (some hoisting setups)
+    join(here, "..", "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+  );
+  // Derive global npm prefix candidates. Two sources — either can be absent.
+  //   • `npm_config_prefix` — set by npm when invoked; often unset in bare shells.
+  //   • `process.execPath` — always set. Under POSIX global installs the node
+  //     binary lives at `<prefix>/bin/node`; under Windows / some Linux distros
+  //     it lives at `<prefix>/node`. Try both parents.
+  const globalPrefixes: string[] = [];
+  if (npmConfigPrefix) globalPrefixes.push(npmConfigPrefix);
+  if (nodeExecPath) {
+    const execDir = dirname(nodeExecPath);            // e.g. /usr/local/bin
+    globalPrefixes.push(execDir);                      // Windows-style: <prefix>
+    globalPrefixes.push(dirname(execDir));             // POSIX-style: <prefix>/bin → <prefix>
+  }
+  for (const prefix of globalPrefixes) {
+    candidates.push(join(prefix, "lib", "node_modules", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"));
+    candidates.push(join(prefix, "node_modules", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"));
+  }
+  return candidates;
+}


### PR DESCRIPTION
Closes #1379

## 病根

`anet node start` 默认通过 npx 拉起 agent-node：

```
/home/vansin/.npm/_npx/<hash>/node_modules/@sleep2agi/agent-node/dist/cli.js
```

而 `resolveFeishuWorkerPath()` 的四个候选路径都基于 `import.meta.url` 做相对解析——它们全指向 npx 缓存树内部。**而 `@sleep2agi/agent-network` 不在 agent-node 的 package.json**（dependencies / peer / optional 都没有），npx 不会把它拉进缓存 ⇒ 全部落空，飞书通道静默失效。

## 修法

抽出纯函数 `computeFeishuWorkerCandidates(opts)`（新文件 `agent-node/src/feishu-worker-resolve.ts`），在原来 4 条候选之后追加 4 条 global-prefix 候选：

- `<npm_config_prefix>/lib/node_modules/…`（POSIX）
- `<npm_config_prefix>/node_modules/…`（Windows）
- `<dirname(process.execPath)>/…` × 两种（POSIX：<prefix>/bin/node；Windows：<prefix>/node）

**只加候选、不改优先级**：env override 仍最高，dev sibling 与已有 npm 布局全部保留。

## 见证

### 单元测试 7/7 green (`bun test src/feishu-worker-resolve.test.ts`)

| # | 测试 | 断言 |
|---|---|---|
| 1 | **witnessed-red** | 原 4 候选集在 npx 布局下对已放在全局前缀的 worker 返回 null（用测内 in-place 转写旧四候选） |
| 2 | green | `npm_config_prefix` 找到 |
| 3 | green | `process.execPath` 启发式 POSIX 布局找到 |
| 4 | green | `process.execPath` 启发式 Windows 布局找到 |
| 5 | env override | 优先级最高 |
| 6 | dev sibling | 无需 global-prefix 提示即可解析 |
| 7 | null 返回 | 全部候选缺失 → 返回 null，保留原 WARN 分支 |

### mutation 检验

用 sed 把 `computeFeishuWorkerCandidates` 里的 global-prefix 分支整块去掉 → **6/7 red**（唯一 pass 的是测内转写的旧四候选测试）。恢复 → 7/7 green。

### 完整套件回归

`bun test src/` = **1553 pass / 0 fail / 5567 expect / 121 files**。未破坏任何现有断言。

### 构建

`bun run build` 通过；`grep -c 'npm_config_prefix' dist/cli.js = 1` — 新符号进了 bundled 制品。

## 按内容搜过

`gh pr list --repo sleep2agi/agent-network --state all --search '<关键词>'`：

- `resolveFeishuWorkerPath` ⇒ **零命中**
- `feishu worker path` ⇒ 命中都是不相关旧 PR (#263 supervise / #1252 commhub routing / #548 docs 等)
- `ANET_FEISHU_WORKER_PATH` ⇒ **零命中**
- `1379` ⇒ **零命中**

⇒ 无同类 PR 在飞。

## 范围

只补路径解析——不动 supervise 逻辑、不动 spawn 参数、**不改 hub 上报能力**（issue 的建议 #3「找不到 worker 时把 `can_use_feishu=false` 上报」应另开 PR 与 #1353 系列一起做，这里只关"路径解析在最常见装法下静默失效"）。

## 关联

- 发现于 Vincent 拍板的「飞书 × codex-tui」实测
- 同族：#1353（在线但建不了节点）、app#196（按钮必然失败）—— **配置了的能力静默不可用**