### PR TITLE
chore(release): bump the daemon batch — server .40 / agent-node .49 / agent-network .64

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1744,7 +1744,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.39";
+const PINNED_SERVER_VERSION = "0.9.0-preview.40";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.63",
+  "version": "2.3.0-preview.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.63",
+      "version": "2.3.0-preview.64",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.63",
+  "version": "2.3.0-preview.64",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.63";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.48";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.64";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.49";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.48",
+  "version": "2.5.0-preview.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.48",
+      "version": "2.5.0-preview.49",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.48",
+  "version": "2.5.0-preview.49",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -62,7 +62,14 @@ set -uo pipefail
 #   内容 = #1376 放开共存 runtime(Vincent 定) + #1372/#1374/#1360/#1377
 #   回滚目标 = 生产机器上当前值(以该机器为准)
 # 2026-08-28: preview36 → preview37（跟随 PINNED;#1381 卡死行出口）
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview39"
+# 2026-08-30: preview39 → preview40（跟随 PINNED_SERVER_VERSION；daemon batch）
+#   内容 = #1448 f1 门铃补偿(#1450) + #1451 opencode 回复解析(#1452) + #1286 对称收敛(#1453)
+#          + start_node stale-starting reaper(#1456) + send_desktop_message 诚实投递态(#1460)
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
+#   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
+#      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
+#      在这里标出来，免得下一个人把这份历史当完整的读。
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview40"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.63 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.64 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.63` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.64` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.63 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.64 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.63`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.64`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.40.md
+++ b/docs/tests/release-v0.9.0-preview.40.md
@@ -1,0 +1,48 @@
+# @sleep2agi/commhub-server 0.9.0-preview.40 — release notes
+
+这一版是 daemon batch 的 hub 侧三条，主题是**「报告的状态要等于真实发生的事」**。
+
+- **#1448 f1 — stop/start/delete 门铃加 SSE 重连补偿**（PR #1450）。门铃是纯 live 扇出：
+  daemon 在重连窗口里错过的门铃事件此前无从补投。现在按 pending-unacked 补投，
+  daemon 重连后能拿到窗口期内错过的指令。
+- **start_node 加 stale-starting reaper**（PR #1456）。此前卡在 `starting` 的节点行没有
+  收敛路径，会一直占着状态；现在与 config-apply 对齐，超时后回收。
+- **`send_desktop_message` 不再谎报成功**（PR #1460）。它只写 `audit_log`、不写 inbox，
+  而 `pushUserEvent` 在用户没有订阅者时静默返回，`/api/messages` 又只读 inbox ——
+  用户 dashboard 关着时消息永久丢，调用方却拿到 `ok:true`。
+  现在返回值带 `delivered`（取自订阅者注册表，不是假设），为 false 时附
+  `reason: "no_live_subscriber"`。
+
+🔴 **本版只让丢失可见，没让它不发生。** desktop message 的持久化 + 重连补投（按 `user_id`
+寻址的新收件表）是下一步，见 #1459。`reason` 取的是**观测到的事实**而不是它的后果，
+所以持久化落地后同一个字段可以细分（lost vs queued），不必改写历史响应的含义。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.64 @sleep2agi/agent-node@2.5.0-preview.49
+anet hub start
+```
+
+hub 自己由 `anet` 按 `PINNED_SERVER_VERSION` 拉起（本版 `0.9.0-preview.40`），
+通常不需要单独装 `@sleep2agi/commhub-server@0.9.0-preview.40`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.64
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1450 | #1448 f1 | stop/start/delete 门铃 SSE 重连补偿 |
+| #1456 | — | start_node stale-starting reaper，对齐 config-apply |
+| #1460 | #1459 | `send_desktop_message` 返回真实投递态 |
+
+未包含：#1464（#1448 findings 4-6）在本版切版时尚未合入 main，走 fast-follow。

--- a/docs/tests/release-v2.3.0-preview.64.md
+++ b/docs/tests/release-v2.3.0-preview.64.md
@@ -1,0 +1,39 @@
+# @sleep2agi/agent-network 2.3.0-preview.64 — release notes
+
+- **#1438 `anet node stop` 的 owned-roots 判定**（PR #1455）：修掉 pid 复用导致的误判。
+
+本版同时把两个 pin 推到本批次的新版本：
+
+- `PINNED_SERVER_VERSION` → `0.9.0-preview.40`
+- `PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.49`
+
+所以装了这一版的 `anet`，`anet hub start` 会拉起 server `.40`，配套 agent-node 是 `.49`。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.64 @sleep2agi/agent-node@2.5.0-preview.49
+anet login
+anet hub start
+```
+
+需要 Node.js ≥ 22.13。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.64
+anet hub restart
+cd ~/anodes && anet project restart
+```
+
+hub 与节点都要重启才会用上新的 pin。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1455 | #1438 | `anet node stop` owned-roots 判定，抵御 pid 复用误判 |
+| — | — | pin 同步：server `.40`、agent-node `.49` |
+
+未包含：#1464（#1448 findings 4-6）在本版切版时尚未合入 main，走 fast-follow。

--- a/docs/tests/release-v2.5.0-preview.49.md
+++ b/docs/tests/release-v2.5.0-preview.49.md
@@ -1,0 +1,48 @@
+# @sleep2agi/agent-node 2.5.0-preview.49 — release notes
+
+这一版四条，集中在 **daemon 的 stop/delete 生命周期** 和 **codex-app-server 的回复完整性**。
+
+- **#1448 f1 门铃补偿的 agent-node 侧**（PR #1450）。与 hub 侧成对：重连后按
+  pending-unacked 取回窗口期内错过的 stop/start/delete 指令。
+- **#1451 opencode 共存 `parseMessageReply`**（PR #1452）。
+- **stop 未命中 childrenMap 时也收敛**（PR #1453），与 #1286 的 delete 侧对称补齐。
+  此前 delete 修好了、stop 没有，同一张内存表未命中在两条路径上行为不一致。
+- **codex-app-server：一个 turn 发多条 agent message 时保住最终答案**（PR #1457，#1449 f1+f2）。
+  side-thread adapter 对每条 `agentMessage` 无条件赋值，而 delta 往同一缓冲追加，
+  于是**最后到达的那条**成为回复。带工具调用的 turn 会发不止一条（前言 → 答案），
+  顺序一旦不是「前言在前」，答案就被过程文本盖掉。现在与主 bridge 一致，按
+  `phase === "final_answer"` 过滤；`phase` 缺失/为 null 时仍按最终答案处理，
+  避免终态变空串被上层读成失败。
+  同 PR 还修了 **owned app-server 启动失败留下孤儿子进程**（#1449 f2）：spawn 之后
+  `waitWs` / `connect` / `bootstrap` 任一抛出都不会 kill 自己拥有的子进程，
+  supervisor 每重试失败一次就攒一个占端口的僵尸。
+
+🔴 **受影响面说明**：#1449 f1 在 **side-thread / BTW** 那条线上，不是普通网络任务回复 ——
+主任务路径（`codex-app-server-bridge.ts`）早就按 `phase` 过滤，前言进不了最终回复。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.64 @sleep2agi/agent-node@2.5.0-preview.49
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.49
+cd ~/anodes && anet project restart
+```
+
+跑着的节点要重启才会拿到新 agent-node（#117）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1450 | #1448 f1 | 门铃 SSE 重连补偿（agent-node 侧） |
+| #1452 | #1451 | opencode 共存 `parseMessageReply` |
+| #1453 | #1286 同族 | stop 未命中 childrenMap 时收敛（与 delete 侧对称） |
+| #1457 | #1449 f1+f2 | 多条 agentMessage 时保住最终答案；启动失败不留孤儿子进程 |
+
+未包含：#1464（#1448 findings 4-6）在本版切版时尚未合入 main，走 fast-follow。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.39",
+  "version": "0.9.0-preview.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.39",
+      "version": "0.9.0-preview.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.39",
+  "version": "0.9.0-preview.40",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.39' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.40' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
**Draft —— 我不 trigger 发布、也没实发任何 npm。** release.yml 由 @通信龙 触发。

