### PR TITLE
fix(codex-app-server): keep the final answer across multiple agent messages, and reap the owned child on startup failure

### DIFF
--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -507,3 +507,63 @@ describe("codexAppServerReplyOrThrow", () => {
       .toBe("（无回复）");
   });
 });
+
+// #1449 finding 2 —— owned-server 分支必须自己收尸。
+//
+// spawn 之后的 waitWs / client.connect / bridge.bootstrap /
+// recoverSharedTurnOnAttach 任何一步抛出，原来都不会 kill 掉我们**自己拥有**的
+// app-server 子进程（onExit 只通知）。supervisor 每重试失败一次就攒一个僵尸，
+// 各自占着一个端口。
+//
+// 不加任何仅为测试存在的接缝：`opts.binary` 本来就可注入，指向一个「只睡、
+// 不监听」的假二进制，waitWs 就会失败，走的是真实启动路径。代价是要等满
+// waitWs 的重试预算（60 × 300ms），所以这条慢。
+//
+// 判据落在**进程表里还有没有它**，不是「kill 有没有被调用」—— 后者可以在
+// 什么都没死的情况下为真。假二进制路径是临时目录里的唯一串，只用来计数。
+describe("#1449 finding 2 — 启动失败时不留孤儿子进程", () => {
+  test("waitWs 失败 ⇒ 自己 spawn 的子进程被 kill，不留在后台占端口", async () => {
+    const { mkdtempSync, writeFileSync, chmodSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { execFileSync } = await import("node:child_process");
+    const { openCodexAppServerRuntime } = await import("./runtime");
+
+    const dir = mkdtempSync(join(tmpdir(), "f1449-orphan-"));
+    const fake = join(dir, "fake-codex");
+    // 🔴 不要用 `exec`：exec 会把进程 argv 换成 `sleep`，这条唯一路径就从 argv 里
+    //    消失，下面按路径计数的量具会恒读 0 —— 那样这条测试在「有孤儿」和
+    //    「没孤儿」两种情况下都绿。我第一版就是这么写的，变异掉 proc.kill()
+    //    之后仍然 24/24 全绿，是拿已知存活的进程去校准计数器才发现的。
+    //    sleep 取 45s：shell 被杀后即使 sleep 短暂残留也很快自退，不留垃圾。
+    writeFileSync(fake, "#!/bin/sh\nsleep 45\n", "utf8");
+    chmodSync(fake, 0o755);
+
+    const countAlive = (): number => {
+      try {
+        const out = execFileSync("/bin/sh", ["-c", `ps -eo args | grep -F ${JSON.stringify(fake)} | grep -v grep | wc -l`], { encoding: "utf8" });
+        return Number(out.trim()) || 0;
+      } catch { return 0; }
+    };
+
+    expect(countAlive()).toBe(0);   // 前提：这条唯一路径此刻没有任何进程
+
+    let threw = false;
+    try {
+      await openCodexAppServerRuntime({ binary: fake, log: () => {}, warn: () => {}, onExit: () => {} });
+    } catch { threw = true; }
+    expect(threw).toBe(true);
+
+    // 给 kill 一点落地时间；修复前这里会一直是 1
+    let alive = countAlive();
+    for (let i = 0; i < 20 && alive > 0; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      alive = countAlive();
+    }
+    if (alive > 0) {
+      // 兜底清理：只按这条唯一路径精确清，避免把孤儿留给后续测试
+      try { execFileSync("/bin/sh", ["-c", `pkill -f ${JSON.stringify(fake)} || true`]); } catch {}
+    }
+    expect(alive).toBe(0);
+  }, 60_000);
+});

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -164,74 +164,87 @@ export async function openCodexAppServerRuntime(opts: {
   let proc: ChildProcess | null = null;
   let url = opts.serverUrl;
 
-  if (!url) {
-    // Owned-server topology: spawn `codex app-server --listen ws://…`.
-    const port = randomPort();
-    url = `ws://127.0.0.1:${port}`;
-    const binary = opts.binary ?? "codex";
-    const wireCommhub = !!(opts.commhubMcpUrl && opts.commhubToken);
-    const spawnArgs = buildOwnedAppServerArgs(url, {
-      approvalPolicy: opts.approvalPolicy,
-      sandboxMode: opts.sandboxMode,
-      commhubMcpUrl: wireCommhub ? opts.commhubMcpUrl : undefined,
-    });
-    // Token via env only (never in argv/config) so it can't leak through a
-    // process list or on-disk config.
-    const childEnv = wireCommhub
-      ? { ...process.env, [COMMHUB_MCP_TOKEN_ENV]: opts.commhubToken }
-      : process.env;
-    log(`[codex-app-server] spawning ${binary} ${spawnArgs.join(" ")}${wireCommhub ? " (+commhub MCP)" : ""}`);
-    proc = spawn(binary, spawnArgs, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: childEnv,
-    });
-    proc.stderr?.on("data", (d) =>
-      log(`[codex-app-server stderr] ${String(d).trim().slice(0, 300)}`),
-    );
-    if (opts.onExit) proc.on("exit", (code, signal) => opts.onExit!({ code, signal }));
-    await waitWs(url);
-  } else {
-    log(`[codex-app-server] attaching to shared server ${url}`);
-  }
-
-  const client = new CodexAppServerClient({ url, clientLabel: "anet_codex_bridge" });
-  client.on("error", (e) => warn(`[codex-app-server] client error: ${String(e).slice(0, 200)}`));
-  await client.connect();
-
-  const bridge = new CodexAppServerBridge({
-    client, threadId: opts.threadId, deferThreadUntilTui: opts.deferThreadUntilTui,
-    initialDeferredThreadId: opts.initialDeferredThreadId,
-    onDeferredCandidate: opts.onDeferredCandidate,
-  });
-  bridge.on("thread_waiting", () => log("[codex-app-server] client-health role=bridge state=waiting-for-tui-thread"));
-  bridge.on("thread_ready", (e: { threadId: string; created: boolean }) => {
-    if (e.created) {
-      log(`[codex-app-server] created thread ${e.threadId.slice(0, 12)}…`);
+  // #1449 — owned-server 分支必须自己收尸。spawn 之后的 waitWs / connect /
+  // bootstrap / recoverSharedTurnOnAttach 任何一步抛出，都会把这个我们**自己拥有**
+  // 的 app-server 子进程留在后台占着端口；onExit 只是通知，不会杀它。supervisor
+  // 每重试失败一次就攒一个僵尸，最终端口耗尽。
+  // 只对我们自己 spawn 的子进程负责：attach 到共享 server 时 proc 为 null，不碰。
+  try {
+    if (!url) {
+      // Owned-server topology: spawn `codex app-server --listen ws://…`.
+      const port = randomPort();
+      url = `ws://127.0.0.1:${port}`;
+      const binary = opts.binary ?? "codex";
+      const wireCommhub = !!(opts.commhubMcpUrl && opts.commhubToken);
+      const spawnArgs = buildOwnedAppServerArgs(url, {
+        approvalPolicy: opts.approvalPolicy,
+        sandboxMode: opts.sandboxMode,
+        commhubMcpUrl: wireCommhub ? opts.commhubMcpUrl : undefined,
+      });
+      // Token via env only (never in argv/config) so it can't leak through a
+      // process list or on-disk config.
+      const childEnv = wireCommhub
+        ? { ...process.env, [COMMHUB_MCP_TOKEN_ENV]: opts.commhubToken }
+        : process.env;
+      log(`[codex-app-server] spawning ${binary} ${spawnArgs.join(" ")}${wireCommhub ? " (+commhub MCP)" : ""}`);
+      proc = spawn(binary, spawnArgs, {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: childEnv,
+      });
+      proc.stderr?.on("data", (d) =>
+        log(`[codex-app-server stderr] ${String(d).trim().slice(0, 300)}`),
+      );
+      if (opts.onExit) proc.on("exit", (code, signal) => opts.onExit!({ code, signal }));
+      await waitWs(url);
     } else {
-      log(`[codex-app-server] resumed thread ${e.threadId.slice(0, 12)}…`);
+      log(`[codex-app-server] attaching to shared server ${url}`);
     }
-    if (opts.onThread) void opts.onThread(e.threadId, e.created);
-  });
-  bridge.on("waiting_human", () =>
-    warn(`[codex-app-server] turn is waiting on a human approval — bridge will NOT answer`),
-  );
-  await bridge.bootstrap();
-  if (opts.serverUrl) {
-    await recoverSharedTurnOnAttach(bridge, log, warn);
-  }
 
-  return {
-    client,
-    bridge,
-    proc,
-    threadId: bridge.getThreadId(),
-    get isRunning() {
-      // Owned server: the child must be alive. Shared server: rely on the
-      // ws client's connection state.
-      if (proc) return proc.exitCode === null && !proc.killed;
-      return client.isConnected;
-    },
-  };
+    const client = new CodexAppServerClient({ url, clientLabel: "anet_codex_bridge" });
+    client.on("error", (e) => warn(`[codex-app-server] client error: ${String(e).slice(0, 200)}`));
+    await client.connect();
+
+    const bridge = new CodexAppServerBridge({
+      client, threadId: opts.threadId, deferThreadUntilTui: opts.deferThreadUntilTui,
+      initialDeferredThreadId: opts.initialDeferredThreadId,
+      onDeferredCandidate: opts.onDeferredCandidate,
+    });
+    bridge.on("thread_waiting", () => log("[codex-app-server] client-health role=bridge state=waiting-for-tui-thread"));
+    bridge.on("thread_ready", (e: { threadId: string; created: boolean }) => {
+      if (e.created) {
+        log(`[codex-app-server] created thread ${e.threadId.slice(0, 12)}…`);
+      } else {
+        log(`[codex-app-server] resumed thread ${e.threadId.slice(0, 12)}…`);
+      }
+      if (opts.onThread) void opts.onThread(e.threadId, e.created);
+    });
+    bridge.on("waiting_human", () =>
+      warn(`[codex-app-server] turn is waiting on a human approval — bridge will NOT answer`),
+    );
+    await bridge.bootstrap();
+    if (opts.serverUrl) {
+      await recoverSharedTurnOnAttach(bridge, log, warn);
+    }
+
+    return {
+      client,
+      bridge,
+      proc,
+      threadId: bridge.getThreadId(),
+      get isRunning() {
+        // Owned server: the child must be alive. Shared server: rely on the
+        // ws client's connection state.
+        if (proc) return proc.exitCode === null && !proc.killed;
+        return client.isConnected;
+      },
+    };
+  } catch (e) {
+    if (proc) {
+      try { proc.kill(); } catch { /* 已经退出了就算了 */ }
+      warn(`[codex-app-server] startup failed, killed owned child pid=${proc.pid ?? "?"}`);
+    }
+    throw e;
+  }
 }
 
 export interface CodexAppServerThinkResult {

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -308,3 +308,72 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(new PrivateFileOperationLedger(join(root, "operations")).get("node-1", "discard-side", operation.operationId)?.state).toBe("ambiguous");
   });
 });
