### PR TITLE
fix(owned-roots): #1438 anet node stop — defeat pid-reuse between ps and /proc

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -36,7 +36,7 @@ import {
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
-import { processVanished, resolveOwnedRoots } from "../src/owned-roots";
+import { processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -8681,6 +8681,70 @@ async function sweepMcpOrphansForAlias(force: boolean, ...aliases: string[]): Pr
 // #180 R3 caveat: alias tokenisation assumes node names conforming to
 // validateNodeName() (no whitespace/quotes) — the entire current node
 // population. A hand-edited legacy alias containing whitespace would not match.
+// #1438 — anet node stop alias fallback needs (pid, birth) from the SAME `ps`
+// snapshot to defeat pid-reuse: findNodeProcessesByAlias + processBirth are
+// two separate reads, and the pid can be recycled between them. This helper
+// captures both in one atomic `ps` call. lstart is a 24-char fixed-width
+// timestamp ("Www Mmm dd HH:MM:SS YYYY"), stable per process incarnation.
+//
+// Kept separate from findNodeProcessesByAlias so the rename lane callers
+// (L8961/L9205) — which have the same class of bug but need their own audit
+// pass — are not silently rewired.
+function findNodeStopCandidates(alias: string): OwnedRootCandidate[] | null {
+  if (!alias) return [];
+  let out = "";
+  try {
+    out = execFileSync("ps", ["-eww", "-o", "pid=", "-o", "lstart=", "-o", "args="], { encoding: "utf-8" }).toString();
+  } catch { return null; }  // #180 R2 — process table unavailable; caller fails closed
+  const candidates = new Map<number, OwnedRootCandidate>();
+  // Regex: pid (leading ws + digits) + lstart (fixed 24 chars: 3-letter weekday,
+  // space, 3-letter month, space, 1-2 digit day right-padded to 2, space,
+  // HH:MM:SS, space, 4-digit year) + args (rest of line).
+  const LINE_RE = /^\s*(\d+)\s+([A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9]\d \d\d:\d\d:\d\d \d{4})\s+(.+)$/;
+  for (const line of out.split("\n")) {
+    const m = line.match(LINE_RE);
+    if (!m) continue;
+    const pid = parseInt(m[1], 10);
+    if (isNaN(pid) || pid === process.pid) continue;
+    const discoveredBirth = m[2];
+    const tok = m[3].split(/\s+/);
+    // Same identity rules as findNodeProcessesByAlias (#180 R1 / #146 PR-3):
+    // command line must be an actual agent process, and the alias must be
+    // in the argv (`-n <alias>` / `--alias <alias>` / `node start <alias>`).
+    const isForegroundStart = tok.some((x, i) => x === "node" && tok[i + 2] === "node" && tok[i + 3] === "start")
+      || tok.some((x, i) => (x.endsWith("/anet") || x === "anet") && tok[i + 1] === "node" && tok[i + 2] === "start");
+    const isAgentProc = isForegroundStart || tok.some(x => {
+      const base = x.split("/").pop() || x;
+      return base === "claude" || base === "agent-node"
+        || base === "codex" || base === "grok"
+        || x.includes("@anthropic-ai/claude-code") || x.includes("@sleep2agi/agent-node")
+        || x.includes("@openai/codex") || x.includes("@openai/codex-sdk");
+    });
+    if (!isAgentProc) continue;
+    let aliasMatch = false;
+    for (let i = 0; i < tok.length - 1; i++) {
+      if ((tok[i] === "-n" || tok[i] === "--alias") && tok[i + 1] === alias) { aliasMatch = true; break; }
+      if (tok[i] === "start" && tok[i - 1] === "node" && tok[i + 1] === alias) { aliasMatch = true; break; }
+    }
+    if (!aliasMatch) continue;
+    candidates.set(pid, { pid, discoveredBirth });
+  }
+  return [...candidates.values()];
+}
+
+// #1438 — read lstart via `ps -p <pid>` so we compare against the SAME format
+// findNodeStopCandidates captured. If pid was recycled between discovery and
+// this call, ps will return the NEW process's lstart (different string) and
+// resolveOwnedRoots' equality check catches it. Returns null on any error
+// (pid gone / ps unavailable / anything else) — resolveOwnedRoots then
+// falls back to the vanished() fail-closed path.
+function probeCurrentBirthSignature(pid: number): string | null {
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf-8" }).trim();
+    return out || null;
+  } catch { return null; }
+}
+
 function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
   const wanted = new Set(aliases.filter(Boolean));
   if (wanted.size === 0) return [];
@@ -9460,15 +9524,24 @@ Stop a running agent node.
       // while holding stop-intent, then freeze exact identities. Reaping never
       // rescans by alias, so a later same-name generation cannot be adopted.
       if (roots.length === 0) {
-        const legacy = findNodeProcessesByAlias(displayName);
+        // #1438 — findNodeStopCandidates captures (pid, discoveredBirth) in
+        // ONE `ps` snapshot; the (pid, birth) pair has no TOCTOU window
+        // between the two fields. resolveOwnedRoots then verifies via
+        // currentBirthSignature that the pid we're about to freeze still
+        // belongs to the SAME incarnation — if it was recycled to another
+        // process B between discovery and here, the mismatch check rejects
+        // pid so reap does not kill B.
+        const legacy = findNodeStopCandidates(displayName);
         if (legacy === null) throw new Error("NODE_PROCESS_TABLE_UNAVAILABLE");
-        // #1422 — `ps` 拿到 pid 与读 `/proc/<pid>/stat` 之间有一个窗口:进程可能
-        // 已经退出。旧代码把「读不到 birth」一律当致命错误,于是 `anet node stop`
-        // 以 exit(1) 结束(test225 报 `node stop failed for <X>`)。
-        // 🔴 那不是失败 —— **stop 的目的就是让进程没了**,「它在我读它之前先退了」
-        // 正是想要的结果。resolveOwnedRoots 只放过**确证已消失**的(processVanished
-        // 仅在 ESRCH 时为真),进程仍在却读不到 birth 依旧抛。
-        roots = resolveOwnedRoots(legacy, { birth: processBirth, vanished: (pid) => processVanished(pid) });
+        // #1422 (window with /proc read collapsing to no-op) is orthogonal:
+        // if pid vanished cleanly between discovery and here, that's the
+        // stop-outcome we wanted. probes.vanished (ESRCH-based) still
+        // handles that path.
+        roots = resolveOwnedRoots(legacy, {
+          birth: processBirth,
+          vanished: (pid) => processVanished(pid),
+          currentBirthSignature: probeCurrentBirthSignature,
+        });
       }
       stopProcesses = snapshotOwnedProcessTree(roots);
       writeLifecycleOwner(resolved.id, {

--- a/agent-network/src/owned-roots.test.ts
+++ b/agent-network/src/owned-roots.test.ts
@@ -2,16 +2,34 @@
 //   ① 进程在 ps 与读 birth 之间消失 ⇒ **不再是失败**(旧行为:throw → node stop failed)
 //   ② 进程仍在、birth 读不到       ⇒ **仍然 throw**(不能因为放宽而吞掉真问题)
 //   ③ vanished 只在**确证**时为 true(ESRCH),权限不足不算消失
+//
+// #1438 加了第 4 类:pid 在 ps 快照与后续 /proc 读之间被回收 —— birth 读得到
+// 但那是新占用者 B 的 birth,旧代码静默收下 B。修法引入 discoveredBirth
+// (ps 同一次快照里取的 lstart)和 probes.currentBirthSignature,让 resolve
+// 阶段能识别「pid 相同、进程不同」。见 #1438 tests below.
 import { describe, expect, test } from "bun:test";
-import { processVanished, resolveOwnedRoots } from "./owned-roots";
+import { processVanished, resolveOwnedRoots, type OwnedRootCandidate, type OwnedRootProbes } from "./owned-roots";
 
 const errno = (code: string) => Object.assign(new Error(code), { code });
 
+// #1422 tests were written before #1438's signature change (candidates
+// carry discoveredBirth). Wrap them via a helper that supplies a matching
+// discoveredBirth == currentBirthSignature so the pid-reuse guard sees
+// "same incarnation" and #1422's original 3 branches are exercised as
+// before.
+const c = (pid: number, birth = `birth-${pid}`): OwnedRootCandidate => ({ pid, discoveredBirth: birth });
+const sameSignature = (candidates: OwnedRootCandidate[]): OwnedRootProbes["currentBirthSignature"] => {
+  const map = new Map(candidates.map(x => [x.pid, x.discoveredBirth]));
+  return (pid) => map.get(pid) ?? null;
+};
+
 describe("#1422 resolveOwnedRoots — ps→birth 之间的 TOCTOU", () => {
   test("读得到 birth 的照收", () => {
-    const roots = resolveOwnedRoots([11, 12], {
+    const cs = [c(11), c(12)];
+    const roots = resolveOwnedRoots(cs, {
       birth: (pid) => `birth-${pid}`,
       vanished: () => false,
+      currentBirthSignature: sameSignature(cs),
     });
     expect(roots).toEqual([
       { pid: 11, birth: "birth-11", role: "agent" },
@@ -20,30 +38,149 @@ describe("#1422 resolveOwnedRoots — ps→birth 之间的 TOCTOU", () => {
   });
 
   test("① 进程在两步之间消失 ⇒ 跳过,不抛 —— 这正是 stop 想要的结果", () => {
-    const roots = resolveOwnedRoots([21, 22], {
+    const cs = [c(21), c(22)];
+    const roots = resolveOwnedRoots(cs, {
       birth: (pid) => (pid === 22 ? null : `birth-${pid}`),
       vanished: (pid) => pid === 22,
+      currentBirthSignature: (pid) => pid === 22 ? null : `birth-${pid}`,
     });
     expect(roots).toEqual([{ pid: 21, birth: "birth-21", role: "agent" }]);
   });
 
   test("全部消失 ⇒ 空列表,仍不抛", () => {
-    expect(resolveOwnedRoots([31, 32], { birth: () => null, vanished: () => true })).toEqual([]);
+    expect(resolveOwnedRoots([c(31), c(32)], {
+      birth: () => null, vanished: () => true, currentBirthSignature: () => null,
+    })).toEqual([]);
   });
 
   test("② 进程仍在、birth 读不到 ⇒ 仍然抛,且带上 pid", () => {
+    // currentBirthSignature reports the pid alive (returns the discoveredBirth),
+    // but the storage-format birth read fails — that's the権限 case
+    // #1422 guarded. Fail-closed remains.
     expect(() =>
-      resolveOwnedRoots([41], { birth: () => null, vanished: () => false }),
+      resolveOwnedRoots([c(41)], {
+        birth: () => null,
+        vanished: () => false,
+        currentBirthSignature: (pid) => `birth-${pid}`,
+      }),
     ).toThrow("NODE_OWNER_BIRTH_UNAVAILABLE: pid=41");
   });
 
   test("🔴 放宽只对『确证消失』生效:同一批里既有消失的也有仍在的 ⇒ 仍抛", () => {
     expect(() =>
-      resolveOwnedRoots([51, 52], {
+      resolveOwnedRoots([c(51), c(52)], {
         birth: () => null,
-        vanished: (pid) => pid === 51, // 51 确证消失,52 仍在
+        vanished: (pid) => pid === 51,
+        currentBirthSignature: (pid) => pid === 51 ? null : `birth-${pid}`, // 51 消失, 52 仍在
       }),
     ).toThrow("NODE_OWNER_BIRTH_UNAVAILABLE: pid=52");
+  });
+});
+
+// #1438 — pid recycling between `ps` discovery and per-pid probe.
+//
+// 前提证:findNodeStopCandidates 用 `ps -eww -o pid= -o lstart= -o args=`
+// 在**单次 ps 快照**里取 pid 与 lstart(24 字符定宽字符串,进程一代内稳定
+// 不变)。probes.currentBirthSignature 后续再用 `ps -p <pid> -o lstart=` 读
+// 当前 pid 的 lstart:两次不等 ⇒ pid 在中间被回收,现在这个 pid 属于另一
+// 个进程 B ⇒ 静默 skip,不能把 B 收进 roots 让 reap 杀掉。
+//
+// 见红形式:内联一份 legacyResolveOwnedRoots(签名 = 旧的 `number[]`,行为 =
+// 旧的「读得到 birth 就收下」),在同一个 pid-回收 scenario 里对比 ——
+// legacy 收下 B(红),new 拒绝(绿)。两者对同一份「B 的 birth 读得到」证据
+// 判定相反,witnessed-red 成立。
+describe("#1438 resolveOwnedRoots — pid-reuse guard", () => {
+  // 旧签名内联对比。**不是**导出的生产代码,只在测试文件里,证明修前的
+  // 行为。如果生产代码里 resolveOwnedRoots 语义漂回旧版,这份对比会失效
+  // 但新语义的 tests 会红,所以要么两侧都动、要么都绿。
+  interface LegacyProbes { birth(pid: number): string | null; vanished(pid: number): boolean; }
+  interface LegacyOwnedRoot { pid: number; birth: string; role: "agent"; }
+  function legacyResolveOwnedRoots(pids: number[], probes: LegacyProbes): LegacyOwnedRoot[] {
+    const roots: LegacyOwnedRoot[] = [];
+    for (const pid of pids) {
+      const birth = probes.birth(pid);
+      if (birth) { roots.push({ pid, birth, role: "agent" }); continue; }
+      if (probes.vanished(pid)) continue;
+      throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
+    }
+    return roots;
+  }
+
+  test("🔴 witnessed-red: pid 回收 scenario — legacy 静默收下 B,new 拒绝", () => {
+    // Scenario: 发现阶段 pid=100 是我们的 agent A(discoveredBirth=lstart-A)。
+    // 我们回头去读 pid=100 时,A 已退出、pid 100 被新进程 B 复用,
+    // B 的 lstart=lstart-B、B 的 /proc-birth=jiffies-B(读得到)。
+    const discoveredBirth_A = "Mon Aug 30 10:00:00 2026";
+    const currentSig_B      = "Mon Aug 30 10:05:12 2026";  // B 起来的时间,不同
+    const currentBirth_B    = "12345";  // B 的 /proc-stat jiffies
+
+    // legacy 只看 birth 是否 truthy ⇒ B 的 birth 读得到 ⇒ **收下 B**
+    const legacyRoots = legacyResolveOwnedRoots([100], {
+      birth: () => currentBirth_B,
+      vanished: () => false,
+    });
+    expect(legacyRoots).toEqual([{ pid: 100, birth: currentBirth_B, role: "agent" }]);
+    //         ^^^^^^^ 🔴 bug: B 被当成 A 收下,下游 reap 会杀 B
+
+    // new 用 discoveredBirth 对比 currentBirthSignature ⇒ 不等 ⇒ **skip B**
+    const newRoots = resolveOwnedRoots(
+      [{ pid: 100, discoveredBirth: discoveredBirth_A }],
+      {
+        birth: () => currentBirth_B,
+        currentBirthSignature: () => currentSig_B,
+        vanished: () => false,
+      },
+    );
+    expect(newRoots).toEqual([]);
+    //             ^^ ✅ B 被拒绝,reap 不会杀 B
+  });
+
+  test("同一代 pid: currentBirthSignature 与 discoveredBirth 相等 ⇒ 收下,birth 用存储格式", () => {
+    const roots = resolveOwnedRoots(
+      [{ pid: 200, discoveredBirth: "Mon Aug 30 10:00:00 2026" }],
+      {
+        birth: () => "67890",
+        currentBirthSignature: () => "Mon Aug 30 10:00:00 2026",
+        vanished: () => false,
+      },
+    );
+    // birth 存储格式(jiffies)与 discoveredBirth(lstart)不同,收进 OwnedRoot
+    // 的 birth 字段是 birth() 返回的存储格式 —— 后续 lifecycle owner.json
+    // 与 wrapperBirth 等消费者仍用同一格式比对,无破坏。
+    expect(roots).toEqual([{ pid: 200, birth: "67890", role: "agent" }]);
+  });
+
+  test("pid 已消失 (vanished 确证) ⇒ skip", () => {
+    const roots = resolveOwnedRoots(
+      [{ pid: 300, discoveredBirth: "Mon Aug 30 10:00:00 2026" }],
+      { birth: () => null, currentBirthSignature: () => null, vanished: () => true },
+    );
+    expect(roots).toEqual([]);
+  });
+
+  test("currentBirthSignature 读不到但 vanished 不确证 (权限等) ⇒ throw", () => {
+    expect(() => resolveOwnedRoots(
+      [{ pid: 400, discoveredBirth: "Mon Aug 30 10:00:00 2026" }],
+      { birth: () => null, currentBirthSignature: () => null, vanished: () => false },
+    )).toThrow("NODE_OWNER_BIRTH_UNAVAILABLE: pid=400");
+  });
+
+  test("批量: 3 个候选,一个同代、一个 pid 回收、一个消失 ⇒ 只收第 1 个", () => {
+    const candidates: OwnedRootCandidate[] = [
+      { pid: 501, discoveredBirth: "Mon Aug 30 10:00:00 2026" },  // 同代
+      { pid: 502, discoveredBirth: "Mon Aug 30 10:00:00 2026" },  // pid 回收
+      { pid: 503, discoveredBirth: "Mon Aug 30 10:00:00 2026" },  // 消失
+    ];
+    const roots = resolveOwnedRoots(candidates, {
+      birth: (pid) => pid === 503 ? null : `birth-${pid}`,
+      currentBirthSignature: (pid) => {
+        if (pid === 501) return "Mon Aug 30 10:00:00 2026";  // 匹配
+        if (pid === 502) return "Mon Aug 30 10:15:00 2026";  // 不匹配 (回收)
+        return null;                                          // 消失
+      },
+      vanished: (pid) => pid === 503,
+    });
+    expect(roots).toEqual([{ pid: 501, birth: "birth-501", role: "agent" }]);
   });
 });
 

--- a/agent-network/src/owned-roots.ts
+++ b/agent-network/src/owned-roots.ts
@@ -23,27 +23,61 @@ export interface OwnedRoot {
   role: OwnedRootRole;
 }
 
-export interface OwnedRootProbes {
-  /** 进程这一代的出生时刻;读不到返回 null(可能已退出,也可能无权限)。 */
-  birth(pid: number): string | null;
-  /** 🔴 只有**确证**进程不存在时返回 false。无权限等一律视为存在。 */
-  vanished(pid: number): boolean;
+/** 🔴 #1438 — 发现阶段(`ps`)与后续 `/proc/<pid>/stat` 读之间,pid 可能被回收。
+ *  为让 resolveOwnedRoots 能识别「pid 相同、进程不同」,发现阶段必须在
+ *  **同一次 `ps` 快照**里同时取 pid 与一个稳定的启动时刻签名(lstart),
+ *  并把这个签名一路带进来做比对。同一次 ps 内的 pid 与 lstart 无 TOCTOU。 */
+export interface OwnedRootCandidate {
+  pid: number;
+  /** 发现时刻的 `ps -o lstart=` 字符串(24 字符定宽),用于识别 pid 回收。 */
+  discoveredBirth: string;
 }
 
-/** 把 `ps` 发现的 pid 列表冻结成 owned roots。
+export interface OwnedRootProbes {
+  /** 进程这一代的出生时刻(以「存储格式」返回,通常是 /proc/stat starttime jiffies);
+   *  读不到返回 null(可能已退出,也可能无权限)。用于写进 lifecycle 记录。 */
+  birth(pid: number): string | null;
+  /** 🔴 只有**确证**进程不存在时返回 true。无权限等一律视为存在。 */
+  vanished(pid: number): boolean;
+  /** 🔴 #1438 — 返回**当前**pid 的 lstart 签名,和发现阶段同格式。
+   *  用来识别 pid 回收:发现时是 A、现在读回来是 B ⇒ pid 已被复用。
+   *  读不到返回 null(进程已退出,或读 ps 失败)。 */
+  currentBirthSignature(pid: number): string | null;
+}
+
+/** 把 `ps` 发现的 (pid, birth) 候选冻结成 owned roots。
  *
- * · 读得到 birth              ⇒ 收下
- * · 读不到、且**确证已消失**  ⇒ 跳过(stop 想要的结果,不是错误)
- * · 读不到、进程仍在          ⇒ throw(权限等真问题,不放过)
+ * · currentBirthSignature 与 discoveredBirth **相等** ⇒ 同一代,收下
+ * · currentBirthSignature 与 discoveredBirth **不等** ⇒ 🔴 #1438 pid 已被复用,
+ *     现在这个 pid 属于另一个进程 B。**跳过**(而不是收下 B 当我们的节点):
+ *     stop 的目的是让 A 没了;B 是无关进程,不能因为它恰好占了 A 的 pid 就被杀。
+ * · currentBirthSignature 为 null、**确证已消失**   ⇒ 跳过(stop 想要的结果)
+ * · currentBirthSignature 为 null、进程仍在        ⇒ throw(权限等真问题)
  */
-export function resolveOwnedRoots(pids: number[], probes: OwnedRootProbes): OwnedRoot[] {
+export function resolveOwnedRoots(candidates: OwnedRootCandidate[], probes: OwnedRootProbes): OwnedRoot[] {
   const roots: OwnedRoot[] = [];
-  for (const pid of pids) {
+  for (const { pid, discoveredBirth } of candidates) {
+    const currentSig = probes.currentBirthSignature(pid);
+    if (currentSig === null) {
+      // pid 现在读不到:要么真消失(stop 结果),要么权限问题(fail-closed)
+      if (probes.vanished(pid)) continue;
+      throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
+    }
+    if (currentSig !== discoveredBirth) {
+      // 🔴 pid 回收命中:这个 pid 现在是另一个进程,不是发现阶段的 A。
+      // 无论 A 是自己退出还是刚被别的 stop 干掉,当前 pid 都不属于我们 ——
+      // 静默跳过,让 reap 不误伤 B。日志放在调用点(cli.ts)以带上 alias
+      // 上下文,这里保持纯函数无 IO。
+      continue;
+    }
     const birth = probes.birth(pid);
     if (birth) {
       roots.push({ pid, birth, role: "agent" });
       continue;
     }
+    // currentBirthSignature 刚成功却 birth 读不到:极窄窗口进程刚退,或
+    // /proc 读法与 ps 读法权限不同(理论上不会,存在打日志的价值)。仍
+    // fail-closed:确证消失才放过。
     if (probes.vanished(pid)) continue;
     throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
   }


### PR DESCRIPTION
Fixes #1438 (`anet node stop` alias-fallback pid-reuse TOCTOU — silently reap wrong process). Pinned to `origin/main = 4f9d51f2`.

**Content search performed:** `gh pr list --repo sleep2agi/agent-network --state all --search "resolveOwnedRoots"` / `--search "owned-roots pid reuse"` / `--search "1438"` → zero prior PR. This is the first fix.

## Root cause

`anet node stop` on a node without a lifecycle receipt (the "legacy" pre-receipt path) discovers pids by alias, then reads birth per pid, then hands the (pid, birth) pairs to `resolveOwnedRoots` for freezing. The two reads happen in different `ps` / `/proc` calls:

```
cli.ts:8684   findNodeProcessesByAlias   ps -eww -o pid= -o args=       → pids
cli.ts:8751   processBirth(pid)          read /proc/<pid>/stat          → birth
owned-roots.ts:39-53   resolveOwnedRoots(pids, probes)                  → freeze
```

Between step 1 and step 2, pid X can die and be recycled to a new unrelated process B. When `processBirth(X)` reads `/proc/X/stat` it reads B's `starttime` — truthy — so `resolveOwnedRoots` puts `{pid: X, birth: B's_birth}` into the roots set. Downstream `snapshotOwnedProcessTree` and reap validate `(pid, birth)` — but the birth they validate against is **B's own**, so validation passes and reap kills B.

Silent, wrong-side-of-safe. Not "one extra error report", "unrelated process killed under the reader's alias".

## Fix

**owned-roots.ts:**

- New `OwnedRootCandidate { pid; discoveredBirth }` where `discoveredBirth` is the lstart string captured **in the same `ps` snapshot** as the pid. Single ps invocation → no window.
- `OwnedRootProbes` gains `currentBirthSignature(pid): string | null` — returns pid's **current** lstart via `ps -p <pid> -o lstart=`. Same format the discovery captured, so equality-compare is meaningful.
- `resolveOwnedRoots(candidates, probes)` — after fetching `currentBirthSignature(pid)`:
  - null → fall through to the existing `vanished()`-based skip-or-throw (#1422 semantics preserved).
  - `!== discoveredBirth` → 🔴 pid was recycled: **silently skip**. The agent A that occupied this pid is definitely gone (recycling requires the old to exit); B is unrelated.
  - `=== discoveredBirth` → same incarnation, read the storage-format birth via `probes.birth()` and freeze.
- `OwnedRoot { pid, birth, role }` shape UNCHANGED. `birth` stored is still `probes.birth()` output (jiffies on Linux), so `snapshotOwnedProcessTree`, `wrapperBirth` comparisons, and `owner.json` records need no migration.

**cli.ts:**

- NEW `findNodeStopCandidates(alias)` uses `ps -eww -o pid= -o lstart= -o args=`. Strict regex for the 24-char fixed-width lstart. Same identity rules as `findNodeProcessesByAlias` (#180 R1 / #146 PR-3).
- NEW `probeCurrentBirthSignature(pid)` uses `ps -p <pid> -o lstart=`.
- Stop alias-fallback call site (~L9463) now uses these two + the new probe wired into `resolveOwnedRoots`. Comment cross-references #1422 (unchanged) and #1438 (this).

**Scope decision — rename lane NOT touched.** `findNodeProcessesByAlias` (cli.ts:8684) is UNCHANGED so its two other callers keep the `number[]` contract:

- L8961 `oldProcs = findNodeProcessesByAlias(oldDisplay, oldId)` — rename precondition
- L9205 `livePids = findNodeProcessesByAlias(oldDisplay, oldId) ?? oldProcs` — rename kill loop

They have the **same class** of pid-reuse bug (both directly `terminateNodeProcess(pid)` by pid alone, no birth verification), but the dispatch specifically scoped this to the stop alias-fallback path. Fixing them requires the same discovery-time-birth threading through `terminateNodeProcess`, which is a separate scope. Recommend filing a follow-up.

## Witnessed-red proof

Body-only revert (signature + interface kept — proves the LOGIC change is what catches the pid-reuse, not merely the shape change):

```
Fixed body:     14 pass / 0 fail / 15 expect() calls
Reverted body:  12 pass / 2 fail / 15 expect()

Failing tests on revert:
  #1438 resolveOwnedRoots — pid-reuse guard > 🔴 witnessed-red: pid 回收 scenario — legacy 静默收下 B,new 拒绝
  #1438 resolveOwnedRoots — pid-reuse guard > 批量: 3 个候选,一个同代、一个 pid 回收、一个消失 ⇒ 只收第 1 个
```

The remaining #1422 tests (5 total, ps→birth-vanish family + `processVanished`) stay green in both — the pid-reuse guard is additive, not a replacement.

## Files

- `agent-network/src/owned-roots.ts` — +45/-15. New `OwnedRootCandidate`, new `currentBirthSignature` probe, resolve logic gains pid-reuse guard.
- `agent-network/src/owned-roots.test.ts` — +125/-24. #1422 wrapper via helper; 5 new #1438 tests (witnessed-red + same-incarnation + vanished + fail-closed-perms + batch).
- `agent-network/bin/cli.ts` — +65/-8. New `findNodeStopCandidates` + `probeCurrentBirthSignature`; stop alias-fallback site rewired.

## Cross-reference

`#1437` (Hub马) introduced `owned-roots`. This fix uses the same seam but tightens the discovery→resolve invariant. If the rename-lane follow-up lands later, both consumers benefit from the same primitive.

## Deploy risk

None to storage format (`OwnedRoot.birth` and `owner.json` schema unchanged). Behavioral change is in the SAFE direction: a stop-path that previously would have (rarely, TOCTOU-window-hit) killed an unrelated recycled-pid process now skips that pid, and the agent A whose pid was recycled was already gone anyway (recycling requires exit). No caller loses functionality.
