### PR TITLE
fix(daemon): stop/start/delete 门铃加 SSE 重连补偿 (#1448 finding 1)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -6027,6 +6027,11 @@ async function processRestartOnly(): Promise<void> {
 //      markStable → backoff doubles` in supervise-child.test.ts pins
 //      this contract so a future patch can't re-introduce the hot loop.
 const recentlyHandledCreateRequestIds = new Set<string>();
+// #1448 — 与 create 同样的去重集合，stop/delete 与 start 各一套。live 门铃 handler
+// 和 SSE 重连补偿(reconcilePendingLifecycleRequestsOnConnect)共享它，防同一 request
+// 被两条路径各处理一次。
+const recentlyHandledStopRequestIds = new Set<string>();
+const recentlyHandledStartRequestIds = new Set<string>();
 async function connectSSE() {
   const sseUrl = `${COMMHUB_URL}/events/${encodeURIComponent(ALIAS)}`;
   const ABANDON_AFTER_MS = 60 * 60 * 1_000;  // 1h continuous failure → give up
@@ -6113,6 +6118,35 @@ async function connectSSE() {
                     ),
                   }).catch((e: any) => warn(`create-node pending reconcile failed: ${e?.message || e}`));
                 }).catch((e: any) => warn(`create-node-daemon import for reconcile failed: ${e?.message || e}`));
+              }
+              // #1448 — 同 create：拉本 daemon 名下 pending 的 stop/delete/start
+              // 请求，补回 SSE 断连期(hub 重启/网络抖/boot 窗口)漏掉的门铃。
+              // 注入 handleStop/StartDoorbell(deps 与下方 live 门铃处理一致)。
+              if (fileConfig.role === "host_supervisor") {
+                Promise.all([
+                  import("./runtime/lifecycle-reconcile.js"),
+                  import("./runtime/stop-daemon.js"),
+                  import("./runtime/start-daemon.js"),
+                ]).then(([{ reconcilePendingLifecycleRequestsOnConnect }, { handleStopDoorbell }, { handleStartDoorbell }]) => {
+                  return reconcilePendingLifecycleRequestsOnConnect({
+                    callCommHub,
+                    log: (m: string) => log(m),
+                    warn: (m: string) => warn(m),
+                    recentlyHandledStopRequestIds,
+                    recentlyHandledStartRequestIds,
+                    handleStopDoorbell: (event: { request_id: string }) => handleStopDoorbell(event, {
+                      callCommHub,
+                      log: (m: string) => log(m),
+                      warn: (m: string) => warn(m),
+                    }),
+                    handleStartDoorbell: (event: { request_id: string }) => handleStartDoorbell(event, {
+                      callCommHub,
+                      workDir: process.cwd(),
+                      log: (m: string) => log(m),
+                      warn: (m: string) => warn(m),
+                    }),
+                  });
+                }).catch((e: any) => warn(`lifecycle pending reconcile failed: ${e?.message || e}`));
               }
               continue;
             }