daemon batch 的 9 个修复已全落 main、尚未发布。一个原子 bump，三包互相的 pin 不会不一致。

```
@sleep2agi/commhub-server  0.9.0-preview.39 → .40
@sleep2agi/agent-node      2.5.0-preview.48 → .49
@sleep2agi/agent-network   2.3.0-preview.63 → .64
```

`PINNED_SERVER_VERSION → 0.9.0-preview.40`、`PAIRED_AGENT_NODE_VERSION → 2.5.0-preview.49`，都由 `scripts/sync-pinned-versions.sh --apply` 写，所以 pin 与 package.json 不可能对不上。

## bump 前先验了基线

三包仓内版本与 npm 的 **`dist-tags.preview`** 逐一对齐（.39 / .48 / .63）才动手。

🔴 用的是 `npm view <pkg> dist-tags.preview`，**不是**裸 `npm view <pkg> version` —— 后者返回的是 `latest` tag，拿它比一个跟着 preview 走的仓库会**凭空造出漂移**（本周刚有两个人独立踩中，得出同一个错数字并互相印证）。

## 另外三处，每一处都是某道门否则会拒绝这次发布

- **getting-started 的 version-claim `.63 → .64`，中英各一**。两份文件里这个版本号**各出现两次**：机器读的注释（gate 读它）和人读的表格行。**两处都改了** —— 只改注释会让门变绿而把错数字留在唯一给人看的那半。
  🔴 那行表格还附带一个**事实断言**（admin 密码是随机的，因为 `server/src/auth.ts` 自 `.49` 起零提交）。把版本号挪到 `.64` 之前我**验了它对 .64 仍成立**（`git log --since=2026-08-27 -- server/src/auth.ts` 为空），而不是把一个版本号搬到一句没核过的话下面。
