### PR TITLE
fix(create): a bare --resume was read as "no resume requested" and silently ignored

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5393,6 +5393,19 @@ async function createCommand(idOverride?: string) {
         opts.session = picked;
         console.log(`[anet] 绑定已有 Claude session: ${picked.slice(0, 8)}…`);
       }
+    } else if (opts.resume === "true") {
+      // #1469 f4 —— 裸 `--resume`（无 id）在非 TTY 里没有任何拿到 id 的办法：
+      // 选单要 TTY，--resume-latest 没打。以前会一路走到底、建出一个带全新
+      // session 的节点 —— 用户打了 --resume 却没有 resume，且零警告。
+      //
+      // 只在**确实打了裸 --resume** 时报错：没打 resume 的 claude-code-cli
+      // 创建在非 TTY 下建新 session 是既有的正确行为，不能被这条波及。
+      console.error("[anet] ❌ --resume 没有给 session id，而当前不是交互终端，无法弹出选单");
+      console.error("[anet]    脚本里请二选一：");
+      console.error("[anet]      anet node create <name> --resume <session-id>");
+      console.error("[anet]      anet node create <name> --resume-latest");
+      console.error("[anet]    查看可用 session: anet session ls");
+      process.exit(1);
     }
   }
 

--- a/agent-network/src/bare-resume-non-tty.test.ts
+++ b/agent-network/src/bare-resume-non-tty.test.ts
@@ -1,0 +1,67 @@
+// #1469 f4 —— 裸 `--resume`（无 id）在非 TTY 里必须报错，而不是静默建一个
+// 没有 resume 的默认 runtime 节点。
+//
+// 缺陷形状：parseCliOptions 把无值 flag 记成 "true"，而 resolveRuntimeForResume
+// 曾把 "true" 排除在 resume 请求之外。后果不是「少推断一次」—— runtime 保持
+// 默认 claude-agent-sdk，于是 cli.ts 里以 `=== "claude-code-cli"` 为条件的整块
+// session 绑定逻辑被跳过，连 TTY 的选单都进不去。用户打了 --resume，拿到的是
+// 一个没有 resume 的节点，零警告。
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "bin", "cli.ts");
+
+// hub 指向一个确定连不上的端口：护栏只检查配置里有没有 hub，不在这一步发请求，
+// 所以测试零网络访问，也不会碰到本机可能正在跑的真 hub。
+const CFG = {
+  hub: "http://127.0.0.1:65535",
+  token: "utok_test_only_not_a_real_credential",
+  network_id: "net_test_only",
+};
+
+function runCreate(extra: string[]) {
+  const home = mkdtempSync(join(tmpdir(), "anet-1469f4-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "anet-1469f4-cwd-"));
+  try {
+    mkdirSync(join(home, ".anet"), { recursive: true });
+    writeFileSync(join(home, ".anet", "config.json"), JSON.stringify(CFG), { mode: 0o600 });
+    const r = spawnSync("bun", [CLI, "node", "create", "probe-node", ...extra], {
+      cwd,
+      env: { PATH: process.env.PATH ?? "", HOME: home },
+      encoding: "utf8",
+      timeout: 20_000,
+      input: "",            // 空 stdin ⇒ 非 TTY
+    });
+    return { code: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("#1469 f4 非 TTY 下的裸 --resume", () => {
+  test("🔴 裸 --resume 被当成 resume 请求 —— 推断出 claude-code-cli", () => {
+    const r = runCreate(["--resume"]);
+    // 修复前 runtime 保持默认 claude-agent-sdk，这一行根本不会打印
+    expect(r.stdout).toContain("--resume 推断 runtime=claude-code-cli");
+  });
+
+  test("🔴 非 TTY 且没有 id ⇒ 给出可执行的下一步，而不是静默建节点", () => {
+    const r = runCreate(["--resume"]);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain("--resume 没有给 session id");
+    // 判据落在「告诉了用户怎么办」上，不是只判它失败
+    expect(r.stderr).toContain("--resume <session-id>");
+    expect(r.stderr).toContain("--resume-latest");
+  });
+
+  test("分界没被推宽：根本没打 --resume 时不受影响", () => {
+    // claude-code-cli + 非 TTY + 无 resume ⇒ 建新 session 是既有的正确行为。
+    // 这条防的是我把新报错写得太宽、把它一起打红。
+    const r = runCreate(["--runtime", "claude-code-cli"]);
+    expect(r.stderr).not.toContain("--resume 没有给 session id");
+  });
+});

--- a/agent-network/src/resume-runtime-infer.test.ts
+++ b/agent-network/src/resume-runtime-infer.test.ts
@@ -32,8 +32,38 @@ describe("resolveRuntimeForResume (#1390)", () => {
   test("no resume flag → no inference (leaves default runtime alone)", () => {
     expect(resolveRuntimeForResume({})).toEqual({});
     expect(resolveRuntimeForResume({ explicitRuntime: "codex-sdk" })).toEqual({});
-    // bare --resume with no value (opts.resume === "true") is not a resume request
-    expect(resolveRuntimeForResume({ resume: "true" })).toEqual({});
+  });
+
+  // #1469 f4 —— 裸 `--resume`（无 id）此前被判成「没请求 resume」。
+  //
+  // 后果不是「少推断一次」：runtime 保持默认 claude-agent-sdk，于是 cli.ts 里
+  // 那整块 session 绑定逻辑（它以 `=== "claude-code-cli"` 为条件）**整段被跳过** ——
+  // 连 TTY 下的交互选单也进不去。用户打了 --resume，拿到的是一个没有 resume 的
+  // 默认 runtime 节点，全程零警告。
+  //
+  // 🔴 这条以前有一条测试**显式钉着旧行为**（`resume:"true"` → `{}`，注释写
+  //    「不算 resume 请求」）。那是一个被编码的决定，不是疏漏，所以这里连同
+  //    理由一起改：用户把这个 flag 打出来了，缺的是 id 不是意图。
+  test("🔴 裸 --resume（无 id）也是 resume 请求 —— 不能静默当成没打过", () => {
+    expect(resolveRuntimeForResume({ resume: "true" })).toEqual({
+      inferredRuntime: "claude-code-cli",
+    });
+  });
+
+  test("裸 --resume + 冲突的显式 runtime ⇒ 与带 id 时一样大声失败", () => {
+    const r = resolveRuntimeForResume({ resume: "true", explicitRuntime: "codex-sdk" });
+    expect(r.conflictError).toContain("codex-sdk");
+    expect(r.inferredRuntime).toBeUndefined();
+  });
+
+  test("裸 --resume + 已显式 claude-code-cli ⇒ 无需改动", () => {
+    expect(resolveRuntimeForResume({ resume: "true", explicitRuntime: "claude-code-cli" })).toEqual({});
+  });
+
+  test("真正没打 --resume 时仍然不推断（分界没有被推宽）", () => {
+    expect(resolveRuntimeForResume({})).toEqual({});
+    expect(resolveRuntimeForResume({ explicitRuntime: "codex-sdk" })).toEqual({});
+    expect(resolveRuntimeForResume({ resume: "" })).toEqual({});
   });
 
   test("an already-resolved session skips inference (interactive picker path)", () => {

--- a/agent-network/src/resume-runtime-infer.ts
+++ b/agent-network/src/resume-runtime-infer.ts
@@ -40,8 +40,17 @@ export interface ResumeRuntimeResult {
 export const CLAUDE_CODE_CLI = "claude-code-cli";
 
 export function resolveRuntimeForResume(input: ResumeRuntimeInput): ResumeRuntimeResult {
+  // #1469 f4 —— 裸 `--resume`（无 id，parseCliOptions 把无值 flag 记成 "true"）
+  // 以前被排除在外，判成「没请求 resume」。那不只是少推断一次：runtime 保持
+  // 默认 claude-agent-sdk，于是 cli.ts 里以 `=== "claude-code-cli"` 为条件的
+  // 整块 session 绑定逻辑被跳过 —— 连 TTY 的交互选单都进不去。用户打了这个
+  // flag，却拿到一个没有 resume 的默认 runtime 节点，全程零警告。
+  //
+  // 用户把 flag 打出来了 = 意图明确，缺的只是 id。所以这里认它是 resume 请求；
+  // 「id 从哪来」（选单 / --resume-latest / 非 TTY 下报错）归调用方决定。
+  // 空串仍然不算 —— 那是「没打」而不是「打了没给值」。
   const resumeRequested =
-    (!!input.resume && input.resume !== "true") || input.resumeLatest === true;
+    !!input.resume || input.resumeLatest === true;
   if (!resumeRequested || input.session) return {};
 
   const explicit = input.explicitRuntime || "";


### PR DESCRIPTION
#1469 finding 4。

## 问题

`parseCliOptions` 把无值 flag 记成 `"true"`（`cli-args.ts:41/47`），而 `resolveRuntimeForResume` 把 `"true"` **排除**在 resume 请求之外。全仓没有别的地方会产生这个值，所以这个例外**只会命中「用户打了 `--resume` 但没给 id」**。

代价比「少推断一次」大得多：没有推断 ⇒ runtime 保持默认 `claude-agent-sdk` ⇒ 而 `cli.ts` 里整块 session 绑定逻辑以 `runtime === "claude-code-cli"` 为条件 ⇒ **整段被跳过，连 TTY 的交互选单都进不去**。

`anet node create X --resume` 于是建出一个 **runtime 不对、也没有 resume** 的节点，**TTY 和脚本里都一样，全程零警告**。

## 改法

**把 flag 打出来就是意图，缺的是 id。** 裸 `--resume` 现在算 resume 请求、推断 `claude-code-cli`，于是既有的绑定块能跑起来：

- TTY → 选单照常弹
- `--resume-latest` → 不变
- **非 TTY 且没有 id** → 报错，并**同时给出两条可执行的下一步**，而不是悄悄建一个全新 session

## 🔴 旧行为是被一条测试显式钉住的

```ts
// bare --resume with no value (opts.resume === "true") is not a resume request
expect(resolveRuntimeForResume({ resume: "true" })).toEqual({});
```

那是一个**被编码的决定，不是疏漏**。所以我不是把断言悄悄翻过来，而是连同**为什么它错**一起写在旁边：用户打了这个 flag，缺的只是 id。

我也查过它的来历（`925ef793` / #1420）：提交说明里没有解释这个例外，看起来是「flag 没值就别推断」的直觉守卫。

## 分界没有被推宽

非 TTY 的那条报错**只在 `opts.resume === "true"` 时触发**。脚本里创建 claude-code-cli 节点、**根本没打 resume** 的情况仍然建新 session —— 那是既有的正确行为。有一条测试专门钉住这个边界，防的是我把新报错写得太宽。

## 验证

- **双向变异**：把 `"true"` 例外装回去 ⇒ 13 条红 4；拿掉非 TTY 那个分支 ⇒ 红 1。还原后 13/13。
- **回归**：6 个 resume/create/cli-args 套件逐文件 ⇒ **44 pass / 0 fail**。`tsc` exit 0。
- 端到端测试把 hub 指向 `127.0.0.1:65535` 并在任何请求之前退出，**零网络访问** —— 特别是不会碰到本机 `:9200` 上真在跑的 hub。

## 查重

按内容搜过：`resolveRuntimeForResume` / `resume-latest` ⇒ 无 open PR 碰这条路径。按文件查重过：#1473 也改 `agent-network/bin/cli.ts`，但改的是 `createInteractiveCommand` / `createCommand` 的护栏段，与本 PR 的 resume 块**不同函数、不同行区间**，合并顺序无所谓。