@@ -6201,30 +6235,42 @@ async function connectSSE() {
             // an unrecognized child_node_id acks 'noop_not_my_child'.
             if (ev.type === "stop_node" && fileConfig.role === "host_supervisor") {
               log(`← SSE stop_node ${ev.request_id || ""}`);
-              import("./runtime/stop-daemon.js").then(({ handleStopDoorbell }) => {
-                handleStopDoorbell(
-                  { request_id: ev.request_id },
+              // #1448 — 与重连补偿共享去重集合：live 门铃先占位,重连 reconcile 就
+              // 不会再重放同一 request。失败则移除,让下一次 connected 能重试。
+              const stopReqId: string = ev.request_id;
+              if (stopReqId && !recentlyHandledStopRequestIds.has(stopReqId)) {
+                recentlyHandledStopRequestIds.add(stopReqId);
+                import("./runtime/stop-daemon.js").then(({ handleStopDoorbell }) => handleStopDoorbell(
+                  { request_id: stopReqId },
                   {
                     callCommHub,
                     log: (m: string) => log(m),
                     warn: (m: string) => warn(m),
                   },
-                ).catch((e: any) => warn(`stop-daemon failed: ${e?.message || e}`));
-              }).catch((e: any) => warn(`stop-daemon import failed: ${e?.message || e}`));
+                )).catch((e: any) => {
+                  recentlyHandledStopRequestIds.delete(stopReqId);
+                  warn(`stop-daemon failed: ${e?.message || e}`);
+                });
+              }
             }
             if (ev.type === "start_node" && fileConfig.role === "host_supervisor") {
               log(`← SSE start_node ${ev.request_id || ""}`);
-              import("./runtime/start-daemon.js").then(({ handleStartDoorbell }) => {
-                handleStartDoorbell(
-                  { request_id: ev.request_id },
+              const startReqId: string = ev.request_id;
+              if (startReqId && !recentlyHandledStartRequestIds.has(startReqId)) {
+                recentlyHandledStartRequestIds.add(startReqId);
+                import("./runtime/start-daemon.js").then(({ handleStartDoorbell }) => handleStartDoorbell(
+                  { request_id: startReqId },
                   {
                     callCommHub,
                     workDir: process.cwd(),
                     log: (m: string) => log(m),
                     warn: (m: string) => warn(m),
                   },
-                ).catch((e: any) => warn(`start-daemon failed: ${e?.message || e}`));
-              }).catch((e: any) => warn(`start-daemon import failed: ${e?.message || e}`));
+                )).catch((e: any) => {
+                  recentlyHandledStartRequestIds.delete(startReqId);
+                  warn(`start-daemon failed: ${e?.message || e}`);
+                });
+              }
             }
             // RFC-028 P1 — provider probe daemon doorbell (host_supervisor only).
             if (ev.type === "probe_provider" && fileConfig.role === "host_supervisor") {

--- a/agent-node/src/runtime/lifecycle-reconcile.test.ts
+++ b/agent-node/src/runtime/lifecycle-reconcile.test.ts
@@ -1,0 +1,88 @@
+// #1448 — SSE 重连补偿 reconcile 的单测。
+//
+// 缺陷：pushEvent 无订阅者静默丢门铃 → node_stop_requests/node_start_requests 行
+// 永远 pending → 节点卡 stopping/deleting/starting。修复：每次 SSE connected 调
+// reconcilePendingLifecycleRequestsOnConnect，拉本 daemon 名下 pending 行、逐条重放
+// 门铃 handler。
+//
+// witnessed-red 判据：一条本应「永远卡 pending」的 stop/start 请求，reconcile 会把
+// 它的门铃重放出去（下面断言 handleStop/StartDoorbell 被以该 request_id 调用）。没有
+// reconcile（改前）这些 handler 一次都不会被调 → 请求永远 pending。去重与失败重试
+// 语义与 create 的 reconcile 一致。
+
+import { describe, expect, test } from "bun:test";
+import { reconcilePendingLifecycleRequestsOnConnect } from "./lifecycle-reconcile.js";
+
+function mkDeps(overrides: Partial<Parameters<typeof reconcilePendingLifecycleRequestsOnConnect>[0]> = {}) {
+  const stopCalls: string[] = [];
+  const startCalls: string[] = [];
+  const warns: string[] = [];
+  const logs: string[] = [];
+  const deps = {
+    callCommHub: async () => ({ ok: true, stop_requests: [], start_requests: [] }),
+    log: (m: string) => logs.push(m),
+    warn: (m: string) => warns.push(m),
+    handleStopDoorbell: async (e: { request_id: string }) => { stopCalls.push(e.request_id); },
+    handleStartDoorbell: async (e: { request_id: string }) => { startCalls.push(e.request_id); },
+    ...overrides,
+  };
+  return { deps, stopCalls, startCalls, warns, logs };
+}
+
+describe("#1448 reconcilePendingLifecycleRequestsOnConnect", () => {
+  test("replays every pending stop/delete + start doorbell the hub returns", async () => {
+    const { deps, stopCalls, startCalls } = mkDeps({
+      callCommHub: async (tool) => {
+        expect(tool).toBe("list_my_pending_lifecycle_requests");
+        return {
+          ok: true,
+          stop_requests: [{ request_id: "sr_a", action: "stop" }, { request_id: "sr_b", action: "delete" }],
+          start_requests: [{ request_id: "str_c" }],
+        };
+      },
+    });
+    await reconcilePendingLifecycleRequestsOnConnect(deps as any);
+    expect(stopCalls).toEqual(["sr_a", "sr_b"]);   // stop + delete both replayed via stop doorbell
+    expect(startCalls).toEqual(["str_c"]);
+  });
+
+  test("empty pending set → no doorbell replays (steady-state no-op)", async () => {
+    const { deps, stopCalls, startCalls, logs } = mkDeps();
+    await reconcilePendingLifecycleRequestsOnConnect(deps as any);
+    expect(stopCalls).toEqual([]);
+    expect(startCalls).toEqual([]);
+    expect(logs.some((l) => l.includes("reconcile handled"))).toBe(false);
+  });
+
+  test("hub ok:false → warns, replays nothing (no crash)", async () => {
+    const { deps, stopCalls, warns } = mkDeps({
+      callCommHub: async () => ({ ok: false, error: "daemon_token_required" }),
+    });
+    await reconcilePendingLifecycleRequestsOnConnect(deps as any);
+    expect(stopCalls).toEqual([]);
+    expect(warns.some((w) => w.includes("daemon_token_required"))).toBe(true);
+  });
+
+  test("shared dedup set: a request already in-flight (live doorbell) is NOT re-replayed", async () => {
+    const seen = new Set<string>(["sr_live"]);
+    const { deps, stopCalls } = mkDeps({
+      recentlyHandledStopRequestIds: seen,
+      callCommHub: async () => ({ ok: true, stop_requests: [{ request_id: "sr_live" }, { request_id: "sr_new" }], start_requests: [] }),
+    });
+    await reconcilePendingLifecycleRequestsOnConnect(deps as any);
+    expect(stopCalls).toEqual(["sr_new"]);   // sr_live skipped (live handler owns it), sr_new replayed
+    expect(seen.has("sr_new")).toBe(true);
+  });
+
+  test("handler failure → id removed from dedup set so the NEXT connect can retry", async () => {
+    const seen = new Set<string>();
+    const { deps, warns } = mkDeps({
+      recentlyHandledStopRequestIds: seen,
+      callCommHub: async () => ({ ok: true, stop_requests: [{ request_id: "sr_boom" }], start_requests: [] }),
+      handleStopDoorbell: async () => { throw new Error("get_stop_request timeout"); },
+    });
+    await reconcilePendingLifecycleRequestsOnConnect(deps as any);
+    expect(seen.has("sr_boom")).toBe(false);   // retryable next reconnect
+    expect(warns.some((w) => w.includes("sr_boom"))).toBe(true);
+  });
+});

--- a/agent-node/src/runtime/lifecycle-reconcile.ts
+++ b/agent-node/src/runtime/lifecycle-reconcile.ts
@@ -1,0 +1,87 @@
+// #1448 — SSE 重连/boot 补偿：stop/delete/start 门铃。
+//
+// hub 的 pushEvent 是纯内存 fan-out：派发 stop/start 门铃那刻若本 daemon 没有
+// live SSE 订阅者(hub 重启 / 网络抖 / daemon boot 的 ~3s 窗口)就静默丢弃、不入队。
+// 于是 node_stop_requests / node_start_requests 的行永远停在 pending、hub 侧节点
+// 卡死 stopping/deleting/starting——delete 有 #1286 的 5min force 逃生，stop/start
+// 连那个都没有。
+//
+// create 早有对称保护(reconcilePendingCreateRequestsOnConnect + hub
+// list_my_pending_create_requests，#1394)；本模块把同一套补偿镜像到
+// stop/delete/start：每次 SSE connected 时拉一遍本 daemon 名下的 pending 生命周期
+// 请求，逐条重放对应的门铃 handler(handleStopDoorbell / handleStartDoorbell)。
+//
+// handler 走注入而非直接 import：① 与 create 的做法一致(它注入
+// handleCreateNodeDoorbell)；② 避免本模块耦合 stop-daemon + start-daemon 两个
+// 运行时；③ 单测可注入假 handler 直接验重放/去重逻辑。
+//
+// 幂等由两层保证：hub 只返回 status='pending' 的行——handler 一旦 pull
+// (get_stop_request/get_start_request 把行标 delivered)该行就不再被列出；再叠一层
+// recentlyHandled 去重集合(与 live 门铃 handler 共享)防「重连 reconcile 与残留 live
+// 门铃同时处理同一行」的竞态。
+
+export interface ReconcilePendingLifecycleDeps {
+  callCommHub: (tool: string, args: Record<string, unknown>) => Promise<any>;
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
+  // 与 live stop/start 门铃 handler 共享的去重集合，避免同一 request 被
+  // 重连补偿和残留 live 门铃各处理一次。可选：不传则仅靠 hub 的 pending 过滤。
+  recentlyHandledStopRequestIds?: Set<string>;
+  recentlyHandledStartRequestIds?: Set<string>;
+  // 注入的门铃 handler。cli 在挂载处用真实 deps 包好 handleStopDoorbell /
+  // handleStartDoorbell 再传进来。
+  handleStopDoorbell: (event: { request_id: string }) => Promise<void>;
+  handleStartDoorbell: (event: { request_id: string }) => Promise<void>;
+}
+
+interface ListPendingLifecycleResult {
+  ok?: boolean;
+  error?: string;
+  stop_requests?: Array<{ request_id?: string }>;
+  start_requests?: Array<{ request_id?: string }>;
+}
+
+async function replayEach(
+  rows: Array<{ request_id?: string }>,
+  seen: Set<string> | undefined,
+  handle: (event: { request_id: string }) => Promise<void>,
+  warn: (m: string) => void,
+  label: string,
+): Promise<number> {
+  let handled = 0;
+  for (const row of rows) {
+    const requestId = typeof row?.request_id === "string" ? row.request_id : "";
+    if (!requestId) continue;
+    if (seen?.has(requestId)) continue;
+    seen?.add(requestId);
+    try {
+      await handle({ request_id: requestId });
+      handled += 1;
+    } catch (e: any) {
+      // 失败就从去重集合里放回来，下一次 connected 还能重试(与 create 一致)。
+      seen?.delete(requestId);
+      warn(`[lifecycle] pending ${label} reconcile handler failed for ${requestId}: ${e?.message || e}`);
+    }
+  }
+  return handled;
+}
+
+export async function reconcilePendingLifecycleRequestsOnConnect(
+  deps: ReconcilePendingLifecycleDeps,
+): Promise<void> {
+  const res: ListPendingLifecycleResult = await deps.callCommHub("list_my_pending_lifecycle_requests", {});
+  if (!res?.ok) {
+    deps.warn(`[lifecycle] pending reconcile failed: ${res?.error || "unknown"}`);
+    return;
+  }
+  const stops = Array.isArray(res.stop_requests) ? res.stop_requests : [];
+  const starts = Array.isArray(res.start_requests) ? res.start_requests : [];
+
+  const handledStop = await replayEach(stops, deps.recentlyHandledStopRequestIds, deps.handleStopDoorbell, deps.warn, "stop/delete");
+  const handledStart = await replayEach(starts, deps.recentlyHandledStartRequestIds, deps.handleStartDoorbell, deps.warn, "start");
+
+  const total = handledStop + handledStart;
+  if (total > 0) {
+    deps.log(`[lifecycle] pending reconcile handled ${total} request(s) (stop/delete=${handledStop}, start=${handledStart})`);
+  }
+}

--- a/server/src/stop-delete-node.test.ts
+++ b/server/src/stop-delete-node.test.ts
@@ -731,6 +731,81 @@ describe("list_my_pending_create_requests HANDLER (#1362 SSE reconnect compensat
   });
 });
 
