### PR TITLE
fix(hub): send_desktop_message reported ok:true even when nobody was listening

### DIFF
--- a/server/src/desktop-message.test.ts
+++ b/server/src/desktop-message.test.ts
@@ -220,3 +220,67 @@ describe("send_desktop_message", () => {
     expect(auditCount()).toBe(0);
   });
 });
+
+// #1459 —— 返回值必须反映真实投递态。
+//
+// send_desktop_message 是 fire-and-forget：只 INSERT audit_log（不写 inbox），
+// 再 pushUserEvent 扇出；而 pushUserEvent 在没有订阅者时静默 return。
+// 用户 dashboard 离线/重连时消息永久丢（无 DB 行 ⇒ 无从 reconcile，
+// /api/messages 只 SELECT ... FROM inbox），而调用方拿到的是 ok:true。
+//
+// 本 PR 只做「让丢失可见」这一半：不碰 schema，返回值说实话。
+// 持久化 + 重连补投（让丢失不发生）是另一条，方向已定为按 user_id 寻址的新表。
+describe("#1459 send_desktop_message 返回值反映真实投递态", () => {
+  test("🔴 无活跃订阅者 ⇒ delivered:false + 可判读的 reason，而不是笼统 ok:true", async () => {
+    // 故意不建 SSE 流：这正是用户 dashboard 关着的情形
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const before = auditCount();
+    const result = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_A,
+      message: "nobody is listening",
+      severity: "info",
+    });
+
+    // ok 仍为 true：调用被接受、审计已落库 —— 这一格没变
+    expect(result.ok).toBe(true);
+    expect(result.message_id).toStartWith("dm_");
+    expect(auditCount()).toBe(before + 1);
+
+    // 新增的那一格：投递态
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toBe("no_live_subscriber");
+  });
+
+  test("有活跃订阅者 ⇒ delivered:true 且不带 reason", async () => {
+    const stream = createUserEventStream(NET_A, TARGET_A);
+    const reader = stream.body!.getReader();
+    await readFrame(reader);
+
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_A,
+      message: "someone is listening",
+      severity: "info",
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.reason).toBeUndefined();
+    // 前提断言：这一条真的送到了订阅者手上，否则 delivered:true 就是空话
+    const evt = await readFrame(reader);
+    expect(evt.message).toBe("someone is listening");
+    await reader.cancel();
+  });
+
+  test("🔴 两种情形必须给出不同读数 —— 防止判据退化成恒真", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const offline = await call(tools.send_desktop_message, { to_user_id: TARGET_A, message: "off", severity: "info" });
+
+    const stream = createUserEventStream(NET_A, TARGET_A);
+    const reader = stream.body!.getReader();
+    await readFrame(reader);
+    const online = await call(tools.send_desktop_message, { to_user_id: TARGET_A, message: "on", severity: "info" });
+    await reader.cancel();
+
+    expect(offline.delivered).not.toBe(online.delivered);
+  });
+});

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -464,6 +464,20 @@ export function pushNetworkObserverEvent(
 /** Push an event to every active Desktop/web client for one user in one
  *  network. No-op for falsy network/user ids; auth must be enforced by
  *  the caller before invoking this helper. */
+/** 这个用户此刻是否真的有活着的 SSE 订阅者。
+ *
+ *  与 alias 版 `hasSubscribers` 同形状：投递可达性的**实测**，
+ *  调用方据此把「送到了」和「没人听」区分开，而不是一律报成功。 */
+export function hasUserSubscribers(
+  networkId: string | null | undefined,
+  userId: string | null | undefined,
+): boolean {
+  if (!networkId || !userId) return false;
+  const arr = clients.get(userKey(networkId, userId));
+  if (!arr) return false;
+  return arr.some((c) => !c.closed);
+}
+
 export function pushUserEvent(
   networkId: string | null | undefined,
   userId: string | null | undefined,

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import { parseAliasFilter } from "./alias-filter.js";
 import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
-import { getSSEStats, hasSubscribers, pushEvent, pushNetworkObserverEvent, pushUserEvent } from "./push.js";
+import { getSSEStats, hasSubscribers, hasUserSubscribers, pushEvent, pushNetworkObserverEvent, pushUserEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { pendingInboxCount } from "./inbox-count.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
@@ -2382,9 +2382,30 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           effectiveNetId,
         ],
       );
+      // #1459 — pushUserEvent 在没有订阅者时静默 return，而这个工具既不写
+      // inbox、也没有任何 user 级回读路径（/api/messages 只 SELECT FROM inbox）。
+      // 也就是说用户 dashboard 关着的时候这条消息就永久没了。
+      //
+      // 这里先把**丢失变可见**：`ok` 仍表示「请求被接受、审计已落库」，
+      // 新增 `delivered` 表示「此刻真的有人收到」。判据取自订阅者注册表，
+      // 不是猜的。持久化 + 重连补投是另一条（按 user_id 寻址的新收件表，#1459）。
+      //
+      // 🔴 `reason` 报的是**观测到的事实**（此刻没有活订阅者），不是它的后果。
+      //    今天「没有活订阅者」确实等于「丢了」，但持久化落地之后同一个事实会
+      //    变成「已入库、等重连补投」。把值取成 no_live_subscriber 而不是
+      //    "lost"/"dropped"，就是为了那天不用改写历史含义 —— 届时按需细分
+      //    （如 lost vs queued）即可，现在不预先把语义焊死。
+      const delivered = hasUserSubscribers(effectiveNetId, target.user_id);
       pushUserEvent(effectiveNetId, target.user_id, event);
 
-      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, message_id: messageId, delivered_to_user_id: target.user_id, network_id: effectiveNetId }) }] };
+      return { content: [{ type: "text" as const, text: JSON.stringify({
+        ok: true,
+        message_id: messageId,
+        delivered,
+        ...(delivered ? {} : { reason: "no_live_subscriber" }),
+        delivered_to_user_id: target.user_id,
+        network_id: effectiveNetId,
+      }) }] };
     },
   );
 


