### PR TITLE
fix(rename): #1458 defeat pid-reuse in rename kill lane

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -36,7 +36,7 @@ import {
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
-import { processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
+import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -8681,17 +8681,21 @@ async function sweepMcpOrphansForAlias(force: boolean, ...aliases: string[]): Pr
 // #180 R3 caveat: alias tokenisation assumes node names conforming to
 // validateNodeName() (no whitespace/quotes) — the entire current node
 // population. A hand-edited legacy alias containing whitespace would not match.
-// #1438 — anet node stop alias fallback needs (pid, birth) from the SAME `ps`
-// snapshot to defeat pid-reuse: findNodeProcessesByAlias + processBirth are
-// two separate reads, and the pid can be recycled between them. This helper
-// captures both in one atomic `ps` call. lstart is a 24-char fixed-width
-// timestamp ("Www Mmm dd HH:MM:SS YYYY"), stable per process incarnation.
+// #1438 + #1458 — anet node stop AND anet node rename both need (pid, birth)
+// from the SAME `ps` snapshot to defeat pid-reuse. Two separate reads —
+// findNodeProcessesByAlias + processBirth (or subsequent process.kill) — leave
+// a window in which pid can be recycled to another process B; without a
+// captured discovery-time birth to compare against, the kill hits B.
 //
-// Kept separate from findNodeProcessesByAlias so the rename lane callers
-// (L8961/L9205) — which have the same class of bug but need their own audit
-// pass — are not silently rewired.
-function findNodeStopCandidates(alias: string): OwnedRootCandidate[] | null {
-  if (!alias) return [];
+// This helper captures both in one atomic `ps` invocation. lstart is a
+// 24-char fixed-width timestamp ("Www Mmm dd HH:MM:SS YYYY"), stable per
+// process incarnation, string-comparable.
+//
+// Widened signature (accepts multiple aliases) because rename passes both
+// the display name and the node id — either can match the argv.
+function findNodeStopCandidates(...aliases: string[]): OwnedRootCandidate[] | null {
+  const wanted = new Set(aliases.filter(Boolean));
+  if (wanted.size === 0) return [];
   let out = "";
   try {
     out = execFileSync("ps", ["-eww", "-o", "pid=", "-o", "lstart=", "-o", "args="], { encoding: "utf-8" }).toString();
@@ -8723,8 +8727,8 @@ function findNodeStopCandidates(alias: string): OwnedRootCandidate[] | null {
     if (!isAgentProc) continue;
     let aliasMatch = false;
     for (let i = 0; i < tok.length - 1; i++) {
-      if ((tok[i] === "-n" || tok[i] === "--alias") && tok[i + 1] === alias) { aliasMatch = true; break; }
-      if (tok[i] === "start" && tok[i - 1] === "node" && tok[i + 1] === alias) { aliasMatch = true; break; }
+      if ((tok[i] === "-n" || tok[i] === "--alias") && wanted.has(tok[i + 1])) { aliasMatch = true; break; }
+      if (tok[i] === "start" && tok[i - 1] === "node" && wanted.has(tok[i + 1])) { aliasMatch = true; break; }
     }
     if (!aliasMatch) continue;
     candidates.set(pid, { pid, discoveredBirth });
@@ -9022,13 +9026,19 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
   let oldSurvivors: number[] = [];  // #180 — set in C2: old agent pids that refused to die
   // #180 R2 — fail closed if the process table is unreadable: a rename that
   // cannot find/stop the old agent could ghost it or stop the wrong process.
-  const oldProcs = findNodeProcessesByAlias(oldDisplay, oldId);
-  if (oldProcs === null) {
+  //
+  // #1458 — capture (pid, discoveredBirth) atomically via findNodeStopCandidates
+  // so we can defeat pid-reuse at kill time (see rename kill loop below).
+  // The bare-pid `findNodeProcessesByAlias` was TOCTOU-vulnerable: between the
+  // ps snapshot and each terminateNodeProcess signal, an old pid could be
+  // recycled to an unrelated process B and this rename would kill B.
+  const oldCandidates = findNodeStopCandidates(oldDisplay, oldId);
+  if (oldCandidates === null) {
     console.error(`[anet] ❌ cannot inspect the process table (\`ps\` failed) — refusing the rename.`);
     console.error(`[anet]    Rename must locate + stop the old agent; without \`ps\` it risks a ghost or stopping the wrong process.`);
     process.exit(1);
   }
-  const running = oldProcs.length > 0;
+  const running = oldCandidates.length > 0;
   if (running && !force) {
     console.error(`Node "${oldId}" is running. Use --force to rename a running node (active rename, RFC-010 §4.4).`);
     process.exit(1);
@@ -9266,16 +9276,34 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
     // unrelated recycled pid). Each: SIGTERM → 8s wait → SIGKILL (--force) → 3s.
     // #180 R2 — re-scan; if `ps` now fails fall back to the detection-time set
     // (never silently treat the old node as already stopped).
-    const livePids = findNodeProcessesByAlias(oldDisplay, oldId) ?? oldProcs;
-    for (const pid of livePids) {
+    //
+    // #1458 — re-scan via findNodeStopCandidates so we have discoveredBirth
+    // for the fresh live set too. Fallback stays to the detection-time
+    // candidates (oldCandidates), NOT bare pids — otherwise the fallback
+    // path would silently drop the pid-reuse guard the primary path has.
+    // Before EACH kill, verify (pid, discoveredBirth) still names the same
+    // incarnation via isSameIncarnation. If pid was recycled, skip (agent A
+    // is already gone; B is unrelated and must not be signaled).
+    const livePidsCandidates = findNodeStopCandidates(oldDisplay, oldId) ?? oldCandidates;
+    for (const { pid, discoveredBirth } of livePidsCandidates) {
+      if (!isSameIncarnation(pid, discoveredBirth, probeCurrentBirthSignature)) {
+        // pid was recycled OR vanished between discovery/re-scan and this
+        // moment. Either way there is nothing of ours to signal here.
+        // Log so operators know a recycled-pid case actually fired in
+        // production (currently zero measured occurrences; this makes it
+        // observable). Do NOT push to oldSurvivors — the agent we wanted
+        // gone (A) is gone.
+        console.log(`[anet] pid ${pid} was recycled or vanished since discovery — not signaling (agent already gone).`);
+        continue;
+      }
       if (!(await terminateNodeProcess(pid, force))) {
         oldSurvivors.push(pid);
         console.error(`[anet] ✗ old agent process (pid ${pid}) did not exit after SIGTERM + SIGKILL.`);
       }
     }
     oldProcessConfirmedDead = oldSurvivors.length === 0;
-    if (oldProcessConfirmedDead && livePids.length > 0) {
-      console.log(`[anet] stopped old agent process(es): ${livePids.join(", ")}`);
+    if (oldProcessConfirmedDead && livePidsCandidates.length > 0) {
+      console.log(`[anet] stopped old agent process(es): ${livePidsCandidates.map(c => c.pid).join(", ")}`);
     }
 
     // #180 — sweep MCP bridge orphans. claude-code-cli spawns `.anet/node-

--- a/agent-network/src/owned-roots.test.ts
+++ b/agent-network/src/owned-roots.test.ts
@@ -8,7 +8,7 @@
 // (ps 同一次快照里取的 lstart)和 probes.currentBirthSignature,让 resolve
 // 阶段能识别「pid 相同、进程不同」。见 #1438 tests below.
 import { describe, expect, test } from "bun:test";
-import { processVanished, resolveOwnedRoots, type OwnedRootCandidate, type OwnedRootProbes } from "./owned-roots";
+import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate, type OwnedRootProbes } from "./owned-roots";
 
 const errno = (code: string) => Object.assign(new Error(code), { code });
 
@@ -199,5 +199,62 @@ describe("#1422 processVanished — 正向判定,不是『读失败就假设没�
 
   test("🔴 未知错误 ⇒ 保守当作存在", () => {
     expect(processVanished(64, () => { throw errno("EIO"); })).toBe(false);
+  });
+});
+
+// #1458 — the same pid-reuse family that resolveOwnedRoots catches for
+// lifecycle FREEZE, isSameIncarnation catches for pre-KILL. Different
+// timepoint, same primitive: compare the discovery-time lstart with the
+// current lstart via the caller-supplied probe.
+//
+// This helper's purpose is narrow — it's the guard the rename kill loop
+// wraps every process.kill() with. It stays pure so it can be unit-tested
+// without spawning real processes.
+describe("#1458 isSameIncarnation — 发信号前的 pid 回收保护", () => {
+  test("🔴 witnessed-red: discoveredBirth (lstart-A) vs current (lstart-B) ⇒ 拒 kill", () => {
+    // The scenario the rename kill loop must catch:
+    //   discovery ps captured (pid=700, lstart-A)  ← agent A
+    //   before we could kill pid 700, A exited and pid 700 was recycled to B
+    //   probe now returns lstart-B ≠ lstart-A
+    //   isSameIncarnation must return false → caller MUST skip process.kill(700)
+    const discovered = "Mon Aug 30 10:00:00 2026";
+    const probe = (_pid: number) => "Mon Aug 30 10:15:37 2026";  // B started 15 min later
+    expect(isSameIncarnation(700, discovered, probe)).toBe(false);
+  });
+
+  test("同代: 相等 ⇒ 允许 kill", () => {
+    const same = "Mon Aug 30 10:00:00 2026";
+    expect(isSameIncarnation(701, same, (_pid) => same)).toBe(true);
+  });
+
+  test("probe 返回 null (进程消失 or ps 读不到) ⇒ 拒 kill (fail-closed 方向对: 不要盲信号)", () => {
+    // 与 resolveOwnedRoots 里 "vanished ⇒ skip" 一致 — 没有确证是同代就不 kill
+    expect(isSameIncarnation(702, "Mon Aug 30 10:00:00 2026", (_pid) => null)).toBe(false);
+  });
+
+  test("多次调用同 pid, probe 每次都是同一个值 ⇒ 稳定 true", () => {
+    // 保证 isSameIncarnation 是纯函数,不带状态。多次 probe 一致就一致。
+    const same = "Mon Aug 30 10:00:00 2026";
+    let calls = 0;
+    const probe = (_pid: number) => { calls++; return same; };
+    expect(isSameIncarnation(703, same, probe)).toBe(true);
+    expect(isSameIncarnation(703, same, probe)).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  test("每次调用只读一次 probe (kill-time 决策不应放大 ps 抖动)", () => {
+    let calls = 0;
+    const probe = (_pid: number) => { calls++; return "Mon Aug 30 10:00:00 2026"; };
+    isSameIncarnation(704, "Mon Aug 30 10:00:00 2026", probe);
+    expect(calls).toBe(1);
+  });
+
+  test("字符串精确匹配 —— lstart 前后空格/大小写差异都算不同代 (安全侧)", () => {
+    // 判据要严: 任何差异都视为可能是回收。 ps -o lstart= 输出格式一致,
+    // 现实中不会出现只差空格的情况,但显式测这条免得后来人以为可以做
+    // "normalize compare" 的松匹配 —— 那会开一条新窗口。
+    const a = "Mon Aug 30 10:00:00 2026";
+    const b = "Mon Aug 30  10:00:00 2026";  // extra space
+    expect(isSameIncarnation(705, a, (_pid) => b)).toBe(false);
   });
 });

--- a/agent-network/src/owned-roots.ts
+++ b/agent-network/src/owned-roots.ts
@@ -99,3 +99,26 @@ export function processVanished(pid: number, kill: (p: number, s: number) => voi
     return (error as NodeJS.ErrnoException)?.code === "ESRCH";
   }
 }
+
+/** 🔴 #1458 — kill 前的 pid 回收保护:发现阶段捕获的 discoveredBirth 与
+ *  **当前**probeCurrentSignature(pid) 相等 ⇒ 同一代,可以信号。
+ *
+ *  · currentSig === discoveredBirth ⇒ true(同代,可 kill)
+ *  · currentSig !== discoveredBirth ⇒ false(pid 被回收,现在这个 pid 是另一
+ *    个进程 B。**不要 kill** —— B 与我们要 stop 的 agent 无关)
+ *  · currentSig === null            ⇒ false(pid 已消失或读不到;caller 判
+ *    是消失就该 skip,权限问题应额外处理但不该 kill 未知对象)
+ *
+ *  与 resolveOwnedRoots 内嵌的同款比较**在语义上一致**,但在**时间点上不同**:
+ *    resolveOwnedRoots 用于「冻结」时刻(装进 lifecycle owner)
+ *    isSameIncarnation 用于「发信号」前那一瞬(rename 的 kill 循环)
+ *  两个时刻中间可能又有窗口,所以这个检查要**离 process.kill 越近越好**。 */
+export function isSameIncarnation(
+  pid: number,
+  discoveredBirth: string,
+  probeCurrentSignature: (pid: number) => string | null,
+): boolean {
+  const currentSig = probeCurrentSignature(pid);
+  if (currentSig === null) return false;
+  return currentSig === discoveredBirth;
+}


### PR DESCRIPTION
Fixes #1458 (rename lane pid-reuse — same class as #1438, one layer earlier). Pinned to `origin/main = 50fa0d87` (post-#1455 merge).

**Content search performed:** `gh pr list --repo sleep2agi/agent-network --state all --search "rename pid reuse"` / `--search "isSameIncarnation"` / `--search "1458"` → zero prior PR. This is the first fix.

## Root cause

The rename path is `anet node rename` — must find, kill, and restart the old agent under the new alias. `findNodeProcessesByAlias(...)` returned `pids: number[]`. Two callers used those pids directly with `terminateNodeProcess(pid, force)`, and `terminateNodeProcess` in turn calls `process.kill(pid, ...)`. **No birth verification anywhere in that chain.**

The concrete window:

```
cli.ts:9025   oldProcs   = findNodeProcessesByAlias(oldDisplay, oldId)   ← ps -eww
   ⋮ (running check, tmux check, various awaits — non-trivial time)
cli.ts:9269   livePids   = findNodeProcessesByAlias(...) ?? oldProcs      ← ps re-scan
   ⋮ (immediately below)
cli.ts:9271   for (const pid of livePids)
cli.ts:9272     await terminateNodeProcess(pid, force)                    ← process.kill(pid, SIGTERM)
```

Between any two of these `ps` calls and each subsequent `process.kill`, the pid can be recycled to an unrelated process B. `process.kill(pidX, SIGTERM)` then hits B. The existing comment above L9269 claims "reuse-proof — never SIGKILLs an unrelated recycled pid" — that comment was aspirational; the code only re-scans by alias, which still returns bare pids.

Same class as #1438 stop-path fix (`resolveOwnedRoots` pre-freeze pid-reuse guard). Different timepoint — pre-freeze vs pre-kill.

## Fix

**owned-roots.ts:** new pure helper `isSameIncarnation(pid, discoveredBirth, probe): boolean`. Wrap every pre-`process.kill` decision with it:

- `probe(pid) === discoveredBirth` → true (same incarnation, kill it)
- `probe(pid) !== discoveredBirth` → false (recycled, skip)
- `probe(pid) === null` → false (fail-closed: don't signal unknown state)

Same primitive as the pre-freeze check embedded in `resolveOwnedRoots` (#1455). Different timepoint. Kept pure so it's unit-testable without spawning real processes.

**cli.ts:**

- `findNodeStopCandidates` widened from `(alias: string)` to `(...aliases: string[])` — the rename lane passes both `oldDisplay` and `oldId` (matches original `findNodeProcessesByAlias` contract). Stop-lane single-alias caller is unaffected.
- Rename precondition (was L9025): `oldProcs` (bare pids) → `oldCandidates` (with discoveredBirth). Same null-check for `ps` failure. `.length` check for "is it running" unchanged.
- Rename kill loop (was L9269): `livePids ?? oldProcs` → `livePidsCandidates ?? oldCandidates`. Fallback stays candidate-typed so it does NOT silently drop the pid-reuse guard on the fallback path. Inside the loop, `isSameIncarnation(pid, discoveredBirth, probeCurrentBirthSignature)` gates each `terminateNodeProcess` call. Recycled/vanished pids get a log line naming the pid (currently zero measured occurrences; this makes the class observable).

`terminateNodeProcess` itself is **UNCHANGED**. Adding an optional `discoveredBirth` param there was considered but rejected: `stopNode` at L9446 also calls `terminateNodeProcess` via a stale `.pid` file (memory at L9459-9461 explicitly acknowledges the pid-reuse risk on that path). If `terminateNodeProcess` grew a birth param, `stopNode` would either need to pass one (out of #1458 scope, needs its own audit) or skip the check (defeats the purpose). Keeping the guard in the caller side makes each caller's obligation explicit.

## Scope decision — stopNode L9446 NOT touched (again)

Same reason as before: dispatch specifically named the rename lane. `stopNode` uses a persisted `.pid` file which can name a long-dead process whose pid was recycled to an unrelated process — the existing comment at L9459 flags this exact class. Fix requires either threading discoveredBirth through the pidfile write/read cycle, or reading it from `/proc` at stop time and comparing. Recommend filing as follow-up.

## Witnessed-red proof

Body-only revert (signature + interface kept — proves the LOGIC change is what catches pid-reuse, not merely the shape change):

```
Fixed body:     20 pass / 0 fail / 23 expect() calls
Reverted body:  15 pass / 5 fail / 23 expect()

Failing tests on revert (all 5 in #1458 describe):
  🔴 witnessed-red: discoveredBirth (lstart-A) vs current (lstart-B) ⇒ 拒 kill
  probe 返回 null ⇒ 拒 kill (fail-closed 方向对: 不要盲信号)
  多次调用同 pid, probe 每次都是同一个值 ⇒ 稳定 true (call-count assertion)
  每次调用只读一次 probe (kill-time 决策不应放大 ps 抖动)
  字符串精确匹配 —— lstart 前后空格/大小写差异都算不同代 (安全侧)
```

#1422 (5) and #1438 (5) tests stay green in both — the pre-kill guard is additive to the pre-freeze guard.

## Files

- `agent-network/src/owned-roots.ts` — +23/-0. New `isSameIncarnation` pure helper.
- `agent-network/src/owned-roots.test.ts` — +59/-1. Import added; new `describe #1458 — 发信号前的 pid 回收保护` with 6 tests.
- `agent-network/bin/cli.ts` — +37/-13. `findNodeStopCandidates` widened; rename precondition + kill loop rewired; stale "kept separate for rename lane" comment updated.

## Dead code note

`findNodeProcessesByAlias` (cli.ts:8752) has zero remaining callers after this PR. **Left in place**; removing dead code is orthogonal to the #1458 fix and can be a follow-up. Trade-off is small: it's one function nobody uses, its signature is still exercised by comments elsewhere.

## Deploy risk

None to storage format (no schema/protocol changes). Behavioral change is in the SAFE direction: rename that previously would have (rarely, TOCTOU-window-hit) killed an unrelated recycled-pid process now skips that pid and logs it. Agent A whose pid was recycled was already gone anyway (recycling requires exit). No caller loses functionality; only the false-kill path is closed.

## Cross-reference

- `#1455` merged as `f1bb77ee` — introduced `findNodeStopCandidates`, `probeCurrentBirthSignature`, `OwnedRootCandidate`. This PR reuses all three and adds `isSameIncarnation`.
- `#1438` — the parent issue for the stop path; #1458 was the follow-up for rename.