+describe("list_my_pending_lifecycle_requests HANDLER (#1448 SSE reconnect compensation)", () => {
+  function seedStop(reqId: string, daemonId: string, status: string, action: string, ageMs: number) {
+    db.run(
+      `INSERT INTO node_stop_requests (request_id, network_id, daemon_node_id, child_node_id,
+         child_alias, action, delete_config, created_by_token, status, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, 'tok_test', ?7, ?8)`,
+      [reqId, NET_A, daemonId, CHILD_A_ID, CHILD_A_ALIAS, action, status, Date.now() - ageMs],
+    );
+  }
+  // child_node_id parameterized: node_start_requests has a partial-unique
+  // index on child_node_id WHERE status IN ('pending','delivered'), so the
+  // "mine" and "other" pending start rows must target different children.
+  function seedStart(reqId: string, daemonId: string, childId: string, status: string, ageMs: number) {
+    db.run(
+      `INSERT INTO node_start_requests (request_id, network_id, daemon_node_id, child_node_id,
+         child_alias, created_by_token, status, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 'tok_test', ?6, ?7)`,
+      [reqId, NET_A, daemonId, childId, CHILD_A_ALIAS, status, Date.now() - ageMs],
+    );
+  }
+
+  test("daemon-bound caller gets only its own PENDING stop/delete + start (excludes delivered + other daemon)", async () => {
+    setupAlphaNetwork();
+    const otherDaemonId = "node_sd_daemon_other";
+    seedDaemon(NET_A, otherDaemonId, "sd-daemon-other", USER_A_ID, "tok_sd_daemon_other");
+    // mine — should be returned (stop + delete, oldest first)
+    seedStop("sr_pending_stop", DAEMON_A_ID, "pending", "stop", 30);
+    seedStop("sr_pending_delete", DAEMON_A_ID, "pending", "delete", 20);
+    seedStart("str_pending_mine", DAEMON_A_ID, CHILD_A_ID, "pending", 25);
+    // excluded — delivered (already pulled) + other daemon's pending
+    seedStop("sr_delivered_mine", DAEMON_A_ID, "delivered", "stop", 40);
+    seedStop("sr_pending_other", otherDaemonId, "pending", "stop", 10);
+    seedStart("str_pending_other", otherDaemonId, "node_sd_child_other", "pending", 10);
+
+    const daemonTools = buildHandlers(USER_A_ID, true, DAEMON_A_TOK, NET_A);
+    const res = await call(daemonTools.list_my_pending_lifecycle_requests, {});
+    expect(res.ok).toBe(true);
+    expect(res.stop_count).toBe(2);
+    expect((res.stop_requests as Array<{ request_id: string }>).map(x => x.request_id))
+      .toEqual(["sr_pending_stop", "sr_pending_delete"]);   // oldest-first, action preserved
+    expect(res.start_count).toBe(1);
+    expect((res.start_requests as Array<{ request_id: string }>).map(x => x.request_id))
+      .toEqual(["str_pending_mine"]);
+  });
+
+  // Witnessed-red 的核心链：真实 stop_node 派发时 daemon 无 SSE 订阅者 →
+  // pushEvent 静默丢门铃 → 行卡 pending / 节点卡 stopping（缺陷态）。修复后这条
+  // pending 行会被 list_my_pending_lifecycle_requests 列出 → 重连 reconcile 能重放。
+  // 改前（无此工具）该行永远无人发现、节点永久卡 stopping。
+  test("stuck-pending after a dropped doorbell IS surfaced for reconnect replay", async () => {
+    setupAlphaNetwork();
+    const userTools = buildHandlers(USER_A_ID);
+    // 无 SSE 订阅者：dispatch 建 pending 行 + pushEvent 丢弃（测试进程里没有 client）
+    const disp = await call(userTools.stop_node, { child_node_id: CHILD_A_ID, daemon_node_id: DAEMON_A_ID, network_id: NET_A });
+    expect(disp.ok).toBe(true);
+    const reqId = disp.request_id as string;
+    // 缺陷态：行 pending、节点 stopping（门铃没送达，无人推进）
+    const row = db.get<{ status: string }>("SELECT status FROM node_stop_requests WHERE request_id = ?1", reqId);
+    expect(row?.status).toBe("pending");
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("stopping");
+    // 修复：pending 行经新工具对本 daemon 可见 → 重连补偿能拿到并重放
+    const daemonTools = buildHandlers(USER_A_ID, true, DAEMON_A_TOK, NET_A);
+    const r = await call(daemonTools.list_my_pending_lifecycle_requests, {});
+    expect(r.ok).toBe(true);
+    expect((r.stop_requests as Array<{ request_id: string }>).map(x => x.request_id)).toContain(reqId);
+  });
+
+  test("non-daemon caller (utok) refused", async () => {
+    setupAlphaNetwork();
+    const userTools = buildHandlers(USER_A_ID);
+    const r = await call(userTools.list_my_pending_lifecycle_requests, {});
+    expect(r.ok).toBe(false);
+  });
+});
+
 // ─── PR1.2a — restart_node resets lifecycle_state ──────────────────
 //
 // 通信龙 #346 ack latent: without this, a stopped node restart-ed via

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3320,6 +3320,53 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     },
   );
 
