### PR TITLE
fix(opencode-copresence): #1451 parseMessageReply — synthesize marker for tool-only turns

### DIFF
--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   OPENCODE_COMMHUB_TOKEN_ENV,
   openVettedOpenCodeCopresence,
+  parseMessageReply,
   requireOpenCodeCopresenceModel,
   wireOpenCodeCommhubMcp,
   wireOpenCodeDefaultModel,
@@ -423,4 +424,86 @@ describe("OpenCode native serve+attach copresence", () => {
       }
     }
   }, 5_000);
+});
+
+// #1451: parseMessageReply used to return "" when a completed opencode turn
+// contained only non-text parts (a pure tool-call turn). The caller then
+// threw "returned no assistant text", reporting a valid outcome to CommHub
+// as a failure. The fix synthesizes a marker naming the emitted part types
+// so the caller always receives a non-empty reply and the throw was removed.
+//
+// The part-type universe checked here comes from opencode 1.18.1's own
+// OpenAPI /doc schema (probed 2026-08-30 against a real 1.18.1 binary):
+// TextPart is one of 13 variants (Tool, Reasoning, File, Patch,
+// StepStart, StepFinish, Snapshot, Agent, Retry, Compaction, Subtask,
+// FilePartSource[Text]). A completed turn with zero TextPart is a
+// canonical shape, not a bug.
+describe("parseMessageReply (#1451)", () => {
+  test("joins and trims text when TextPart present (existing behavior preserved)", () => {
+    const msg = { parts: [
+      { type: "step-start" },
+      { type: "text", text: "hello " },
+      { type: "text", text: "world  " },
+      { type: "step-finish" },
+    ] };
+    expect(parseMessageReply(msg)).toBe("hello world");
+  });
+
+  test("tool-only turn returns non-empty marker naming the tool part (would have thrown at caller before #1451)", () => {
+    const msg = { parts: [
+      { type: "step-start" },
+      { type: "tool", tool: "bash", state: { output: "ok" } },
+      { type: "step-finish" },
+    ] };
+    const reply = parseMessageReply(msg);
+    // The critical assertion — the whole point of the fix: not "" so caller
+    // does not throw and CommHub does not see a false failure.
+    expect(reply.length).toBeGreaterThan(0);
+    expect(reply).toContain("tool");
+    // step-{start,finish} are book-ends and are deliberately omitted from
+    // the marker (they say nothing about what the model did on their own).
+    expect(reply).not.toContain("step-start");
+    expect(reply).not.toContain("step-finish");
+    expect(reply).toContain("no text");
+  });
+
+  test("multiple non-text part types are deduped, sorted, and named", () => {
+    const msg = { parts: [
+      { type: "reasoning", text: "thinking" },
+      { type: "tool", tool: "read" },
+      { type: "tool", tool: "grep" },
+      { type: "patch" },
+      { type: "reasoning", text: "more thinking" },
+    ] };
+    const reply = parseMessageReply(msg);
+    // Dedup: "reasoning" and "tool" appear twice each; marker names each once.
+    expect(reply).toContain("patch");
+    expect(reply).toContain("reasoning");
+    expect(reply).toContain("tool");
+    // Sorted (alphabetical) — stable output across runs regardless of
+    // whatever order opencode happens to emit part types in.
+    const patchIdx = reply.indexOf("patch");
+    const reasoningIdx = reply.indexOf("reasoning");
+    const toolIdx = reply.indexOf("tool");
+    expect(patchIdx).toBeLessThan(reasoningIdx);
+    expect(reasoningIdx).toBeLessThan(toolIdx);
+  });
+
+  test("empty parts array or missing parts still returns non-empty marker (never throws)", () => {
+    expect(parseMessageReply({ parts: [] })).toBe("[opencode: assistant returned no reply]");
+    expect(parseMessageReply({})).toBe("[opencode: assistant returned no reply]");
+    expect(parseMessageReply(null)).toBe("[opencode: assistant returned no reply]");
+    expect(parseMessageReply(undefined)).toBe("[opencode: assistant returned no reply]");
+  });
+
+  test("text falsiness — a TextPart with empty text falls through to the marker path, not empty return", () => {
+    const msg = { parts: [
+      { type: "text", text: "   " },  // whitespace-only trims to ""
+      { type: "tool", tool: "bash" },
+    ] };
+    // Whitespace-only text is treated as "no text", so we still get the
+    // non-text marker rather than an empty reply.
+    const reply = parseMessageReply(msg);
+    expect(reply).toContain("tool");
+  });
 });

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -304,14 +304,43 @@ async function waitUntilSessionIdle(
   throw new Error(`OpenCode session remained busy for ${timeoutMs}ms`);
 }
 
