### PR TITLE
docs(release-notes): 更正 #1464(findings 4-6) 实际已含入 preview.40/.49 产物

### DIFF
--- a/docs/tests/release-v0.9.0-preview.40.md
+++ b/docs/tests/release-v0.9.0-preview.40.md
@@ -45,4 +45,4 @@ curl -fsS http://127.0.0.1:9200/health
 | #1456 | — | start_node stale-starting reaper，对齐 config-apply |
 | #1460 | #1459 | `send_desktop_message` 返回真实投递态 |
 
-未包含：#1464（#1448 findings 4-6）在本版切版时尚未合入 main，走 fast-follow。
+包含：#1464（#1448 findings 4-6：F4 daemon 校验防静默假 stopped / F5 ntok 按 token_id 精撤 / F6 start replay cmdline 复验）—— 切版时(#1468 bump)已合入 main，产物含之。`npm pack` 实测确认 F5 `child_token_id`、F4 校验代码在 tarball 内。

--- a/docs/tests/release-v2.5.0-preview.49.md
+++ b/docs/tests/release-v2.5.0-preview.49.md
@@ -45,4 +45,4 @@ cd ~/anodes && anet project restart
 | #1453 | #1286 同族 | stop 未命中 childrenMap 时收敛（与 delete 侧对称） |
 | #1457 | #1449 f1+f2 | 多条 agentMessage 时保住最终答案；启动失败不留孤儿子进程 |
 
-未包含：#1464（#1448 findings 4-6）在本版切版时尚未合入 main，走 fast-follow。
+包含：#1464（#1448 findings 4-6：F4 daemon 校验防静默假 stopped / F5 ntok 按 token_id 精撤 / F6 start replay cmdline 复验）—— 切版时(#1468 bump)已合入 main，产物含之。`npm pack` 实测确认 F5 `child_token_id`、F4 校验代码在 tarball 内。


### PR DESCRIPTION
发版后 `npm pack` 实测确认 server .40 tarball 含 #1464 的 F5(`child_token_id` in db.ts)+F4 校验代码。#1464 在 #1468 bump 前已合 main，故产物含 F4-6。原 notes「未包含…走 fast-follow」不准，更正为「已含」。纯 release-notes 文本更正，无代码/版本变动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)