### PR TITLE
fix(hub): start_node 加 stale-starting reaper,对齐 config/restart (#1448 finding-2)

### DIFF
--- a/server/src/start-node.test.ts
+++ b/server/src/start-node.test.ts
@@ -50,3 +50,60 @@ describe("start_node Hub -> daemon lifecycle", () => {
     expect((await call(u.start_node, { child_node_id: CHILD, daemon_node_id: "node_wrong", network_id: NET })).error).toBe("daemon_child_mismatch");
   });
 });
+
+// #1448 finding-2 — stale-starting reaper（对齐 update_node_config/restart_node 的 60s
+// single-flight stale-supersede）。start 只受理 stopped;卡在 starting 的节点(门铃丢 /
+// daemon 在 UPDATE starting 后死)改前永远 start 不了(gate 返 node_not_stopped)、也无
+// reaper 拉回 → 永久卡死。改后:in-flight start 请求晾过 60s ⇒ 标 timeout 超越 + 放行
+// 重派;未过阈值 ⇒ 拒 node_already_starting。
+describe("start_node — stale-starting reaper (#1448 finding-2)", () => {
+  function seedStartReq(reqId: string, status: string, ageMs: number) {
+    db.run(
+      `INSERT INTO node_start_requests(request_id,network_id,daemon_node_id,child_node_id,child_alias,created_by_token,status,created_at)
+       VALUES(?1,?2,?3,?4,?5,'t',?6,?7)`,
+      [reqId, NET, DAEMON, CHILD, CHILD_ALIAS, status, Date.now() - ageMs],
+    );
+  }
+
+  test("starting + FRESH in-flight start (< 60s) → refused node_already_starting (not superseded)", async () => {
+    db.run(`UPDATE nodes SET lifecycle_state='starting' WHERE node_id=?1`, CHILD);
+    seedStartReq("str_fresh", "delivered", 5_000);   // 5s old — within threshold
+    const u = handlers(USER);
+    const r = await call(u.start_node, { child_node_id: CHILD, network_id: NET });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_already_starting");
+    expect(r.existing_request_id).toBe("str_fresh");
+    expect(typeof r.age_ms).toBe("number");
+    // old request untouched, no new dispatch
+    expect(db.get<any>(`SELECT status FROM node_start_requests WHERE request_id='str_fresh'`)?.status).toBe("delivered");
+  });
+
+  // witnessed-red：改前 gate 直接 `!== 'stopped' → node_not_stopped`，一个 stale 的
+  // 'starting' 节点返回 node_not_stopped、永远卡死。改后应超越重派(ok:true)。
+  test("starting + STALE in-flight start (> 60s) → supersede old + re-dispatch (converges)", async () => {
+    db.run(`UPDATE nodes SET lifecycle_state='starting' WHERE node_id=?1`, CHILD);
+    seedStartReq("str_stale", "delivered", 61_000);   // 61s old — past 60s threshold
+    const u = handlers(USER);
+    const r = await call(u.start_node, { child_node_id: CHILD, network_id: NET });
+    expect(r.ok).toBe(true);
+    expect(r.lifecycle_state).toBe("starting");
+    expect(typeof r.request_id).toBe("string");
+    expect(r.request_id).not.toBe("str_stale");                       // fresh request
+    // old stale request superseded → terminal, unblocks the child-inflight unique index
+    expect(db.get<any>(`SELECT status FROM node_start_requests WHERE request_id='str_stale'`)?.status).toBe("timeout");
+    // exactly one non-terminal start request now (the new one)
+    const live = db.all<any>(`SELECT request_id FROM node_start_requests WHERE child_node_id=?1 AND status IN ('pending','delivered')`, CHILD);
+    expect(live.map((x:any)=>x.request_id)).toEqual([r.request_id]);
+    // audit records the real prior state
+    const aud = db.get<any>(`SELECT detail FROM audit_log WHERE target_id=?1`, r.request_id);
+    expect(JSON.parse(aud.detail).lifecycle_state_before).toBe("starting");
+  });
+
+  test("starting + NO in-flight row (orphaned state) → self-heals by re-dispatching", async () => {
+    db.run(`UPDATE nodes SET lifecycle_state='starting' WHERE node_id=?1`, CHILD);
+    const u = handlers(USER);
+    const r = await call(u.start_node, { child_node_id: CHILD, network_id: NET });
+    expect(r.ok).toBe(true);
+    expect(r.lifecycle_state).toBe("starting");
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -4019,8 +4019,43 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       );
       if (!child) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden_cross_tenant" }) }] };
       if (!canWrite(child.network_id)) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "permission_denied" }) }] };
