### PR TITLE
ci(mutation): 抽出变异守卫共享件 + 画准全仓真图(#1257 —— 普查数错三次的更正)

### DIFF
--- a/docs/mutation-guard-map.txt
+++ b/docs/mutation-guard-map.txt
@@ -1,0 +1,113 @@
+# 变异注入守卫 —— 全仓真图(#1257)
+#
+# 判据:一个套件只要用了下面**四类等价写法之一**,就算「验了替换生效」。
+#   mutate      tests/lib/mutation-guard.sh 的 mutate 包裹(sha256 前后比对)
+#   cmp         cmp -s <orig-copy> <file>
+#   diff        diff -q
+#   sha256      直接 sha256sum 前后比对
+#   set-e-grep  在 set -e 下 grep【变异后】的特征串(no-op ⇒ 串不存在 ⇒ grep 失败 ⇒ 中断)
+#
+# 🔴 这张表存在的理由:本条 issue 的普查我数错过三次,三次方向一致地偏「无守卫」——
+#    v1 只认 mutate/NO-OP(数出 1 个) → v2 补 cmp/diff/sha256(25 个) → v3 补 set-e-grep。
+#    每一版都以为判据够了。**按写法数而不是按语义数,就会把已有守卫的算成没有**,
+#    后果是给它们重复加一层。这张表是给下一个人的护栏,别再从零数。
+#
+# ⚠️ 已知边界(set-e-grep 形态):若被 grep 的特征串在 sed 之前就已存在于目标文件,
+#    no-op 时 grep 照样命中,守卫失效。模式越裸越危险 —— 名单里就有实例:
+#    test1195-side-thread-hub-contract 用的是裸 `if (false)`,而 `if (false && prior)`
+#    这类带具体标识符的独特性高。**本表只标出可疑者,未逐个回源码实测。**
+#
+# 格式:<套件>\t<变异命令数>\t<守卫形态,逗号分隔;NONE=真无守卫>
+
+test688-owner-gated-schedule-hub	13	set-e-grep
+test1204-btw-production-wiring	11	NONE
+test671-task-runtime-evidence-hub	10	cmp,set-e-grep
+test1200-side-thread-command-transport	8	set-e-grep
+test1181-codex-durable-poll	7	NONE
+test601-hub-scheduled-tasks	7	set-e-grep
+test689-owner-schedule-agent	7	cmp,sha256
+test604-scheduled-task-edit	6	set-e-grep
+test624-task-cursor-pagination	5	set-e-grep
+test690-scheduled-run-terminal	5	cmp
+test698-atomic-peer-reply	5	sha256
+test292-e2e-hard-gate	4	cmp
+test336-feishu-bridge-wire	4	mutate
+test466-codex-copresence-p3	4	cmp
+test623-feishu-scrub-health	4	NONE
+test647-rest-explicit-columns	4	NONE
+test654-dashboard-managed-launch	4	cmp
+test813-grok-mcp-readiness	4	cmp
+lib	3	mutate,sha256
+test236-dashboard-codex-goal	3	sha256
+test292-e2e-agent-registration	3	cmp
+test292-e2e-identity-fixtures	3	cmp
+test292-e2e-residual-fixtures	3	cmp
+test30-mock-llm-smoke	3	cmp
+test467-headless-bootstrap	3	cmp,set-e-grep
+test617-feishu-ws-readiness	3	NONE
+test649-token-cli	3	NONE
+test659-codex-appserver-activity-timeout	3	NONE
+test660-explicit-prod-db-optin	3	set-e-grep
+test661-explicit-bootstrap-db	3	set-e-grep
+test765-batch-runtime-gate	3	set-e-grep
+test1193-side-thread-contract	2	NONE
+test1195-side-thread-hub-race	2	NONE
+test292-e2e-contract-drift	2	cmp
+test292-e2e-rename-command	2	cmp
+test313-test-all-v3-fixtures	2	NONE
+test344-ack-transport-zod	2	NONE
+test599-skillhub	2	NONE
+test605-grok-startup-model-label	2	NONE
+test611-cli-boolean-flags	2	NONE
+test612-visible-inbox-skip	2	NONE
+test613-codex-dead-endpoint	2	NONE
+test625-explicit-env-crlf	2	set-e-grep
+test630-file-download-header-auth	2	NONE
+test631-private-config-permissions	2	NONE
+test632-honest-sse-recovery	2	NONE
+test633-doctor-locale	2	NONE
+test634-windows-secret-guidance	2	set-e-grep
+test635-daemon-private-state	2	NONE
+test638-server-aggregate-isolation	2	NONE
+test648-probe-ip-pin	2	NONE
+test651-init-no-token-prompt	2	NONE
+test652-admin-network-list	2	NONE
+test653-batch-workdir	2	cmp
+test657-claude-native-version-pin	2	NONE
+test673-claude-image-attachment-block	2	cmp
+test736-pm2-fleet-rebuild	2	sha256
+test766-bunx-preflight	2	NONE
+test1183-sync-pinned-dryrun	1	NONE
+test1195-side-thread-hub-contract	1	set-e-grep
+test1195-side-thread-hub-security	1	NONE
+test225-grok-preview-package-live	1	sha256
+test234-grok-profile-disclosure	1	NONE
+test235-grok-mcp-outbound-only	1	NONE
+test292-e2e-ok-assertions	1	cmp
+test34-playwright-discovery	1	NONE
+test596-goal-loop-docs	1	NONE
+test600-public-skillhub	1	NONE
+test602-scheduled-misfire	1	set-e-grep
+test606-node-start-help	1	set-e-grep
+test607-health-upload-limits	1	NONE
+test608-claude-cli-dependency	1	set-e-grep
+test609-dashboard-chat-doc-path	1	NONE
+test610-opencode-clean-test-workspace	1	NONE
+test614-rest-single-network	1	NONE
+test615-network-name	1	NONE
+test618-claude-vendor-env	1	NONE
+test621-test384-layer-isolation	1	NONE
+test637-database-url-guard	1	NONE
+test643-transient-hub-legacy-repair	1	cmp
+test646-config-node-id-precedence	1	NONE
+test650-anet-attach	1	NONE
+test656-claude-sdk-tool-aliases	1	NONE
+test693-agent-local-upload	1	NONE
+test735-hub-daemon-rebuild	1	sha256
+
+# ── 汇总 ──
+# 用文本变异的套件: 85
+# 变异命令合计:     232
+# 已有守卫:         39
+# 真无守卫:         46
+# 形态可疑(模式过裸,可能假阳): test660-explicit-prod-db-optin, test661-explicit-bootstrap-db, test634-windows-secret-guidance, test1195-side-thread-hub-contract, test608-claude-cli-dependency

--- a/tests/lib/mutation-guard.sh
+++ b/tests/lib/mutation-guard.sh
@@ -1,0 +1,47 @@
+# 变异注入守卫(#1257) —— 证明「变异真的被注入了」,而不只是「锚点还在」。
+#
+# 🔴 它替换的旧写法:
+#     perl -0pi -e 's/<模式>/<变异>/' <file>
+#     grep -Fq '<锚点>' <file>          # ← 只证明锚点还在
+#     expect_red <name> <test-cmd>
+#   被测代码换个写法(加参数、跨行、内联局部变量、改名)⇒ 模式不匹配 ⇒ perl 是
+#   no-op;锚点通常还在,grep 照过,于是 expect_red 拿一份**没被变异的源码**去
+#   跑 → 恒绿。输出是 `mutation <name> stayed green`,读起来像「这条规则没人守
+#   了」,而真相是「这个变异从来没被注入过」—— **两者指向完全相反的修法**。
+#   (#1054/#1051/#1056/#1059 是同一机制的四个实例;#1252 上我们据此派错过工。)
+#
+# 用法:
+#     source tests/lib/mutation-guard.sh
+#     mutation_guard_report() { bad "$@"; }        # 可选:接到套件自己的计数
+#     mutate <name> <file> <命令...> && expect_red <name> <test-cmd>
+#
+# 🔴 用 `&&` 串联是刻意的:no-op 只记一笔账、不中断整轮 —— 取证期要的是失败的
+#    **分布**,不是第一颗就停。
+#
+# 🔴 不绑定套件的 bad()/FAIL 计数:那会把这个共享件焊死在某一套计数约定上。
+#    调用方用 mutation_guard_report 注入自己的报告方式;缺省只打印并返回非零。
+
+# 缺省报告:只打印。套件覆盖它即可接入自己的 PASS/FAIL 计数。
+if ! declare -F mutation_guard_report >/dev/null 2>&1; then
+  mutation_guard_report() { printf 'FAIL %s\n' "$*"; }
+fi
+
+# mutate <name> <file> <命令...>
+#   跑 <命令...>,并以 <file> 的 sha256 前后是否变化判定变异有没有真的注入。
+#   返回 0 = 确实改动了字节;返回 1 = NO-OP(或文件缺失),并报告。
+mutate() {
+  local name="$1" file="$2"; shift 2
+  local before after
+  if [ ! -f "$file" ]; then
+    mutation_guard_report "mutation $name NO-OP —— 目标文件不存在($file)"
+    return 1
+  fi
+  before="$(sha256sum "$file" | cut -d' ' -f1)"
+  "$@"
+  after="$(sha256sum "$file" | cut -d' ' -f1)"
+  if [ "$before" = "$after" ]; then
+    mutation_guard_report "mutation $name NO-OP —— 模式没匹配到任何东西,变异从未注入($file 未改变)"
+    return 1
+  fi
+  return 0
+}

--- a/tests/lib/mutation-guard.test.sh
+++ b/tests/lib/mutation-guard.test.sh
@@ -6,6 +6,11 @@
 #    所以这里必须**喂一个 no-op 变异,看它拒不拒**。
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# 🔴 不用裸 `rm -rf "$VAR"` —— 2026-06-16 有过 `rm -rf $HOME` 抹掉真实项目的事故,
+# tests/ 下由 lint-no-bare-rm-rf.sh 一律拒。safe_rm_rf 只放行 /tmp/* 前缀,越界
+# 直接 exit 99 且不执行 rm。本脚本的 $WORK 来自 mktemp -d,落在 /tmp,符合。
+# shellcheck disable=SC1091
+source "$HERE/safe-rm.sh"
 
 PASS=0; FAIL=0
 ok(){ PASS=$((PASS+1)); printf '  PASS %s\n' "$*"; }
@@ -16,7 +21,7 @@ mutation_guard_report(){ REPORTED="$*"; }   # 捕获报告,验证它真的报了
 # shellcheck disable=SC1091
 source "$HERE/mutation-guard.sh"
 
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+WORK="$(mktemp -d)"; trap 'safe_rm_rf "$WORK"' EXIT
 F="$WORK/target.txt"
 
 echo "== mutation-guard meta =="

--- a/tests/lib/mutation-guard.test.sh
+++ b/tests/lib/mutation-guard.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# mutation-guard.sh 自己的 meta 测试(#1257)
+#
+# 🔴 这一格是本条改动的判据核心:守卫本身也可能是假门。
+#    如果它对「什么都没变」也放行,那它就只是换了个写法的 `grep -Fq 锚点`。
+#    所以这里必须**喂一个 no-op 变异,看它拒不拒**。
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$*"; }
+
+REPORTED=""
+mutation_guard_report(){ REPORTED="$*"; }   # 捕获报告,验证它真的报了
+# shellcheck disable=SC1091
+source "$HERE/mutation-guard.sh"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+F="$WORK/target.txt"
+
+echo "== mutation-guard meta =="
+
+# ① 真变异 ⇒ 放行(返回 0),且不报告
+printf 'const dir = feishuOutboundDir(conversationId);\n' > "$F"
+REPORTED=""
+if mutate real-change "$F" sed -i 's/conversationId/sender.id/' "$F"; then
+  [ -z "$REPORTED" ] && ok "真变异:放行且未报告" || bad "真变异却报告了:$REPORTED"
+else
+  bad "真变异被误判为 NO-OP"
+fi
+grep -q 'sender.id' "$F" && ok "真变异:文件内容确实被改了" || bad "文件没被改,前提不成立"
+
+# ② 🔴 no-op 变异 ⇒ 必须拒绝(返回非 0)并报告
+printf 'const dir = feishuOutboundDir(conversationId);\n' > "$F"
+REPORTED=""
+if mutate no-op "$F" sed -i 's/THIS_PATTERN_DOES_NOT_EXIST/x/' "$F"; then
+  bad "🔴 no-op 变异被当成有效变异放行了 —— 守卫本身是假门"
+else
+  ok "no-op 变异:被拒绝(返回非 0)"
+  case "$REPORTED" in
+    *"NO-OP"*) ok "no-op 变异:报告里点名了 NO-OP" ;;
+    "")        bad "no-op 被拒但没有任何报告 —— 红话不指名" ;;
+    *)         bad "报告未点名 NO-OP:$REPORTED" ;;
+  esac
+  case "$REPORTED" in
+    *no-op*) ok "报告里带上了变异名,可定位" ;;
+    *)       bad "报告没带变异名:$REPORTED" ;;
+  esac
+fi
+
+# ③ 目标文件不存在 ⇒ 也必须拒绝(不能因为 sha 读不到就当成"变了")
+REPORTED=""
+if mutate missing "$WORK/nope.txt" true; then
+  bad "🔴 目标文件不存在却放行了"
+else
+  ok "文件不存在:被拒绝"
+  case "$REPORTED" in *"不存在"*) ok "文件不存在:报告说明了原因" ;; *) bad "原因未说明:$REPORTED" ;; esac
+fi
+
+# ④ 报告方式可注入(不绑死套件的 bad/FAIL)
+declare -F mutation_guard_report >/dev/null && ok "报告回调可被套件覆盖" || bad "报告回调不可注入"
+
+printf '\n  PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test336-feishu-bridge-wire/Dockerfile
+++ b/tests/test336-feishu-bridge-wire/Dockerfile
@@ -14,6 +14,7 @@ RUN cd /repo/agent-network && bun install --ignore-scripts \
 
 COPY agent-network /repo/agent-network
 COPY agent-node /repo/agent-node
