### PR TITLE
fix(daemon): stop 未命中 childrenMap 时收敛,对称补 #1286 (#1448 finding-3)

### DIFF
--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -5,7 +5,7 @@ import {
   handleStopDoorbell,
   recordSpawnedChild,
 } from "./stop-daemon";
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, statSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, statSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -108,8 +108,12 @@ describe("recordSpawnedChild + map shape", () => {
   });
 });
 
-describe("handleStopDoorbell — noop_not_my_child", () => {
-  test("unknown child_node_id → degraded ack (not error)", async () => {
+describe("handleStopDoorbell — stop without map entry converges (#1448 finding-3)", () => {
+  // 改前(#1286 前的对称缺口)：stop 未命中 map ack `noop_not_my_child`,hub 侧
+  // 留在 stopping 卡死。改后：与 delete 一样 sweep(按 alias 找并 SIGTERM 任何还
+  // 在跑的子进程)+ ack `stopped` 收敛。这条断言 expect "stopped" 在改前会红
+  // (拿到 "noop_not_my_child")——witnessed-red。
+  test("unknown/absent child on stop → sweep + ack stopped (not noop)", async () => {
     const { acks, deps } = makeDeps({
       getStopReturn: {
         ok: true, request_id: "sr_x",
@@ -120,7 +124,8 @@ describe("handleStopDoorbell — noop_not_my_child", () => {
     await handleStopDoorbell({ request_id: "sr_x" }, deps);
     expect(acks.length).toBe(1);
     expect(acks[0].tool).toBe("ack_stop_request");
-    expect(acks[0].args.status).toBe("noop_not_my_child");
+    expect(acks[0].args.status).toBe("stopped");
+    expect(acks[0].args.backup_path).toBeUndefined();   // stop 不搬 config
   });
 });
 
@@ -568,15 +573,30 @@ describe("#1286 handleStopDoorbell — stop 之后再 delete", () => {
     expect(statSync(join(workdirRoot, alias)).isDirectory()).toBe(true);
   });
 
-  test("回归钉：action=stop 未命中时行为不变，仍是 noop_not_my_child", async () => {
-    const h = makeDeps({
+  // #1448 finding-3 — stop 的收敛路径**绝不**动 config 目录(那是 delete 的语义)——即使盘上有目录、
+  // 即使请求误带 delete_config,stop 都必须原样保留。
+  test("#1448 finding-3: stop 未命中 map 时,盘上 config 目录被保留(不搬进回收站)", async () => {
+    const workdirRoot = join(scratch, "nodes-f3-stop");
+    const deletedRoot = join(scratch, "deleted-f3-stop");
+    mkdirSync(workdirRoot, { recursive: true });
+    const childDir = join(workdirRoot, "alias-f3-keep");
+    mkdirSync(childDir);
+    writeFileSync(join(childDir, "config.json"), JSON.stringify({ token: "ntok_keep" }), { mode: 0o600 });
+
+    const { acks, deps } = makeDeps({
+      workdirRoot, deletedRoot,
       getStopReturn: {
-        ok: true, request_id: "req-stop-miss", child_node_id: "node_absent", child_alias: "absent-1286",
-        action: "stop", delete_config: false, grace_seconds: 10, force: false,
+        ok: true, request_id: "req-stop-keep", child_node_id: "node_keep", child_alias: "alias-f3-keep",
+        // 故意把 delete_config 设 true 也不能让 stop 搬目录——action 门挡住。
+        action: "stop", delete_config: true, grace_seconds: 10, force: false,
       },
     });
-    await handleStopDoorbell({ request_id: "req-stop-miss" }, h.deps as any);
-    expect(h.acks.at(-1)!.args.status).toBe("noop_not_my_child");
+    await handleStopDoorbell({ request_id: "req-stop-keep" }, deps);
+    expect(acks.at(-1)!.args.status).toBe("stopped");
+    expect(acks.at(-1)!.args.backup_path).toBeUndefined();
+    // 原目录仍在，回收站没有它
+    expect(statSync(childDir).isDirectory()).toBe(true);
+    expect(existsSync(deletedRoot) ? readdirSync(deletedRoot).length : 0).toBe(0);
   });
 });
 

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -198,45 +198,36 @@ export async function handleStopDoorbell(
   const { child_node_id, child_alias, action, delete_config = true, grace_seconds = 10 } = req;
 
   const entry = childrenMap.get(child_node_id);
-  if (!entry && action !== "delete") {
-    // §2.4 — degraded path, not an error. Daemon restart + pre-boot-
-    // rebuild scenario. Nothing to signal, so ack and let hub move on.
-    //
-    // 🔴 This early return is correct for `stop` and wrong for `delete`.
-    // childrenMap tracks RUNNING PROCESSES; a delete also has to remove an
-    // ON-DISK config directory, and those two have different lifetimes.
-    // Letting a process table decide a filesystem cleanup is a category
-    // error. See the delete branch below.
-    deps.log(`[stop-daemon] child not in map (likely daemon-restarted): ${child_node_id}`);
-    await deps.callCommHub("ack_stop_request", {
-      request_id, status: "noop_not_my_child",
-      error: "child not in children_map; daemon likely restarted before rebuild",
-    }).catch(() => { /* ack failure → next sweeper picks up */ });
-    return;
-  }
   if (!entry) {
-    // #1286 — delete without a map entry. This is not the rare
-    // daemon-restart case: a successful `stop` removes the entry, so
-    // stop-then-delete makes the miss GUARANTEED, not incidental.
+    // #1286 (delete) + #1448 finding-3 (stop): no map entry, for BOTH actions.
     //
-    // Nothing here needs the map. `child_alias` comes from the hub request
-    // (not from `entry`), and sweepOrphansForAlias finds processes by alias.
-    // The map only ever supplied `entry.pid`, which just the pgid signal in
-    // `stop` requires. So do the work instead of returning.
-    deps.log(`[stop-daemon] delete without map entry (expected after stop): ${child_node_id}`);
+    // entry 缺失不是罕见事：成功 stop 会删 map 条目、子节点自己崩了 rebuild 的
+    // pgrep 也找不到 → stop-then-delete 或 crash-then-stop 时 miss 是必然的。
+    //
+    // #1286 把 delete 从「ack noop_not_my_child、留 hub 卡 deleting」修成了
+    // 「sweep + (delete 才)搬 workdir + ack stopped」收敛。但当时只改了 delete,
+    // 对称的 stop 路径仍走老的 noop 分支 → hub 卡 stopping(finding-3 的症状)。
+    //
+    // 这里两个 action 统一收敛:map 只提供过 entry.pid(命中路径的 pgid 信号用),
+    // child_alias 来自 hub 请求、sweepOrphansForAlias 按 alias(pgrep+/proc token
+    // 精确)找进程——所以「daemon 重启但子节点还在跑」这种情况 sweep 会把它 SIGTERM
+    // 掉,ack stopped 才是诚实的;子节点已崩则 sweep 无命中、ack stopped 同样诚实。
+    // 🔴 workdir 只在 action==='delete' 时搬(stop 保留 config);stop 的 delete_config
+    //    本就是 false,这里再叠一层 action 显式门,防任何 stop 请求误带 delete_config。
+    deps.log(`[stop-daemon] ${action} without map entry (expected after stop / crash): ${child_node_id}`);
     if (child_alias) {
-      await sweepOrphansForAlias(child_alias, signalProcess, deps, "delete without map entry");
+      await sweepOrphansForAlias(child_alias, signalProcess, deps, `${action} without map entry`);
     }
-    const backup = (delete_config && child_alias)
+    const backup = (action === "delete" && delete_config && child_alias)
       ? moveWorkdirToTrash(child_alias, workdirRoot, deletedRoot, deps, ensureDir, chmod, renameDir)
       : null;
-    // Ack `stopped` either way: the child is not running and its config is
-    // not in place, which IS delete's end state, so the hub must converge
-    // (row deleted + ntok revoked). Acking noop_not_my_child here would
-    // leave lifecycle_state stuck at 'deleting' — the reported symptom.
-    // `backup_path` present vs absent is what distinguishes "moved it" from
-    // "nothing was on disk"; a failed move is surfaced by warn, matching the
-    // stance the hit path already takes.
+    // Ack `stopped` either way: the child is not running (swept) and — for
+    // delete — its config is not in place, which IS each action's end state,
+    // so the hub must converge (stop→stopped / delete→row gone + ntok revoked).
+    // Acking noop_not_my_child would leave lifecycle_state stuck at
+    // 'stopping'/'deleting' — the reported symptom. `backup_path` present vs
+    // absent distinguishes "moved it" from "nothing was on disk"; a failed
+    // move is surfaced by warn, matching the hit path's stance.
     await deps.callCommHub("ack_stop_request", {
       request_id, status: "stopped", ...(backup ? { backup_path: backup } : {}),
     }).catch((e: any) => {


### PR DESCRIPTION
Addresses #1448 **finding 3** (MEDIUM, stuck-state). Fast-follow to #1450 (finding 1); independent file (`stop-daemon.ts`), composes with it.

## 缺陷（CONFIRMED）
`#1286` 把 **delete** 未命中 childrenMap 从「ack `noop_not_my_child`、留 hub 卡 `deleting`」修成「sweep + 搬 workdir + ack `stopped`」收敛——但只改了 delete。**对称的 stop 路径仍走老的 noop 分支**（`stop-daemon.ts` 的 `if (!entry && action !== "delete")`）：

可达链：子节点自己崩 → daemon rebuild 的 `pgrep` 找不到 → 不记入 map → 后续 `stop_node` 门铃到达、entry 缺失 → ack `noop_not_my_child` → hub 侧 `ack_stop_request` 的 noop 分支不改 `lifecycle_state` → 节点**永久卡 `stopping`**。

## 修复
删掉 stop 专用的 noop 早返分支，让 stop 落入**已 action-agnostic** 的统一 no-entry 收敛分支：
- `sweepOrphansForAlias`（按 alias `pgrep` + `/proc/cmdline` token 精确匹配 → SIGTERM）先杀掉任何还在跑的子进程（daemon 重启但子节点仍活的情况），`ack stopped` 才诚实；子节点已崩则 sweep 无命中、`ack stopped` 同样诚实。
- workdir 只在 `action === 'delete' && delete_config` 时搬——叠一层 **`action` 显式门**，stop 绝不动 config（stop 的 `delete_config` 本就是 false，防任何 stop 请求误带）。

**为什么去掉 noop 是安全的**：`get_stop_request` 已校验 `row.daemon_node_id === callerDaemon`（`not_your_request`），daemon 只会拿到自己名下的请求 → 「不在 map」永远只是内存态缺失、绝非跨 daemon 混淆 → 收敛总是对的。`noop_not_my_child` 至此在 no-entry 路径不再产生（hub 侧对应分支成 dead-but-harmless，不动它）。

## Witnessed-red
`stop-daemon.test.ts`：
- 回归钉从「stop 未命中 ⇒ noop_not_my_child」翻转为「stop 未命中 ⇒ sweep + ack `stopped`（不再 noop）」——改前 `expect stopped` 红（拿到 `noop_not_my_child`）。
- 新增：stop 未命中 map 且盘上有 config 目录（甚至请求误带 `delete_config=true`）⇒ 目录**被保留**、回收站为空、`ack stopped` 无 `backup_path`。
- 判别力已证：把 `stop-daemon.ts` 还原成 origin/main（旧 noop 分支）→ 上述两条立即变红。

## 验证
- `tsc --noEmit` 0 error；`stop-daemon.test.ts` 22/22；`doc-symbol-pins` OK。
- 与 #1450 组合：#1450 保证 SSE 断连期漏掉的 stop 门铃在重连时被重放，#1448-f3 保证该门铃到达时（子节点已不在 map）真正收敛而非再 noop——两者一起消除卡 `stopping`。

finding-2（start 无 stale reaper）另开 fast-follow PR。
