### PR TITLE
fix(cli): #1469 finding-2 — persist network_id in saveProfile whitelist

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -37,6 +37,7 @@ import {
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
+import { serializeProfileForConfigJson } from "../src/profile-serialize";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -2268,50 +2269,7 @@ function saveProfile(id: string, profile: Profile) {
     ensurePrivateDirectory(dir);
   }
   const normalized = normalizeStoredProfile(id, profile);
-  const toSave: Record<string, any> = {
-    anet_version: normalized.anet_version,
-    node_id: normalized.node_id,
-    node_name: normalized.node_name,
-    runtime: normalized.runtime,
-    ...(normalized.hub ? { hub: normalized.hub } : {}),
-    ...(normalized.token ? { token: normalized.token } : {}),
-    ...(normalized.model ? { model: normalized.model } : {}),
-    ...(normalized.tools ? { tools: normalized.tools } : {}),
-    channels: normalized.channels || [],
-    env: normalized.env || {},
-    flags: normalized.flags || {},
-    ...(normalized.session ? { session: normalized.session } : {}),
-    ...((normalized.codexAppServerUrl ?? profile.codexAppServerUrl)
-      ? { codexAppServerUrl: normalized.codexAppServerUrl ?? profile.codexAppServerUrl }
-      : {}),
-    ...((normalized.codexThreadId ?? profile.codexThreadId)
-      ? { codexThreadId: normalized.codexThreadId ?? profile.codexThreadId }
-      : {}),
-    ...((normalized.opencodeMode ?? profile.opencodeMode)
-      ? { opencodeMode: normalized.opencodeMode ?? profile.opencodeMode }
-      : {}),
-    ...(normalized.grokSession ? { grokSession: normalized.grokSession } : {}),
-    ...(normalized.grokCliSession ? { grokCliSession: normalized.grokCliSession } : {}),
-    ...(typeof normalized.grokCopresence === "boolean"
-      ? { grokCopresence: normalized.grokCopresence }
-      : {}),
-    ...(typeof (normalized.codexCopresence ?? profile.codexCopresence) === "boolean"
-      ? { codexCopresence: normalized.codexCopresence ?? profile.codexCopresence }
-      : {}),
-    ...(typeof (normalized.codexCopresenceFullAccess ?? profile.codexCopresenceFullAccess) === "boolean"
-      ? { codexCopresenceFullAccess: normalized.codexCopresenceFullAccess ?? profile.codexCopresenceFullAccess }
-      : {}),
-    ...(normalized.grokLeaderSocket ? { grokLeaderSocket: normalized.grokLeaderSocket } : {}),
-    ...(normalized.grokAttachSocket ? { grokAttachSocket: normalized.grokAttachSocket } : {}),
-    // RFC-008 / issue #51 team-scale demo metadata. Optional on every node;
-    // present only when set by `anet demo sci-team` (Phase 1 scaffold) or
-    // a future RFC-008 client. Without this persist, agent-node reads back a
-    // config.json missing systemPrompt / team / role and the scaffold's
-    // placeholder leader/researcher prompts are silently dropped.
-    ...(normalized.systemPrompt ? { systemPrompt: normalized.systemPrompt } : {}),
-    ...(normalized.team ? { team: normalized.team } : {}),
-    ...(normalized.role ? { role: normalized.role } : {}),
-  };
+  const toSave = serializeProfileForConfigJson(normalized, profile);
   const body = JSON.stringify(toSave, null, 2) + "\n";
   if (isOpencode) {
     // The profile contains the node ntok_. Never replace through a

--- a/agent-network/src/profile-network-id-persist.test.ts
+++ b/agent-network/src/profile-network-id-persist.test.ts
@@ -1,0 +1,107 @@
+// #1469 finding-2 — witnessed-red for the network_id persist gap in
+// `serializeProfileForConfigJson` (extracted from saveProfile).
+//
+// 见红先于见绿:
+//   Before: 白名单不含 network_id ⇒ 建于网络 X 的节点写盘后丢失 network_id
+//           ⇒ 重加载后 profile.network_id === undefined ⇒ 消费者 fallback
+//           到可变的 gc.network_id ⇒ 半对规则:全局网络不变时看似正常,
+//           `anet network use Y` 之后节点静默按 Y 跑但 ntok_ 仍绑 X ⇒
+//           config/token 网络失配,没错误信息。
+//   After:  白名单持久化 network_id ⇒ 重加载后消费者读到真值,不看全局。
+//
+// 纯逻辑测试:直接对 serializeProfileForConfigJson 断言,零文件系统、零网络、
+// 零可变全局。JSON.stringify+parse 走一遍模拟真正的落盘/读回。
+import { describe, expect, test } from "bun:test";
+import { serializeProfileForConfigJson } from "./profile-serialize";
+
+// Minimum profile satisfying the required Profile fields (channels/env/flags
+// are non-optional). Tests focused on network_id treat every other field as
+// noise — the only assertions are on the `network_id` key.
+const baseProfile = () => ({
+  anet_version: "1.0.0",
+  node_id: "n_test",
+  node_name: "alpha",
+  name: "alpha",
+  alias: "alpha",
+  runtime: "claude-code-cli",
+  session: "",
+  hub: "http://localhost:9200",
+  token: "ntok_test",
+  channels: [] as string[],
+  env: {},
+  flags: {},
+} as any);
+
+describe("#1469 finding-2 — network_id persist gap", () => {
+  test("🔴 witnessed-red: profile carrying network_id round-trips through toSave shape", () => {
+    // Simulate the exact input saveProfile would hand to the serializer:
+    // normalizeStoredProfile spreads the input, so normalized.network_id
+    // equals profile.network_id when present.
+    const profile = { ...baseProfile(), network_id: "net_X_specific" };
+    const normalized = { ...profile };  // matches normalizeStoredProfile's spread
+    const toSave = serializeProfileForConfigJson(normalized, profile);
+    // The whole point: the whitelist must include network_id under this key,
+    // with the exact value from the profile.
+    expect(toSave.network_id).toBe("net_X_specific");
+    // JSON round-trip (what actually lands in config.json + comes back on load).
+    const roundTripped = JSON.parse(JSON.stringify(toSave));
+    expect(roundTripped.network_id).toBe("net_X_specific");
+  });
+
+  test("profile with no network_id ⇒ key OMITTED (not present as undefined)", () => {
+    // Pre-1469 nodes and any other legacy load path lack network_id. The
+    // whitelist must not sprinkle `network_id: undefined` — that would
+    // JSON-serialize as absent anyway, but the invariant we want is the
+    // KEY is absent, not just falsy — otherwise `key in` checks elsewhere
+    // in the codebase (e.g. authz decisions) could shift semantics silently.
+    const profile = baseProfile();
+    const normalized = { ...profile };
+    const toSave = serializeProfileForConfigJson(normalized, profile);
+    expect("network_id" in toSave).toBe(false);
+  });
+
+  test("normalized has network_id but profile does not ⇒ persist normalized's value", () => {
+    // Direction sanity check: serialization prefers `normalized ?? profile`.
+    // Even if a call site hands a stitched-up profile where only normalized
+    // carries the id, the write must not drop it.
+    const profile = baseProfile();
+    const normalized = { ...profile, network_id: "net_from_normalized" };
+    const toSave = serializeProfileForConfigJson(normalized, profile);
+    expect(toSave.network_id).toBe("net_from_normalized");
+  });
+
+  test("profile has network_id but normalized does not ⇒ fall back to profile", () => {
+    // Reverse direction: the defensive fallback the fix comment mentions.
+    // (normalizeStoredProfile always preserves network_id via its `...project`
+    // spread, so in practice normalized === profile for this field; test the
+    // fallback anyway so a future change to normalizeStoredProfile that
+    // filters network_id out doesn't silently drop the persist too.)
+    const profile = { ...baseProfile(), network_id: "net_from_profile" };
+    const normalized = { ...profile };
+    delete normalized.network_id;
+    const toSave = serializeProfileForConfigJson(normalized, profile);
+    expect(toSave.network_id).toBe("net_from_profile");
+  });
+
+  test("core identity fields still present (regression floor for the refactor)", () => {
+    // The fix extracted `toSave` from inline into an exported function; make
+    // sure the refactor didn't drop unrelated fields the file-format contract
+    // depends on. Not exhaustive — 25 fields would be maintenance noise —
+    // just the top-of-file identity block that anet-node reads first.
+    const profile = { ...baseProfile(), model: "claude-3-opus", tools: ["fs"], session: "sess_abc" };
+    const normalized = { ...profile };
+    const toSave = serializeProfileForConfigJson(normalized, profile);
+    expect(toSave.anet_version).toBe("1.0.0");
+    expect(toSave.node_id).toBe("n_test");
+    expect(toSave.node_name).toBe("alpha");
+    expect(toSave.runtime).toBe("claude-code-cli");
+    expect(toSave.hub).toBe("http://localhost:9200");
+    expect(toSave.token).toBe("ntok_test");
+    expect(toSave.model).toBe("claude-3-opus");
+    expect(toSave.tools).toEqual(["fs"]);
+    expect(toSave.session).toBe("sess_abc");
+    expect(toSave.channels).toEqual([]);
+    expect(toSave.env).toEqual({});
+    expect(toSave.flags).toEqual({});
+  });
+});

--- a/agent-network/src/profile-serialize.ts
+++ b/agent-network/src/profile-serialize.ts
@@ -1,0 +1,82 @@
+// #1469 finding-2 — the persist shape for a node's config.json (extracted
+// from bin/cli.ts saveProfile so a witnessed-red test can exercise the exact
+// whitelist without spawning a real filesystem write or booting the CLI).
+//
+// 🔴 The bug this closes: `network_id` was set into the profile at node
+// creation time (createProfileFromOpts) but was NOT in the persist whitelist
+// this file's shape defines, so `config.json` never carried it. Reloading
+// the profile then returned no network_id, and every consumer of
+// `profile.network_id` silently fell back to the mutable global
+// `gc.network_id`. Bind a node to network X, then run
+// `anet network use Y`, and that node quietly starts speaking to Y with an
+// ntok_ token still scoped to X — a half-right rule (works until the
+// global network changes, then breaks silently).
+//
+// Keep this function additive-only: every consumer of a persisted field
+// treats a missing key as "not set", so adding entries never breaks any
+// existing reader.
+//
+// Typing: uses structural `any` shapes rather than importing Profile from
+// bin/cli.ts, so this module has zero side-effect imports and can be
+// unit-tested cleanly. The shape it accepts is defined by which keys it
+// reads (see the whitelist below).
+
+export function serializeProfileForConfigJson(
+  normalized: Record<string, any>,
+  profile: Record<string, any>,
+): Record<string, any> {
+  return {
+    anet_version: normalized.anet_version,
+    node_id: normalized.node_id,
+    node_name: normalized.node_name,
+    runtime: normalized.runtime,
+    // #1469 finding-2 — network binding is part of node IDENTITY: which
+    // Agent Network the ntok_ is scoped to. Persist it so it survives
+    // `anet network use <other>` (which mutates gc.network_id and would
+    // otherwise silently repoint the node's config while its token stays
+    // bound to the original). normalizeStoredProfile preserves this via
+    // its `...project` spread; we also read from `profile` as a defensive
+    // fallback for callers that hand a stitched-up profile in.
+    ...((normalized.network_id ?? profile.network_id)
+      ? { network_id: normalized.network_id ?? profile.network_id }
+      : {}),
+    ...(normalized.hub ? { hub: normalized.hub } : {}),
+    ...(normalized.token ? { token: normalized.token } : {}),
+    ...(normalized.model ? { model: normalized.model } : {}),
+    ...(normalized.tools ? { tools: normalized.tools } : {}),
+    channels: normalized.channels || [],
+    env: normalized.env || {},
+    flags: normalized.flags || {},
+    ...(normalized.session ? { session: normalized.session } : {}),
+    ...((normalized.codexAppServerUrl ?? profile.codexAppServerUrl)
+      ? { codexAppServerUrl: normalized.codexAppServerUrl ?? profile.codexAppServerUrl }
+      : {}),
+    ...((normalized.codexThreadId ?? profile.codexThreadId)
+      ? { codexThreadId: normalized.codexThreadId ?? profile.codexThreadId }
+      : {}),
+    ...((normalized.opencodeMode ?? profile.opencodeMode)
+      ? { opencodeMode: normalized.opencodeMode ?? profile.opencodeMode }
+      : {}),
+    ...(normalized.grokSession ? { grokSession: normalized.grokSession } : {}),
+    ...(normalized.grokCliSession ? { grokCliSession: normalized.grokCliSession } : {}),
+    ...(typeof normalized.grokCopresence === "boolean"
+      ? { grokCopresence: normalized.grokCopresence }
+      : {}),
+    ...(typeof (normalized.codexCopresence ?? profile.codexCopresence) === "boolean"
+      ? { codexCopresence: normalized.codexCopresence ?? profile.codexCopresence }
+      : {}),
+    ...(typeof (normalized.codexCopresenceFullAccess ?? profile.codexCopresenceFullAccess) === "boolean"
+      ? { codexCopresenceFullAccess: normalized.codexCopresenceFullAccess ?? profile.codexCopresenceFullAccess }
+      : {}),
+    ...(normalized.grokLeaderSocket ? { grokLeaderSocket: normalized.grokLeaderSocket } : {}),
+    ...(normalized.grokAttachSocket ? { grokAttachSocket: normalized.grokAttachSocket } : {}),
+    // RFC-008 / issue #51 team-scale demo metadata. Optional on every node;
+    // present only when set by `anet demo sci-team` (Phase 1 scaffold) or
+    // a future RFC-008 client. Without this persist, agent-node reads back a
+    // config.json missing systemPrompt / team / role and the scaffold's
+    // placeholder leader/researcher prompts are silently dropped.
+    ...(normalized.systemPrompt ? { systemPrompt: normalized.systemPrompt } : {}),
+    ...(normalized.team ? { team: normalized.team } : {}),
+    ...(normalized.role ? { role: normalized.role } : {}),
+  };
+}


### PR DESCRIPTION
Fixes [#1469 finding-2](https://github.com/sleep2agi/agent-network/issues/1469) — `network_id` was set on a Profile at node creation but silently dropped by `saveProfile`'s persist whitelist. On reload, consumers fell back to the mutable global `gc.network_id`; after `anet network use <other>`, the node's config quietly repointed while its `ntok_` token stayed scoped to the original network.

Pinned to `origin/main = 65b61d60` (dispatch pinned `3a5733a9` + one intervening CI PR).

**Content search performed:** `gh pr list --repo sleep2agi/agent-network --state all --search "serializeProfileForConfigJson"` / `--search "1469"` / `--search "network_id persist"` → zero prior PR. This is the first fix.

## Failure mode (verified against pinned SHA)

Three sites, verbatim at pin:
- `bin/cli.ts:4165` — `createProfileFromOpts` writes `...(gc.network_id ? { network_id: gc.network_id } : {})` into the profile object.
- `bin/cli.ts:2271-2320` (was) — `saveProfile`'s `toSave` whitelist has 25 keys. **`network_id` is NOT in the list.**
- `bin/cli.ts:4425 / 9049 / 10308` — three consumers, all `profile.network_id || gc.network_id`. Correct fallback shape — but with the persist gap, the LHS is always undefined, so `gc.network_id` wins every time.

Result: half-right rule. Works as long as `gc.network_id` never changes; the moment a user runs `anet network use <other>`, the node quietly starts speaking to a different network while its ntok_ stays scoped to the original.

## Fix

- **`agent-network/src/profile-serialize.ts`** (NEW). Pure exported `serializeProfileForConfigJson(normalized, profile) → Record<string, any>` — extracted verbatim from `saveProfile`'s inline `toSave` block, plus one new entry.
  - New entry (identity block, right after `runtime`):
    ```ts
    ...((normalized.network_id ?? profile.network_id)
      ? { network_id: normalized.network_id ?? profile.network_id }
      : {}),
    ```
  - `normalizeStoredProfile` already preserves `network_id` via its `...project` spread, so `normalized.network_id === profile.network_id` in practice. The `??` fallback is defensive — matches the same-shape idiom the whitelist uses for `codexAppServerUrl`, `codexThreadId`, etc.
- **`agent-network/bin/cli.ts`** — import from the new module, replace the 50-line inline `toSave` block with a single call to the helper.
- **Consumer sites unchanged.** L4425/9049/10308 already do the right thing (`profile.network_id || gc.network_id`) — with the persist round-trip now working, they become authoritative.

Why extract to `src/profile-serialize.ts` instead of exporting from `bin/cli.ts`: `bin/cli.ts` executes top-level CLI code on import (prints the help banner in a test context). A test importing the helper from `bin/cli` triggered that side effect. Extracting to `src/` gives a clean side-effect-free import surface.

## Witnessed-red

Pure logic — zero filesystem, zero global, zero network. 5 tests in `src/profile-network-id-persist.test.ts`:

1. 🔴 witnessed-red: profile with `network_id` → key + value in `toSave`, JSON round-trips
2. profile without `network_id` → key **OMITTED** (not `undefined`) — invariant for `key in` checks elsewhere in the codebase
3. `normalized` has `network_id` but `profile` doesn't → persist `normalized`'s value
4. `profile` has `network_id` but `normalized` doesn't → fall back to `profile`
5. Regression floor: `anet_version`, `node_id`, `node_name`, `runtime`, `hub`, `token`, `model`, `tools`, `session`, `channels`, `env`, `flags` all still present after the refactor

Proof via body-only revert (helper + export kept):
```
Fixed body:     5 pass / 0 fail / 17 expect() calls
Reverted body:  2 pass / 3 fail / 16 expect()
```

The 3 failures are exactly tests 1/3/4 — the ones asserting `network_id` is present. Tests 2 (omission) and 5 (regression floor) pass in both versions.

Full `agent-network` src test suite: **696 pass / 0 fail / 3 skip** — refactor is behaviour-preserving for every other field.

## Scope

**This PR closes finding-2 only.** #1469's other findings (interactive wizard guardrails, plus finding-3/4/5) are independent and untouched — one finding per PR.

## Follow-up not in this PR

`bin/cli.ts:5410-5430` in `ensureNodeToken` (the non-`createProfileFromOpts` creation path) also uses `gc.network_id` directly. Once this PR is in, that call site can persist the same `network_id` it stamped into the request, closing the same failure mode on the second creation path.

## Deploy risk

None. Behavioural change is additive-only: profiles that never had `network_id` continue to omit the key (test #2), and profiles that had it now retain it across reloads. Any downstream code that already handled `undefined` continues to handle `undefined`; any code that read `network_id` now reads the correct authoritative value from the profile instead of the mutable global.