+
+// #1449 finding 1 —— 一个 turn 发多条 agentMessage 时，终态取哪一条。
+//
+// onItem 对 agentMessage 用「赋值」，onDelta 用「追加」，共用同一个
+// execution.text。带工具调用的典型形状是「前言 → 工具 → 最终答案」，会发
+// 两条 agentMessage item；后一条覆盖前一条本身是对的，但**没有按 phase 过滤**
+// 意味着顺序一旦不是「前言在前」，答案就会被前言覆盖，且累积的 delta 也一起没了。
+//
+// 主任务路径（runtime/codex-app-server-bridge.ts:834、:844）早就按
+// `phase === "final_answer"` 过滤，并在没有 final 时回退到累积的 delta
+// （:1078 "Prefer the captured final_answer item; fall back to accumulated deltas"）。
+// 这里对齐它。
+describe("#1449 finding 1 — 多条 agentMessage 时的终态文本", () => {
+  const drive = async () => {
+    const { client, adapter } = make();
+    const { derivedThreadId } = await adapter.fork({ sideThreadId: "side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    await adapter.start({ sideThreadId: "side", attemptId: "attempt", derivedThreadId, prompt: "question" });
+    const terminals: any[] = [];
+    adapter.subscribe((e) => terminals.push(e));
+    return { client, derivedThreadId, terminals };
+  };
+
+  test("🔴 前言 + final_answer（各带 delta）⇒ 终态只应是 final_answer", async () => {
+    const { client, derivedThreadId, terminals } = await drive();
+    // 前言（phase 明确不是 final_answer），带它自己的流式 delta
+    client.emit("item/agentMessage/delta", { threadId: derivedThreadId, turnId: "turn-1", delta: "我先看一下" });
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", phase: "preamble", text: "我先看一下" } });
+    // 工具调用之后的最终答案
+    client.emit("item/agentMessage/delta", { threadId: derivedThreadId, turnId: "turn-1", delta: "磁盘 96%" });
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", phase: "final_answer", text: "磁盘 96%" } });
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    expect(terminals).toHaveLength(1);
+    // 既不是前言，也不是把两段拼起来 —— 就是 final_answer 本身
+    expect(terminals[0].text).toBe("磁盘 96%");
+  });
+
+  test("🔴 顺序反过来（final_answer 先到、前言后到）⇒ 答案不能被前言覆盖", async () => {
+    const { client, derivedThreadId, terminals } = await drive();
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", phase: "final_answer", text: "答案" } });
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", phase: "preamble", text: "过程文本" } });
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    expect(terminals[0].text).toBe("答案");
+  });
+
+  test("🔴 一个 final_answer 都没有 ⇒ 回退到累积的 delta，绝不发空串", async () => {
+    const { client, derivedThreadId, terminals } = await drive();
+    client.emit("item/agentMessage/delta", { threadId: derivedThreadId, turnId: "turn-1", delta: "只有" });
+    client.emit("item/agentMessage/delta", { threadId: derivedThreadId, turnId: "turn-1", delta: "流式内容" });
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", phase: "preamble", text: "前言" } });
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    expect(terminals[0].text).toBe("只有流式内容");
+    expect(terminals[0].text.length).toBeGreaterThan(0);
+  });
+
+  test("回归钉：phase 缺失/为 null 的 agentMessage 仍然算最终答案", async () => {
+    // 线上 phase 是 `MessagePhase | null`（types/codex/v2/ThreadItem.ts）。
+    // 严格要求 === "final_answer" 会把 null 那种判成前言 ⇒ 终态变空串，
+    // 那正是「空串=误报失败」。缺失/null 一律按最终答案处理。
+    for (const item of [
+      { type: "agentMessage", text: "无 phase" },
+      { type: "agentMessage", phase: null, text: "null phase" },
+    ] as const) {
+      const { client, derivedThreadId, terminals } = await drive();
+      client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item });
+      client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+      expect(terminals[0].text).toBe(item.text);
+    }
+  });
+});

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -373,7 +373,23 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
       const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