-function parseMessageReply(message: any): string {
-  const parts: string[] = [];
+// OpenCode 1.18.1 message parts are a 13-variant discriminated union (per its
+// OpenAPI /doc: TextPart, ToolPart, ReasoningPart, FilePart, PatchPart,
+// StepStartPart, StepFinishPart, SnapshotPart, AgentPart, RetryPart,
+// CompactionPart, SubtaskPart, FilePartSource[Text]). A completed assistant
+// turn can legitimately have zero TextParts — a pure tool-call turn is the
+// canonical example. Reporting that shape as a failure to CommHub (which is
+// what the caller used to do when this returned "") turned a valid outcome
+// into a false red on the fleet dashboard; see #1451.
+//
+// Contract now: always returns a non-empty string. If any TextPart is
+// present, returns the joined+trimmed text (unchanged behavior). Otherwise
+// returns a bracketed marker naming the non-text part types the model
+// emitted, so the network sees "assistant did work but did not reply in
+// text" rather than an empty reply that downstream layers might silently
+// drop.
+export function parseMessageReply(message: any): string {
+  const textOut: string[] = [];
+  const nonTextTypes: string[] = [];
   for (const part of message?.parts ?? []) {
     if (part?.type === "text" && typeof part.text === "string") {
-      parts.push(part.text);
+      textOut.push(part.text);
+      continue;
+    }
+    if (typeof part?.type === "string" && part.type !== "step-start" && part.type !== "step-finish") {
+      // step-{start,finish} are paired book-ends OpenCode emits around every
+      // reply. On their own they say nothing about what the model did, so
+      // they are omitted from the fallback marker to keep it informative.
+      nonTextTypes.push(part.type);
     }
   }
-  return parts.join("").trim();
+  const text = textOut.join("").trim();
+  if (text) return text;
+  if (nonTextTypes.length > 0) {
+    const unique = Array.from(new Set(nonTextTypes)).sort();
+    return `[opencode: assistant responded with ${unique.join(", ")} (no text)]`;
+  }
+  return "[opencode: assistant returned no reply]";
 }
 
 function parseModelRef(model: string | undefined): { providerID: string; modelID: string } | undefined {
@@ -534,10 +563,12 @@ export async function openVettedOpenCodeCopresence(
           // idle admission or before an unconfirmed POST.
           evidence?.onSubmitted?.();
           evidence?.onConsumed?.();
+          // parseMessageReply now always returns a non-empty string (either
+          // the joined text or a marker naming the non-text part types the
+          // model emitted). #1451: the old `if (!replyText) throw` here
+          // turned any pure tool-call turn — a valid completed opencode
+          // outcome — into a false failure report on CommHub. Removed.
           const replyText = parseMessageReply(message);
-          if (!replyText) {
-            throw new Error("OpenCode POST /session/:id/message returned no assistant text");
-          }
           return {
             replyText,
             stdout: JSON.stringify(message),

--- a/docs/analysis/opencode-copresence-serve-exit-1451.md
+++ b/docs/analysis/opencode-copresence-serve-exit-1451.md
@@ -1,0 +1,66 @@
+# opencode-copresence serve-exit design note (#1451 finding #2)
+
+**Pinned to `origin/main = 4f9d51f2` (2026-08-30).** Re-read the cited lines against the current tree before acting on this — if the file has moved, the description of the failure mode is stale.
+
+## The finding, restated
+
+`agent-node/src/runtime/opencode-copresence/runtime.ts:589`:
+
+```ts
+child.once("exit", (code, signal) => {
+  if (!closed) warn(`[opencode-copresence] serve exited code=${code} signal=${signal}; next task must reopen`);
+});
+```
+
+When `opencode serve` exits mid-life (crash, OOM, host restart, opencode upgrade), the runtime does exactly one observable thing: emits a warn line. Nothing else recovers state.
+
+The next inbound task then reaches `ensureOpencodeCopresenceRuntime` in `agent-node/src/cli.ts:3335`:
+
+```ts
+if (opencodeCopresenceSession?.isRunning) return opencodeCopresenceSession;
+// … cleanup …
+opencodeCopresenceSession = null;
+// … openOpenCodeCopresenceRuntime({...})   // <-- new opencode serve, new session id
+```
+
+Which spawns a **fresh** `opencode serve` and gets a **new** session id back from `POST /session`. The runtime's `onSession` callback overwrites `opencodeSessionId` and calls `writebackSession(id)`, so the node's config now points at the new session.
+
+**But the human TUI is attached to the old, dead session id** (via `opencode-attach.sh` written at open time). It has no signal that the server it was talking to is gone, and no way to follow the node onto the new session.
+
+## Why the other two co-presence runtimes don't have this shape
+
+- **grok** (`agent-node/src/runtime/grok-build-acp/resume-hint.ts`, 194L): on resume, the runtime prepends a curated context block to the LLM's next prompt naming any outbound tasks that were in-flight when it stopped. The session identity is durable (grok owns it), and the network side survives a restart.
+- **codex-app-server** (`agent-node/src/runtime/codex-app-server/runtime.ts:116, 211`): a persisted `codexThreadId` is loaded on boot; the bridge either resumes that exact thread on `codex app-server` or falls back to a fresh one and writes the adopted id back. The human `codex --remote` TUI is attached to the same thread the network side just resumed — so a serve restart is invisible to the human.
+
+opencode has neither. The 1.18.1 REST surface (per its OpenAPI `/doc`) does expose `POST /session` and `GET /session/:id`, but does not offer a way for a client to "attach me to whatever id is currently live" — the id is what identifies the session and the TUI's attach script bakes it in.
+
+## Should this be fixed by adding resume?
+
+**Recommendation: NOT NOW, and the tradeoff is worth stating explicitly rather than filed away.**
+
+**Arguments for adding resume:**
+
+- Consistency with grok + codex — makes the three co-presence runtimes shaped the same way; less lore to remember.
+- Serve exits happen for benign reasons (opencode binary upgrade, disk full then freed, host reboot in a cluster) and a silent orphan is a bad UX for the human.
+
+**Arguments against, at current data:**
+
+1. **The observable frequency is unknown.** No one has produced a case where a human TUI silently went dark on us because of a serve exit — the finding is a code-read, not a report. Fixing a rare unmeasured problem carries the risk that the fix introduces a more common one.
+2. **The 1.18.1 REST surface does not offer a clean resume primitive.** Any attempt to bind the human TUI to a different session id post-hoc requires either (a) coordination through the TUI's own state — which opencode 1.18.1 does not expose as an API — or (b) killing the human TUI on serve exit and letting a wrapper script reopen it against the new session. Option (b) is a materially different UX from what humans get today (a stable TUI window across restarts) and needs a decision, not a quiet ship.
+3. **The current outage mode is at least loud.** The warn line lands in the node log with a specific string; adding a resume shim also adds the failure modes of the shim itself.
+
+**Proposed instead:** add a lightweight signal at the *observation* level, not the *recovery* level:
+
+- On the `child.once("exit")` handler, in addition to the warn, publish a notice to CommHub — one line naming the exited session id and that the human TUI on that node is now orphaned. Cheap (~5 lines), gives fleet observers a chance to react manually, does not touch the resume gap.
+
+This is a smaller step than resume and it makes the frequency measurable — after a few weeks we know whether this actually happens often enough to justify the resume design work.
+
+## What was NOT done in this branch
+
+- No live probe of the serve-exit path (would require killing `opencode serve` mid-session on a real node, and the dispatch red-line says 不碰生产 — a controlled probe on a fresh isolated node would need its own setup effort out of scope for this PR).
+- No code change under finding #2. The signal-on-exit suggestion above is a follow-up if the fleet wants it.
+
+## Related
+
+- Finding #1 (`parseMessageReply` false failure) — fixed in this PR; witnessed-red covered in `agent-node/src/runtime/opencode-copresence/runtime.test.ts`.
+- opencode 1.18.1 OpenAPI schema was probed (2026-08-30) against a fresh isolated install to confirm the `Message.parts` shape used by finding #1's tests.


### PR DESCRIPTION
Fixes #1451 (finding #1: `parseMessageReply` false failure on tool-only turns). Includes finding #2 as a design memo (no code change).

Dispatch: 通信龙 task_id `4ee00252`, pinned to `origin/main = 4f9d51f2`. Both premises verified verbatim at that pin before touching any code.

**Content search performed (per team rule):** `gh pr list --repo sleep2agi/agent-network --state all --search "parseMessageReply"` and `--search "opencode-copresence runtime"` — zero prior PR touching this parse layer. This is the first fix in the space.

## Finding #1 — parseMessageReply false failure

**Root cause.** `runtime.ts:307-315` collected only `TextPart`; `runtime.ts:537-539` `throw`-ed if the collected text was empty. opencode 1.18.1's OpenAPI schema (probed 2026-08-30 against a fresh isolated install) defines a **13-variant** `Part` union — `TextPart` is one of them, alongside `ToolPart`, `ReasoningPart`, `FilePart`, `PatchPart`, `StepStart/FinishPart`, `SnapshotPart`, `AgentPart`, `RetryPart`, `CompactionPart`, `SubtaskPart`, `FilePartSource[Text]`. A completed assistant turn made entirely of tool calls (canonical shape when the model decides "call tool, then wait for result before speaking") is a **valid** completed opencode outcome — the runtime was reporting it to CommHub as a failure.

**Fix.**
- `parseMessageReply` now always returns a non-empty string. TextPart present → joined+trimmed text (unchanged). Otherwise → a bracketed marker naming the non-text part types the model emitted, e.g. `[opencode: assistant responded with reasoning, tool (no text)]`. `step-start` / `step-finish` are book-ends that always fire; they are omitted from the marker so it stays informative.
- Caller's `throw` at `runtime.ts:537-539` removed — parseMessageReply's contract (always non-empty) makes it dead code.

**Witnessed-red proof (pure function, zero hub).** 5 tests added in `runtime.test.ts`. Verified against a temp revert that keeps the `export parseMessageReply` line intact but restores the original 8-line body:

```
Pre-fix body:  1 pass / 4 fail / 5 expect() calls
Post-fix body: 5 pass / 0 fail / 16 expect() calls
```

The one test that passes on both is the "existing behavior preserved" case (text-only message returns joined+trimmed text). Four new tests capture the shape the bug produced (tool-only, mixed non-text, empty parts / null / undefined, whitespace-only text). Each fails on the pre-fix body with a specific assertion (`expect(reply.length).toBeGreaterThan(0)` receives `0`, `expect(reply).toContain("tool")` receives `""`, etc.) — no import-level or shape-level failure.

## Finding #2 — serve-exit → human TUI orphan

**No code change in this PR.** Design memo at `docs/analysis/opencode-copresence-serve-exit-1451.md` covers:

- Confirmed failure mode via code-read (grok has `resume-hint.ts` L194; codex has `codexAppServerThreadId` persist+resume; opencode has neither — on serve exit, `cli.ts:3341` nulls the session and `openOpenCodeCopresenceRuntime` creates a fresh id).
- Reason not to add resume yet: no reported human-TUI-orphan incidents to measure against; 1.18.1 REST surface offers no "attach to whatever id is currently live" primitive; adding a shim carries its own new failure modes.
- Recommended smaller step: publish a CommHub notice from the `child.once("exit")` handler naming the exited session id. Cheap (~5 lines), makes orphan frequency measurable so we know whether resume is worth designing.

Per dispatch red-line 不碰生产, no live serve-kill probe was done — a controlled probe on a fresh isolated node would need its own setup and belongs in a follow-up.

## Files

- `agent-node/src/runtime/opencode-copresence/runtime.ts` — +38/-7. `parseMessageReply` rewrite (13-variant-schema-aware, always returns non-empty, exported), caller `throw` removal.
- `agent-node/src/runtime/opencode-copresence/runtime.test.ts` — +83/0. 5 new tests under `describe("parseMessageReply (#1451)")`.
- `docs/analysis/opencode-copresence-serve-exit-1451.md` — +66/0. Design memo (finding #2).

## Deploy risk

Behavioral change: turns that previously threw `returned no assistant text` now succeed and report the synthesized marker to CommHub. Any monitoring that keys on that exact error string will silence — flagging so it's not a surprise.