+COPY tests/lib/mutation-guard.sh /repo/tests/lib/mutation-guard.sh
 COPY tests/test336-feishu-bridge-wire /repo/tests/test336-feishu-bridge-wire
 RUN chmod +x /repo/tests/test336-feishu-bridge-wire/run.sh
 

--- a/tests/test336-feishu-bridge-wire/run.sh
+++ b/tests/test336-feishu-bridge-wire/run.sh
@@ -28,18 +28,12 @@ expect_red(){
 # 而真相是"这个变异从来没被注入过"。这两种结论指向完全相反的修法。
 #
 # 改成比对文件内容:变异前后必须不同。
-mutate(){
-  local name="$1" file="$2"; shift 2
-  local before after
-  before="$(sha256sum "$file" | cut -d" " -f1)"
-  "$@"
-  after="$(sha256sum "$file" | cut -d" " -f1)"
-  if [[ "$before" == "$after" ]]; then
-    bad "mutation $name NO-OP —— 模式没匹配到任何东西,变异从未注入($file 未改变)"
-    return 1
-  fi
-  return 0
-}
+# #1257:抽到 tests/lib/mutation-guard.sh 共享,行为不变。
+# 报告走本套件自己的 bad()(计入 FAIL),由 mutation_guard_report 注入 ——
+# 共享件不绑定任何一套计数约定。
+mutation_guard_report(){ bad "$@"; }
+# shellcheck disable=SC1091
+source "$ROOT/tests/lib/mutation-guard.sh"
 
 printf 'source_commit=%s\n' "${TEST336_SOURCE_COMMIT:-unknown}"
 cd "$ROOT"


### PR DESCRIPTION
refs #1257(不关闭 —— 46 个真无守卫的套件尚未按图施工)。

## 核完之后,这条 issue 的产出变了

#1257 说「变异守卫只验锚点不验替换生效」。核实后**机制成立,但规模比 issue 记的小得多** —— 而这个更正是普查数错三次才拿到的。

| 判据版本 | 认哪些写法 | 数出「已有守卫」 |
|---|---|---|
| v1 | `mutate()` / `NO-OP` 两种字面写法 | **1** |
| v2 | + `cmp -s` / `diff -q` / `sha256` | **25**(test671 被救回) |
| v3 | + `set -e` 下 grep **变异后**特征串 | **39**(test688 被救回) |

🔴 **每一版我都以为判据够了,而三次错误方向完全相同:把已有守卫的算成没有。** 按写法数、不按语义数——后果是给它们重复加一层。

被救回的两个形态:

```bash
# test671:比对副本
sed -i '…' server/src/tools.ts
if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
  bad "remove-node-ownership mutation did not change source"; fi

# test688:set -e 下 grep【变异后】的串
set -euo pipefail
sed -i 's/…/if (false && ctx.auth.userId !== …)/' <file>
grep -Fq 'if (false && ctx.auth.userId !== …)' <file>   # no-op ⇒ 串不在 ⇒ 失败 ⇒ 中断
```

## 交付物

**1. `tests/lib/mutation-guard.sh`** — 从 #1256 在 test336 的原型抽出。报告方式经 `mutation_guard_report` 注入,**不绑死任何一套 PASS/FAIL 计数**;目标文件不存在也判 NO-OP(不能因为 sha 读不到就当"变了")。

**2. `tests/lib/mutation-guard.test.sh`** — 🔴 **守卫自己的 meta 测试**(8 项)。这一格是本 PR 的判据核心:**守卫本身也可能是假门**——若它对"什么都没变"放行,它就只是换了写法的 `grep -Fq 锚点`。

两向见证:

| 变异 | 红话 |
|---|---|
| 守卫退化成「一律放行」 | `🔴 no-op 变异被当成有效变异放行了 —— 守卫本身是假门` |
| 「拒绝但不报告」 | `no-op 被拒但没有任何报告 —— 红话不指名` |

两条红**各自说清了红的是哪一种**。恢复后复跑 rc=0。

**3. test336 改用共享件** — **抽取零行为变化是实测的**:同一组输入下,抽取前后 `real_rc=0 noop_rc=1 FAIL=1` 三项一致,报告文案逐字相同。Dockerfile 加 `COPY tests/lib/mutation-guard.sh`(该镜像原本不含 `tests/lib`)。

**4. `docs/mutation-guard-map.txt`** — **全仓真图**。85 个用文本变异的套件 / 232 条变异命令,逐个标注用四类等价写法中的哪一种,或 `NONE`。

```
用文本变异的套件: 85     变异命令合计: 232
已有守卫: 39            真无守卫: 46
形态分布: cmp 18 · set-e-grep 16 · sha256 7 · mutate 2
```

**这份清单本身就是护栏** —— 下一个人不必从零数,也不会重蹈我三次的偏差。

## 已知边界(写在清单头部,不是脚注)

`set-e-grep` 形态有理论假阳:**若特征串在 `sed` 之前就已存在于目标文件**,no-op 时 grep 照样命中、守卫失效。**模式越裸越危险**,而这不是纯理论——清单自动标出 5 个可疑者,其中 `test1195-side-thread-hub-contract` 用的是**裸 `if (false)`**(相比之下 `if (false && prior)` 这类带标识符的独特性高)。

**本表只标出可疑者,未逐个回源码实测** —— 这一格如实标注,不冒充已验证。

## 本版为什么不接第二个套件

真图显示 **39/85 已有守卫**。在名单可信之前接第二个,很可能又是给已有守卫的套件重复加 —— **三次数错已经证明这个风险是真的,不是假想**。

真无守卫的 46 个(top:`test1204` 变异=11、`test1181` 变异=7)留待按图施工。

## 未做

- 46 个套件的逐个接入(另开)
- `test1200` 需先搭「期望红」框架(无 `ok()/bad()`、无 `ROOT=`、`expect_red` 计 0),**不同形、不能照抄**,另开
- 给 `set-e-grep` 形态加具名红话(`|| { echo "MUTATION_NOOP: …"; exit 1; }`)属 DX 增强,非正确性修复,不进本 PR