-      if (execution) execution.text = p.item.text; else this.dropped("unowned-agent-message");
+      if (!execution) { this.dropped("unowned-agent-message"); return; }
+      // #1449 — 一个 turn 会发多条 agentMessage（带工具调用时的典型形状是
+      // 「前言 → 工具 → 最终答案」）。原来无条件赋值，等于让**最后到达的那条**
+      // 成为答案；顺序一旦不是「前言在前」，最终答案就被过程文本盖掉，
+      // 连累积的 delta 也一起丢。
+      //
+      // 主任务路径早就按 phase 过滤（codex-app-server-bridge.ts:834、:844），
+      // 这里对齐它：只有最终答案能覆盖缓冲区。
+      //
+      // 🔴 但比主路径宽一格，而且是**朝安全方向宽**：线上 phase 的类型是
+      // `MessagePhase | null`（types/codex/v2/ThreadItem.ts），严格要求
+      // `=== "final_answer"` 会把 null / 缺失那种判成前言，终态就变成空串 ——
+      // 而空串会被上层读成「失败」。所以只在 phase **明确是别的相位**时才跳过。
+      const phase = (p.item as { phase?: unknown }).phase;
+      const isNonFinalPhase = typeof phase === "string" && phase !== "final_answer";
+      if (isNonFinalPhase) return;
+      execution.text = p.item.text;
     }
   };
 