+  // #1448 — stop/delete/start 门铃的 SSE 重连补偿，镜像 create 的
+  // list_my_pending_create_requests(#1394)。pushEvent(push.ts) 是纯内存
+  // fan-out：派发门铃那刻若 daemon 无 live SSE 订阅者(hub 重启/网络抖/boot
+  // 窗口)就静默丢弃、不入队，于是 node_stop_requests/node_start_requests 的行
+  // 永远停在 pending、节点卡死 stopping/deleting/starting。daemon 每次 SSE
+  // connected 调本工具把漏掉的门铃拉回来重放(reconcilePendingLifecycleRequestsOnConnect)。
+  //
+  // 统一一个工具返回两张表的 pending 行(stop 表用 action 区分 stop/delete)，
+  // 省一次往返。鉴权同 create：token-bound daemon 身份(alias 不是安全边界)，
+  // 只返回绑定到本 daemon + 本网络的 pending 行。
+  server.tool(
+    "list_my_pending_lifecycle_requests",
+    "Daemon lists pending stop/delete/start requests bound to itself for SSE reconnect compensation. Mirrors list_my_pending_create_requests (#1394/#1448).",
+    {},
+    async () => {
+      const callerDaemon = resolveCallerDaemonTokenBound();
+      if (!callerDaemon.ok) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: callerDaemon.error }) }] };
+      }
+      const stop_requests = db.all<{ request_id: string; action: string; child_node_id: string; child_alias: string; created_at: number }>(
+        `SELECT request_id, action, child_node_id, child_alias, created_at
+           FROM node_stop_requests
+          WHERE daemon_node_id = ?1
+            AND network_id = ?2
+            AND status = 'pending'
+          ORDER BY created_at ASC`,
+        callerDaemon.daemonNodeId, callerDaemon.networkId,
+      );
+      const start_requests = db.all<{ request_id: string; child_node_id: string; child_alias: string; created_at: number }>(
+        `SELECT request_id, child_node_id, child_alias, created_at
+           FROM node_start_requests
+          WHERE daemon_node_id = ?1
+            AND network_id = ?2
+            AND status = 'pending'
+          ORDER BY created_at ASC`,
+        callerDaemon.daemonNodeId, callerDaemon.networkId,
+      );
+      return { content: [{ type: "text" as const, text: JSON.stringify({
+        ok: true,
+        stop_count: stop_requests.length,
+        start_count: start_requests.length,
+        stop_requests,
+        start_requests,
+      }) }] };
+    },
+  );
+
   // §2.5 step 3 — daemon-facing pull. Returns full spec + env_blob +
   // child_ntok in one shot. Map evicted on take (one-shot consume).
   //