### PR DESCRIPTION
#1459 的**「让丢失可见」**那一半。持久化 + 重连补投是另一半，归 @Hub马（他有 #1448 f1 的 pending-unacked 补投上下文，会设计按 `user_id` 寻址的新表）。

## 问题

`send_desktop_message` 写一行 `audit_log`、调 `pushUserEvent`、然后返回 `{ok:true, delivered_to_user_id}`。而：

- 它**从不写 `inbox`**
- `pushUserEvent` 在该用户没有订阅者时**静默 return**
- `/api/messages` 只 `SELECT ... FROM inbox`

⇒ 用户 dashboard 关着时发的消息**没了** —— 没有任何 DB 行可供 reconcile —— **而调用方被告知成功**。

## 改动

返回值新增 `delivered`，取自**订阅者注册表**而不是假设；为 false 时附 `reason: "no_live_subscriber"`。`ok` 保持原义：调用被接受、审计已落库。

🔴 **`reason` 报的是观测到的事实，不是它的后果。** 今天「没有活订阅者」确实等于「丢了」，但持久化落地之后，同一个事实会变成「已入库、等重连补投」。取名 `no_live_subscriber` 而不是 `lost`/`dropped`，就是为了那天不必改写历史响应的含义 —— 届时按需细分（lost vs queued）即可，而不是现在就把语义焊死。**这一格是 @Hub马 提的前瞻提示。**

`hasUserSubscribers` 镜像 #1277 加的 alias 版 `hasSubscribers`。

## 为什么不顺手做持久化

`inbox` 按 `session_name`（alias）寻址，而本工具的目标是 `user_id`。把「用户伪 alias」塞进 `session_name` 会让 `/api/messages`、`inbox_count`、SSE gate 一票现有查询**在没被告知的情况下开始返回用户消息** —— 隐性耦合。方向已定为新建按 `user_id` 寻址的表，由 @Hub马 收口。

## 验证

- **变异**：把 `delivered` 写死成 `true` ⇒ 3 条新测红 2。
- 🔴 第 3 条测试**只为防这个形状而存在**：它断言离线与在线两次调用返回**不同**的值 —— 一个退化成常量的判据过不了它。（这是我这两天反复吃的亏：判据看起来在工作，其实两种相反的真相下读数相同。）
- 回归：6 个 push/desktop/observer 套件**逐文件独立进程** ⇒ **91 pass / 0 fail**。
- 纯 hub 逻辑：不碰 schema、零生产、零真 IM。

## 同族提示（issue 里另有 cross-ref 评论）

这与 #1276（未命中时编一个收件人）、#1277（`delivered` 置位而推送从未发出）是**同一族**：**没验证投递就报成功**。三处互不相干的代码，同一个形状。

## 查重

按内容搜过：`send_desktop_message` / `pushUserEvent` / `hasUserSubscribers` ⇒ 无 open PR 碰这条路径。按文件查重过：扫 open PR 的 `server/src/tools.ts`、`push.ts` ⇒ 零重叠。
