### PR TITLE
fix(create): the interactive wizard skipped every guardrail the named path has

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4972,7 +4972,65 @@ function createRuntimeChoices() {
   ];
 }
 
+/** #1469 f1 —— 「创建节点」的环境护栏，一处定义。
+ *
+ *  带名路径（`anet node create <name> --flags`）一直有这两道；而无名的交互向导
+ *  在 `createCommand` 里被 `if (!id) return createInteractiveCommand()` 提前短路，
+ *  从没走到它们。结果是**最傻瓜的新手入口反而设防最少**：起了 hub 但没跑过
+ *  `anet init` 的用户被挡在「Run 'anet init' first」，而带名路径本会自探 127.0.0.1:9200。
+ *
+ *  抽成函数而不是把交互向导重构成走带名路径：向导是一份独立的 ~170 行实现，
+ *  动它的流程风险远大于让两边共用同一道门。
+ *
+ *  带名路径的调用点保持在**原来的位置**，所以它的行为逐字不变。 */
+async function ensureHubConfigured(gc: ReturnType<typeof loadGlobal>): Promise<ReturnType<typeof loadGlobal>> {
+  if (!gc.hub) {
+    try {
+      const h = await fetch("http://127.0.0.1:9200/health").then(r => r.json() as any);
+      if (h.ok) {
+        gc.hub = "http://127.0.0.1:9200";
+        saveGlobal(gc);
+        console.log(`[anet] 检测到本地 CommHub: ${gc.hub}`);
+      }
+    } catch {}
+  }
+  if (!gc.hub) {
+    console.error("未找到 CommHub Server。请先运行:\n  anet hub start\n\n或手动配置:\n  anet init --hub http://YOUR_IP:9200");
+    process.exit(1);
+  }
+  return gc;
+}
+
+/** #1469 f1 —— 登录态 + 网络（#467 自选之后仍缺 network_id 的情形）。
+ *
+ *  交互路径以前会一路走到 `requestNodeToken`，那里是 `throw new Error("missing
+ *  network_id; run: anet login")` —— 一个未捕获错误，用户看到的是堆栈而不是下一步。
+ *  带名路径给的是可操作退出，这里让两边一致。 */
+function ensureLoginAndNetwork(gc: ReturnType<typeof loadGlobal>): void {
+  if (!gc.token) {
+    console.error(`[anet] ❌ Not logged in. Run: anet login   (or: anet register)`);
+    process.exit(1);
+  }
+  if (!gc.network_id) {
+    console.error(`[anet] ❌ Global config is missing network_id; no unique writable network could be selected.`);
+    console.error(`[anet]    Run: anet network ls`);
+    console.error(`[anet]    Then: anet network use <name>`);
+    process.exit(1);
+  }
+}
+
 async function createInteractiveCommand() {
+  // #1469 f1 —— 环境先验，再向用户要任何输入。
+  //
+  // 顺序是有意的，和带名路径同一条原则（那边的注释原话：「Check hub connection
+  // BEFORE asking for model/key」）：hub 不通时先问厂商和 API key，用户粘完 key
+  // 才被告知连不上，白费一轮输入。
+  //
+  // 这两道以前只有带名路径有 —— `if (!id) return createInteractiveCommand()`
+  // 在 createCommand 里短路得比它们早，于是最傻瓜的入口设防最少。
+  const gcPre = await ensureHubConfigured(loadGlobal());
+  ensureLoginAndNetwork(gcPre);
+
   console.log(`
 [anet] Create a node
 
@@ -5188,20 +5246,8 @@ async function createCommand(idOverride?: string) {
   }
 
   // ── Check hub connection BEFORE asking for model/key ──
-  if (!gc.hub) {
-    try {
-      const h = await fetch("http://127.0.0.1:9200/health").then(r => r.json() as any);
-      if (h.ok) {
-        gc.hub = "http://127.0.0.1:9200";
-        saveGlobal(gc);
-        console.log(`[anet] 检测到本地 CommHub: ${gc.hub}`);
-      }
-    } catch {}
-  }
-  if (!gc.hub) {
-    console.error("未找到 CommHub Server。请先运行:\n  anet hub start\n\n或手动配置:\n  anet init --hub http://YOUR_IP:9200");
-    process.exit(1);
-  }
+  // 同一道门现在也用在交互向导上（#1469 f1）；调用点位置未变。
+  await ensureHubConfigured(gc);
 
   // #133 runtime-first wizard (Vincent 5101 实测 catch): the old vendor-first
   // selector only enumerated claude-agent-sdk vendors, leaving users who want
@@ -5415,16 +5461,7 @@ async function createCommand(idOverride?: string) {
 
   // Request a network token (ntok_) for this node — agent-node REQUIRES ntok_ for SSE.
   // No silent fallback to utok_; that just defers the failure to runtime.
-  if (!gc.token) {
-    console.error(`[anet] ❌ Not logged in. Run: anet login   (or: anet register)`);
-    process.exit(1);
-  }
-  if (!gc.network_id) {
-    console.error(`[anet] ❌ Global config is missing network_id; no unique writable network could be selected.`);
-    console.error(`[anet]    Run: anet network ls`);
-    console.error(`[anet]    Then: anet network use <name>`);
-    process.exit(1);
-  }
+  ensureLoginAndNetwork(gc);   // #1469 f1 —— 与交互向导共用同一道门；调用点位置未变
   let nodeTokenRes: any;
   try {
     nodeTokenRes = await fetch(`${gc.hub}/api/auth/node-token`, {

--- a/agent-network/src/interactive-create-guardrails.test.ts
+++ b/agent-network/src/interactive-create-guardrails.test.ts
@@ -1,0 +1,86 @@
+// #1469 f1 —— 无名的 `anet node create` 交互向导必须走和带名路径同一套环境护栏，
+// 且顺序一致：**先验环境，再向用户要输入**。
+//
+// 缺陷形状：`createCommand` 里 `if (!id) return createInteractiveCommand()` 短路得
+// 比那两道门更早，于是最傻瓜的新手入口反而设防最少 —— hub 自探跳过、
+// 「先验 hub 再问 model/key」的刻意顺序反过来、network 缺失时抛未捕获错。
+//
+// 🔴 测法上有一个环境限制，写在这里免得下一个人以为是漏测：
+//    「hub 不通」那条**没法在本机端到端测** —— 自探硬编码 127.0.0.1:9200，
+//    而开发/生产机上通常正跑着 hub，测试会真的连上它：既让用例因错误原因变绿，
+//    又是在打生产。所以下面改用**等价且零网络**的判据：护栏必须在向导横幅
+//    之前生效。横幅是向导的第一次输出，护栏先于它 = 顺序对了。
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "bin", "cli.ts");
+const BANNER = "[anet] Create a node";
+
+/** 起真的 CLI，HOME/cwd 都是一次性目录；global config 由调用方决定内容。 */
+function runCreate(globalConfig: Record<string, unknown>) {
+  const home = mkdtempSync(join(tmpdir(), "anet-1469-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "anet-1469-cwd-"));
+  try {
+    mkdirSync(join(home, ".anet"), { recursive: true });
+    writeFileSync(join(home, ".anet", "config.json"), JSON.stringify(globalConfig), { mode: 0o600 });
+    const r = spawnSync("bun", [CLI, "node", "create"], {
+      cwd,
+      env: { PATH: process.env.PATH ?? "", HOME: home },
+      encoding: "utf8",
+      timeout: 20_000,
+      input: "",            // 非交互：stdin 立刻 EOF
+    });
+    return { code: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("#1469 f1 交互向导与带名路径共用环境护栏", () => {
+  test("🔴 未登录 ⇒ 在打出向导横幅【之前】就给出可操作退出", () => {
+    // hub 已配置（所以不会去 fetch 任何东西），但没有 token。
+    const r = runCreate({ hub: "http://127.0.0.1:65535" });
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("Not logged in");
+    expect(r.stderr).toContain("anet login");
+    // 判据落在**顺序**上：修复前向导会先打横幅、问 runtime、问厂商和 key，
+    // 直到 requestNodeToken 才炸。
+    expect(r.stdout).not.toContain(BANNER);
+  });
+
+  test("🔴 network_id 缺失 ⇒ 可操作退出，不是未捕获的 throw", () => {
+    const r = runCreate({ hub: "http://127.0.0.1:65535", token: "utok_test_only_not_a_real_credential" });
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("missing network_id");
+    expect(r.stderr).toContain("anet network ls");
+    expect(r.stderr).toContain("anet network use");
+    // 修复前这里是 requestNodeToken 抛的 Error —— 用户看到堆栈而不是下一步
+    expect(r.stderr).not.toContain("at requestNodeToken");
+    expect(r.stdout).not.toContain(BANNER);
+  });
+
+  test("护栏只有一份实现 —— 两条路径共用，不会各自漂开", async () => {
+    const src = await Bun.file(CLI).text();
+    // 🔴 这两句提示在整个 cli.ts 里本来就出现多次（hub start / node start 等
+    //    别的命令也用），所以「全文只出现一次」是我一开始凭空假设的判据，错的。
+    //    真正要守的是：**创建路径**只有一份实现 —— 两个 helper 各定义一次，
+    //    且 createCommand 与 createInteractiveCommand 都只通过调用使用它们。
+    expect(src.split("async function ensureHubConfigured(").length - 1).toBe(1);
+    expect(src.split("function ensureLoginAndNetwork(").length - 1).toBe(1);
+    // 两条路径各自都在引用（各 1 次调用，共 2 次出现：1 定义 + 2 调用）
+    expect(src.split("ensureHubConfigured(").length - 1).toBe(3);
+    expect(src.split("ensureLoginAndNetwork(").length - 1).toBe(3);
+    // 而且交互向导里，护栏调用必须排在横幅之前
+    const iStart = src.indexOf("async function createInteractiveCommand()");
+    expect(iStart).toBeGreaterThan(-1);
+    const iGuard = src.indexOf("ensureHubConfigured(loadGlobal())", iStart);
+    const iBanner = src.indexOf(BANNER, iStart);
+    expect(iGuard).toBeGreaterThan(-1);
+    expect(iBanner).toBeGreaterThan(-1);
+    expect(iGuard).toBeLessThan(iBanner);
+  });
+});


### PR DESCRIPTION
#1469 finding 1。

## 问题

无名的 `anet node create` 在 `createCommand` 里 `if (!id) return createInteractiveCommand()` 短路，而那一行**位于带名路径的三道护栏之上**。于是**面向新手的入口反而设防最少**：

- **本地 hub 自探没跑** —— 起了 hub 但没跑过 `anet init` 的用户被挡住，而 `anet node create <name>` 本会自探 `127.0.0.1:9200` 继续；
- **顺序反了** —— 带名路径那段注释原话是 *"Check hub connection BEFORE asking for model/key"*；向导却先问厂商、先要 API key，粘完才发现连不上 hub，白费一轮输入；
- **network_id 缺失时抛未捕获错** —— 向导一路走到 `requestNodeToken` 的 `throw`，用户看到堆栈；带名路径给的是「下一步该跑什么」。

三条都在 main（`2a08fff2`）上逐条复核过。

## 改法

两道门抽成函数，两条路径共用。**向导在打出任何东西之前调用它们；带名路径的调用点留在原来的位置**，所以它的时序和行为逐字不变。

**没有**把向导重构成走带名路径：它是独立的 ~170 行实现，改交互流程的风险远大于让两边共用同一道门。

## 测试

起**真的 CLI**（独立 HOME、空 stdin），判据落在**顺序**上：没有 token 时，可操作错误出现、而向导横幅**不出现** —— 修复前是横幅、runtime 选单、key 提示都先来。

🔴 **有一条没法在本机端到端测，写出来免得读成漏测**：「hub 不通」那一支。自探硬编码 `127.0.0.1:9200`，而开发/生产机上通常正跑着 hub，测试会真的连上它 —— **既让用例因错误原因变绿，又是在打生产**。所以改用等价且零网络的判据（护栏先于任何 prompt）。

- **变异**：拿掉向导那两行护栏 ⇒ 3 条全红。
- **回归**：23 个 create/node/runtime 套件逐文件独立跑 ⇒ **284 pass / 0 fail**。`tsc` exit 0。

## 我自己犯的两个错，都被测试抓到，都长得像对的

1. **第一版抽取让 `ensureLoginAndNetwork` 调用了自己。** 我先插入了一个含相同文本的 helper，再 `replace(old, new, 1)` —— 命中的是**我自己那份副本**（它在文件里更靠前）。无限递归，而且只有真起 CLI 才看得出来。第二次改用**按行号**替换。
2. **第一版结构断言要求 hub 错误串在 `cli.ts` 里只出现一次。它出现 5 次** —— 别的命令也打印它。那个分母是我假设的、不是量的。现在断言的是真正要守的性质：**两个 helper 各只有一处定义，两条路径都只通过调用使用它们**。

## 查重

按内容搜过：`createInteractiveCommand` / `ensureHubConfigured` ⇒ 无 open PR 碰这条路径。按文件查重过：扫 open PR 的 `agent-network/bin/cli.ts` ⇒ 与 #1468（bump）零重叠（那个只改版本号常量）。