-      if ((child.lifecycle_state ?? "active") !== "stopped") {
-        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "node_not_stopped", current_state: child.lifecycle_state ?? "active" }) }] };
+      // #1448 finding-2 — stale-starting reaper，对齐 update_node_config / restart_node
+      // 的 60s single-flight stale-supersede。start 只受理 'stopped';一旦卡 'starting'
+      // (门铃丢 / daemon 在 UPDATE 'starting' 后死),config/restart 有 reaper、delete 有
+      // 5min force,唯独 start 裸奔 → 下面的 gate 永远拦、也无人把节点拉回 stopped →
+      // 永久卡 'starting'。出口:'starting' 且最近一条 in-flight start 请求晾过阈值 → 标
+      // 旧请求 timeout 超越、放行重派;未过阈值则拒 node_already_starting(带 age)。
+      const priorState = child.lifecycle_state ?? "active";
+      if (priorState !== "stopped") {
+        if (priorState !== "starting") {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "node_not_stopped", current_state: priorState }) }] };
+        }
+        const STALE_STARTING_MS = 60_000;
+        const inFlight = db.get<{ request_id: string; created_at: number; delivered_at: number | null; acked_at: number | null }>(
+          `SELECT request_id, created_at, delivered_at, acked_at FROM node_start_requests
+             WHERE child_node_id = ?1 AND status IN ('pending', 'delivered')
+             ORDER BY created_at DESC LIMIT 1`, child.node_id,
+        );
+        if (inFlight) {
+          // Age anchor = COALESCE(acked_at, delivered_at, created_at)，同 config reaper:
+          // 已 pull/已 ack 的活着但慢的 start 会刷新存活时钟,不被误 reap。
+          const ageAnchor = inFlight.acked_at ?? inFlight.delivered_at ?? inFlight.created_at;
+          const age = Date.now() - ageAnchor;
+          if (age <= STALE_STARTING_MS) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({
+              ok: false, error: "node_already_starting",
+              existing_request_id: inFlight.request_id, age_ms: age,
+              hint: `再等一下;超过 ${STALE_STARTING_MS / 1000}s 仍卡 starting,重试 start 会重新派发`,
+            }) }] };
+          }
+          // Stale — 标旧请求 timeout(autocommit,先于下面 tx 的新 INSERT,解除
+          // node_start_requests 对 pending/delivered 的 child 唯一约束),放行重派。
+          db.run(
+            `UPDATE node_start_requests SET status = 'timeout', acked_at = ?1, error = ?2 WHERE request_id = ?3`,
+            [Date.now(), `superseded by new start after ${age}ms stale (> ${STALE_STARTING_MS}ms threshold)`, inFlight.request_id],
+          );
+        }
+        // else: 'starting' 但无 in-flight 行(异常残留态)——照样放行重派以自愈。
       }
       // The caller may provide daemon_node_id, but it cannot override the
       // authoritative child->daemon relationship recorded at creation.