- **`deploy/hub/hub-daemon.sh` 的 RUNTIME_DIR → `preview40`**，跟随 `PINNED_SERVER_VERSION`（`check-hub-launcher-pin.py`）。
  顺带标了一格：该文件的历史行只记到 `preview37`，而改动前的值是 `preview39` —— **`37→39` 那两跳没有记录**。我没补写别人的历史（内容我不知道），只在注释里标出这个缺口，免得下一个人把它当完整的读。
- **三份 release-notes**，各含 gate 3 要求的 `## Install` + `## Upgrade`，且 Install 段里含被发的那个版本号。

## fix 归属按实际改动核过，没照抄清单

`gh pr view <n> --json files` 逐个看改了哪个包：

| PR | 实际触及 | 落在哪份 notes |
|---|---|---|
| #1450 | `agent-node` + `server` | **两份都列**（它确实两侧都改了） |
| #1452 | `agent-node` | agent-node |
| #1453 | `agent-node` | agent-node |
| #1455 | `agent-network` | agent-network |
| #1456 | `server` | server |
| #1457 | `agent-node` | agent-node |
| #1460 | `server` | server |

## 本地门

```
check-doc-version-claims.py        exit 0   （4 个戳 / 2 个文档，全部指向正在发的版本；--selftest 0）
check-hub-launcher-pin.py          exit 0   （一致于 preview40）
```

CI 上的 `release version sync dry-run (Docker)` 是这次 bump 一致性的判据，等它绿。

## #1464

切版时仍是 **OPEN**，所以它的 fix **没有**被写进任何一份 notes，三份都显式写了「未包含 #1464，走 fast-follow」。避免 notes 声称了一个用户其实拿不到的修复。

## 查重

按内容搜过：`sync-pinned-versions` / `PINNED_SERVER_VERSION` / `preview.40` ⇒ 无 open PR 碰这条路径。按文件查重过：扫 open PR 的三个 `package.json`、`hub-daemon.sh`、`getting-started.md` ⇒ 零重叠。