--- a/tests/test629-mcp-schema-policy/probe.ts
+++ b/tests/test629-mcp-schema-policy/probe.ts
@@ -15,7 +15,7 @@ const expectedTools = [
   "send_ack", "retry_task", "get_task", "list_tasks",
   "cancel_task", "reassign_task", "send_desktop_message", "broadcast", "get_completions",
   "update_node_config", "get_config_update", "ack_config_update", "restart_node",
-  "list_host_supervisors", "create_node", "list_my_pending_create_requests", "get_create_request", "ack_create_request",
+  "list_host_supervisors", "create_node", "list_my_pending_create_requests", "list_my_pending_lifecycle_requests", "get_create_request", "ack_create_request",
   "stop_node", "delete_node", "get_stop_request", "ack_stop_request",
   "start_node", "get_start_request", "ack_start_request",
   "list_my_children", "upsert_network_secret", "list_network_secrets", "upsert_provider",


### PR DESCRIPTION
Addresses #1448 **finding 1** (HIGH, systemic). Findings 2/3 verified below, proposed as fast-follow PRs.

## 缺陷（finding 1，CONFIRMED）

`pushEvent`（server/src/push.ts:410）是纯内存 fan-out：派发门铃那刻若目标 daemon **没有 live SSE 订阅者**（hub 重启 / 网络抖 / daemon boot 的 ~3s 窗口）就 `if (!arr || arr.length === 0) return` **静默丢弃、不入队**。

`create_node` 早有对称保护（#1394）：daemon 每次 SSE `connected` 调 `reconcilePendingCreateRequestsOnConnect`（cli.ts:6095）拉 hub 的 `list_my_pending_create_requests`（tools.ts:3302）把漏掉的门铃补回。

**stop_node / delete_node / start_node 无等价物**（grep `list_my_pending_stop/start` 为空；重连 handler 只 reconcile create；boot rebuild 只重建 child map）→ `node_stop_requests` / `node_start_requests` 行永远 `pending`、节点卡死 `stopping`/`deleting`/`starting`。delete 尚有 #1286 的「5min 后 force」逃生，**stop/start 连那个都没有**。

## 修复（镜像 #1394）

| 层 | 改动 |
|---|---|
| **hub** `server/src/tools.ts` | 新增 `list_my_pending_lifecycle_requests`：token-bound daemon 身份（alias 非安全边界）拉本 daemon + 本网络名下 `status='pending'` 的 stop（含 delete，用 `action` 区分）+ start 行，一次往返返回两张表 |
| **daemon** `agent-node/src/runtime/lifecycle-reconcile.ts`（新） | `reconcilePendingLifecycleRequestsOnConnect`：拉 pending 行、逐条重放 `handleStopDoorbell`/`handleStartDoorbell`。handler **注入**（同 create，不耦合 stop-daemon+start-daemon 两运行时、可单测） |
| **cli** `agent-node/src/cli.ts` | 重连 `connected` handler 挂载 reconcile；live stop/start 门铃与 reconcile **共享去重集合** `recentlyHandledStop/StartRequestIds`，防同一 request 双重处理，失败则从集合移除以便下次 connected 重试 |

**幂等两层**：① hub 只返 `pending`——handler 一旦 pull（`get_stop_request`/`get_start_request` 把行标 `delivered`）该行就不再被列出；② 去重集合。

## Witnessed-red

- **daemon reconcile 单测**（`lifecycle-reconcile.test.ts`，5/5）：给一批 pending stop/delete/start 行 → 断言 `handleStop/StartDoorbell` 被以正确 request_id 重放；空集不动；`ok:false` 只 warn 不炸；去重集合命中不重放；handler 失败则移除以便重试。**改前（无此机制）这些 handler 一次都不会被调 → 请求永远 pending。**
- **hub 工具测**（`stop-delete-node.test.ts`，新增 3 测）：
  - scoping：只返本 daemon 的 pending，排除 `delivered` + 他 daemon 的行（oldest-first、`action` 保留）。
  - **stuck→surfaced 链**：真实 `stop_node` 派发、测试进程无 SSE client → `pushEvent` 丢门铃 → 断言行 `pending` + 节点 `stopping`（缺陷态）→ 断言 `list_my_pending_lifecycle_requests` 返回该 request_id（重连能拿到重放）。
  - 非 daemon（utok）拒。
  - **判别力已证**：把工具 WHERE 的 `status='pending'` 临时改成 `'delivered'`，上面两条 hub 测试立即变红（附带 create/get_stop 同族红）。

## 验证
- `tsc --noEmit` server + agent-node 均 0 error
- 新增：daemon reconcile 5/5、hub 工具 3/3
- 无回归：`stop-delete-node` 35/35、`stop-daemon` 22/22、`start-daemon` 6/6、`create-node` 14/14（`list_my_pending_create` 未受影响）、`doc-symbol-pins` OK（漂移 0）

## Findings 2/3（已核实，建议 fast-follow，不在本 PR）
- **2 [CONFIRMED]** `node_start_requests` 无 stale reaper：`update_node_config`（tools.ts:2696）/`restart_node`（2893）有 60s reaper、delete 有 5min force，**start 都没有** → 门铃丢或 daemon 在 UPDATE `starting` 后死掉 → 节点钉死 `starting`。finding 1 的重连补偿覆盖了「门铃丢（行仍 pending）」这一主因；「已 pull 后 daemon 死」这条独立缺口需一个 hub 侧 reaper，另开 PR。
- **3 [CONFIRMED]** stop 无 map entry 时 ack `noop_not_my_child`（stop-daemon.ts:201）留 hub 卡 `stopping`——#1286 只把 delete 修成 sweep+ack `stopped` 收敛（216+），对称的 stop 路径被留着。属 #1286 孪生，需自己的 witnessed-red（sweep 掉可能仍在跑的 child 再 ack stopped），另开 PR。

一 PR 一机制、各自独立 witnessed-red，故拆分。