### PR DESCRIPTION
#1449 的 finding 1 与 2。finding 3 留 follow-up（按约定不塞同一个 PR）。

## 🔴 先更正一格范围（已与 @通信龙 对齐）

brief 里的路径 `runtime/codex-app-server/codex-app-server-adapter.ts` 不存在；真实位置是 **`runtime/side-thread/codex-app-server-adapter.ts`**。

而**主任务路径是另一份代码**（`codex-app-server-bridge.ts`），它早就按 `phase === "final_answer"` 过滤。所以受影响面是 **side-thread / BTW 那条线**（`side-thread/production.ts` + `fork-process-race-worker.ts`，入口 `cli.ts:6433`），**不是普通网络任务回复**。

## finding 1 — 多条 agentMessage 时答案被覆盖

`onItem` 对每条 agentMessage **无条件赋值** `execution.text`，而 `onDelta` 往同一个缓冲 `+=`。带工具调用的 turn 会发不止一条（前言 → 答案），于是**最后到达的那条**成为回复，累积的 delta 也一起没了。

修法对齐主路径：只有 `final_answer` 能覆盖缓冲区。

**一处刻意的差异，朝安全方向**：线上类型是 `phase: MessagePhase | null`。严格要求 `=== "final_answer"` 会把 null/缺失判成前言 ⇒ 终态空串 ⇒ 上层读成失败。所以只在 phase **明确是别的相位**时才跳过。
本文件既有的 `binds execution by echoed client id` 用例发的正是**无 phase 且无 delta** 的 agentMessage 并断言拿到它的文本 —— 严格过滤会把它一起打红。**那条既有测试本身就是「无 phase 的 item 真实存在」的证据。**