@@ -4046,12 +4081,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7)`,
             [requestId, child.network_id, daemon.node_id, child.node_id, child.alias, callerTokenId || "unknown", now],
           );
-          db.run(`UPDATE nodes SET lifecycle_state = 'starting' WHERE node_id = ?1 AND lifecycle_state = 'stopped'`, [child.node_id]);
+          // #1448 finding-2 — 也接受从 'starting' 重派(stale-supersede 后原态仍是
+          // starting);两种入态都合法地转/留到 'starting'。
+          db.run(`UPDATE nodes SET lifecycle_state = 'starting' WHERE node_id = ?1 AND lifecycle_state IN ('stopped', 'starting')`, [child.node_id]);
           auditCreateNodeStrict({
             action: "start_node_dispatched", user_id: enforceUserId,
             network_id: child.network_id, target_id: requestId,
             detail: { child_node_id: child.node_id, child_alias: child.alias, daemon_node_id: daemon.node_id,
-              lifecycle_state_before: "stopped", lifecycle_state_after: "starting", ts_request: now },
+              lifecycle_state_before: priorState, lifecycle_state_after: "starting", ts_request: now },
           });
         });
       } catch (e: any) {


### PR DESCRIPTION
Addresses #1448 **finding 2** (MEDIUM, stuck-state). Fast-follow to #1450 (finding 1, merged) + #1453 (finding 3). Independent from both (touches only `start_node` in `tools.ts` + `start-node.test.ts`).

## 缺陷（CONFIRMED）
`start_node` 只受理 `lifecycle_state='stopped'`。一旦节点卡在 `'starting'`（SSE 门铃丢 / daemon 在 `UPDATE 'starting'` 后死），它就再也 start 不了：gate 返 `node_not_stopped`，而**没有任何东西把 `starting` 拉回 `stopped`**。`update_node_config`（tools.ts:~2696）/`restart_node` 有 60s single-flight reaper、`delete` 有 5min force，**唯独 start 裸奔** → 永久卡 `starting`，唯一出路是 `delete_node`（`restart_node` 无效：stopped/starting 子节点无自己的 SSE 消费者）。

与 #1450（finding 1）的分工：#1450 的重连补偿覆盖「门铃丢 → 行仍 `pending`」——重连时重放。finding-2 覆盖 **「已 pull 后 daemon 死 → 行卡 `delivered` / 节点卡 `starting`」** 这条重连补偿够不着的独立缺口。

## 修复（镜像 config/restart 的 60s stale-supersede）
`start_node` 的 state gate：`state === 'starting'` 时查最近一条 in-flight（`pending`/`delivered`）start 请求——
- age（锚 `COALESCE(acked_at, delivered_at, created_at)`，**同 config reaper**：已 pull/ack 的「活着但慢」的 start 会刷新存活时钟，不被误 reap）**> 60s** ⇒ 标旧请求 `timeout` 超越（autocommit，先于新 INSERT，解除 `node_start_requests` 对 child 的 `pending/delivered` 唯一约束）+ 放行重派；
- **≤ 60s** ⇒ 拒 `node_already_starting`（带 `age_ms` + hint）。

dispatch 的 `UPDATE nodes SET lifecycle_state='starting'` 放宽到 `WHERE lifecycle_state IN ('stopped','starting')`，audit `lifecycle_state_before` 记真实入态。无 schema 改动（不加 force，与 config/restart 一致自动超越）。

## Witnessed-red（`start-node.test.ts` +3）
- `starting` + **fresh**（<60s）in-flight ⇒ 拒 `node_already_starting`，旧请求不动、无新派发。
- `starting` + **stale**（>60s）in-flight ⇒ `ok:true` 超越重派：旧请求 → `timeout`、唯一 in-flight 为新请求、audit `before='starting'`。**改前 gate `!== 'stopped' → node_not_stopped`，此断言 `ok:true` 红。**
- `starting` + 无 in-flight 行（残留态）⇒ 自愈重派。
- 判别力已证：把 `tools.ts` 还原成 origin/main（旧 gate）→ 三条全红。

## 验证
- `tsc --noEmit` 0 error；`start-node.test.ts` 5/5；无回归（`stop-delete-node` 32/32、`node-lifecycle-controllable` 8/8）；`doc-symbol-pins` OK（漂移 0）。

至此 #1448 三条 stuck-state 缺口（finding 1 SSE 重连补偿 / finding 3 stop 收敛 / finding 2 start reaper）全部有 PR。findings 4-6（LOW/SUSPECTED 一致性/硬化）可另行排。