🔴 值得记一格：**常见顺序（前言在前、答案在后）在有 bug 的代码下也是对的**，因为最后一次写入正好是答案。这就是它一直没被发现的原因。两条真正会红的用例是**顺序反过来**和**没有 final_answer**。

## finding 2 — 启动失败留下孤儿 app-server

spawn 之后 `waitWs` / `connect` / `bootstrap` / `recoverSharedTurnOnAttach` 任一抛出都不会 kill 子进程（`onExit` 只通知），supervisor 每失败一次攒一个占着端口的僵尸。现在启动整段被兜住，**只对自己 spawn 的那个负责**（attach 共享 server 时 `proc === null`，不碰）。

## 验证

- **双向变异**：撤掉 phase 过滤 ⇒ 4 条新 adapter 测试红 2；撤掉 `proc.kill()` ⇒ 孤儿测试红。还原后全绿。
- **回归**：12 个 side-thread / codex-app-server / bridge 套件**逐文件独立进程** ⇒ **135 pass / 0 fail**。
- 孤儿测试的判据落在**进程表**上，不是「kill 有没有被调用」（后者可以在什么都没死的情况下为真）。**不加任何仅为测试存在的接缝**：`opts.binary` 本来就可注入。

🔴 **这条测试我第一版是错的，而且看起来是对的**：假脚本用了 `exec sleep`，`exec` 会把进程 argv 换掉，按唯一路径 grep 的计数器于是恒读 0 —— 有没有孤儿它都绿，**变异掉 `proc.kill()` 仍然 24/24 全绿**。是拿一个已知存活的 pid 去校准计数器才发现的。原因写在脚本旁边，免得下一个人重新踩。

## 探针状态（① 未能完成）

按要求本地隔离起 app-server（随机端口、独立 cwd、不碰 `~/.codex/app-server-control`、不碰任何生产节点），RPC 全链路正常，但**账号额度用尽**，turn 直接 failed、模型零输出。

那个「agentMessage = 0」是**模型没跑**，不是「codex 只发一条」，所以不作为结论。改为依据：主 bridge 里 `phase === "final_answer"` 过滤**存在本身**（若一个 turn 只会有一条，这个过滤没有存在的理由），以及 `phase` 是协议类型的一部分。

## 查重

按内容搜过：`agentMessage` / `execution.text` / `proc.kill` ⇒ 无 open PR 碰这两个文件。按文件查重过：扫 open PR ⇒ 零重叠。
