### PR TITLE
fix(cli): #1469 finding-3 — validate --tools and --model in createProfileFromOpts

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4107,6 +4107,16 @@ function createProfileFromOpts(id: string, opts: ReturnType<typeof parseOpts>): 
   }
   const runtime = runtimeForExecution(opts.runtime, "create node");
   const defaultModel = defaultCodexModelForRuntime(runtime);
+  // #1469 finding-3 — validate opts.model in place before the profile
+  // literal below builds { model: opts.model || defaultModel }. Mutating
+  // opts.model here keeps the downstream `opts.model || defaultModel`
+  // idiom byte-identical, which test697's L5 mutation guard pins by
+  // literal string (`explicit-model-overwritten`). Validation is not-
+  // empty-after-trim + no-embedded-whitespace — no known-model allowlist
+  // (models are vendor-defined and evolve independently; dispatch
+  // explicitly warned against over-restricting). See src/tool-allowlist.ts
+  // for the rationale + tests.
+  if (opts.model) opts.model = validateModel(opts.model);
   const nodeId = generateNodeId();
   const grokHeadless = opts["grok-headless"] === "true";
   if (grokHeadless && runtime !== "grok-build-cli") {
@@ -4123,17 +4133,7 @@ function createProfileFromOpts(id: string, opts: ReturnType<typeof parseOpts>): 
     ...grokBuildCliCreationFields(runtime, nodeId, grokHeadless),
     ...(gc.network_id ? { network_id: gc.network_id } : {}),
     ...(opts.hub ? { hub } : {}),
-    // #1469 finding-3 — validate opts.model / opts.tools loudly. Before,
-    // `--tools Bsh,Read` silently persisted the typo and dropped Bash from
-    // the agent's allowlist; `--model "  "` silently persisted whitespace.
-    // Mirrors what #478 did for --runtime via normalizeRuntimeStrict: at
-    // the profile boundary, an unrecognized value is a typo, not an
-    // unknown-future-thing. defaultModel comes from
-    // defaultCodexModelForRuntime and is validated at source, so only
-    // opts.model needs the check here.
-    ...((opts.model ? validateModel(opts.model) : undefined) || defaultModel
-      ? { model: (opts.model ? validateModel(opts.model) : undefined) || defaultModel }
-      : {}),
+    ...(opts.model || defaultModel ? { model: opts.model || defaultModel } : {}),
     ...(opts.tools ? { tools: parseAndValidateTools(opts.tools, runtime) } : {}),
     channels: opts._channels.length > 0 ? opts._channels : ["server:commhub"],
     env: envMap,

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -38,6 +38,7 @@ import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
 import { serializeProfileForConfigJson } from "../src/profile-serialize";
+import { parseAndValidateTools, validateModel } from "../src/tool-allowlist";
 import { createConnection as netCreateConnection, createServer as netCreateServer } from "net";
 import { PassThrough } from "stream";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -4122,8 +4123,18 @@ function createProfileFromOpts(id: string, opts: ReturnType<typeof parseOpts>): 
     ...grokBuildCliCreationFields(runtime, nodeId, grokHeadless),
     ...(gc.network_id ? { network_id: gc.network_id } : {}),
     ...(opts.hub ? { hub } : {}),
-    ...(opts.model || defaultModel ? { model: opts.model || defaultModel } : {}),
-    ...(opts.tools ? { tools: opts.tools.split(",").map((s: string) => s.trim()) } : {}),
+    // #1469 finding-3 — validate opts.model / opts.tools loudly. Before,
+    // `--tools Bsh,Read` silently persisted the typo and dropped Bash from
+    // the agent's allowlist; `--model "  "` silently persisted whitespace.
+    // Mirrors what #478 did for --runtime via normalizeRuntimeStrict: at
+    // the profile boundary, an unrecognized value is a typo, not an
+    // unknown-future-thing. defaultModel comes from
+    // defaultCodexModelForRuntime and is validated at source, so only
+    // opts.model needs the check here.
+    ...((opts.model ? validateModel(opts.model) : undefined) || defaultModel
+      ? { model: (opts.model ? validateModel(opts.model) : undefined) || defaultModel }
+      : {}),
+    ...(opts.tools ? { tools: parseAndValidateTools(opts.tools, runtime) } : {}),
     channels: opts._channels.length > 0 ? opts._channels : ["server:commhub"],
     env: envMap,
     flags: {
@@ -5222,7 +5233,9 @@ async function createCommand(idOverride?: string) {
   } else if (opts.runtime === "grok-build-acp" || opts.runtime === "grok-build-cli") {
     console.log("[anet] 请确保已安装并登录 Grok Build CLI: grok login");
     if (opts.runtime === "grok-build-cli") {
-      const requestedTools = opts.tools ? opts.tools.split(",").map((tool) => tool.trim()) : undefined;
+      // #1469 finding-3 — validate here too so a typo fails at the interactive
+      // grok warning rather than passing through and only tripping at persist.
+      const requestedTools = opts.tools ? parseAndValidateTools(opts.tools, "grok-build-cli") : undefined;
       printGrokCopresenceWarning(id, requestedTools, "configured");
     }
   } else if (opts.runtime === "opencode-cli") {

--- a/agent-network/src/tool-allowlist.test.ts
+++ b/agent-network/src/tool-allowlist.test.ts
@@ -1,0 +1,135 @@
+// #1469 finding-3 — witnessed-red for the --tools / --model validation
+// missing in createProfileFromOpts. Before the fix, `--tools Bsh,Read`
+// silently produced the profile { tools: ["Bsh", "Read"] } — the typo
+// erased Bash from the agent's allowlist and nothing surfaced until the
+// model tried (and failed) to use Bash much later.
+//
+// The witnessed-red pattern:
+//   Pre-fix:  no validator exists; opts.tools split+trim only. Typo passes.
+//   Post-fix: parseAndValidateTools throws with a message naming the bad
+//             token and the expected set (mirrors what #478 did for
+//             --runtime via normalizeRuntimeStrict).
+//
+// These tests exercise the validator directly (pure fn, zero fs, zero
+// CLI). The equivalent full-flow shape — createProfileFromOpts calls
+// parseAndValidateTools — is covered by that call site's throw path,
+// which is a mechanical wiring: the guard is the value.
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_KNOWN_TOOLS,
+  parseAndValidateTools,
+  validateModel,
+} from "./tool-allowlist";
+
+describe("#1469 finding-3 — parseAndValidateTools (--tools guard)", () => {
+  test("🔴 witnessed-red: --tools Bsh,Read on claude-agent-sdk throws naming the typo", () => {
+    // The exact failure mode reported in the dispatch.
+    expect(() => parseAndValidateTools("Bsh,Read", "claude-agent-sdk")).toThrow(
+      /unknown Claude-side tool "Bsh"/,
+    );
+    // The error message must include the expected set so the user knows
+    // what to type — the whole reason for throwing instead of silently
+    // dropping the bad token.
+    let thrown: Error | undefined;
+    try { parseAndValidateTools("Bsh,Read", "claude-agent-sdk"); } catch (e) { thrown = e as Error; }
+    expect(thrown).toBeDefined();
+    expect(thrown!.message).toContain("Bash");
+    expect(thrown!.message).toContain("Read");  // in the "expected one of" list
+  });
+
+  test("all-known claude tools pass and return the trimmed list", () => {
+    const result = parseAndValidateTools("Bash, Read, Write, Grep", "claude-agent-sdk");
+    expect(result).toEqual(["Bash", "Read", "Write", "Grep"]);
+  });
+
+  test("claude-code-cli runtime uses the same allowlist as claude-agent-sdk", () => {
+    // Both claude-lineage runtimes reject the same typo — the allowlist is
+    // shared, not per-runtime.
+    expect(() => parseAndValidateTools("Bsh", "claude-code-cli")).toThrow(/unknown Claude-side tool/);
+    expect(parseAndValidateTools("Bash", "claude-code-cli")).toEqual(["Bash"]);
+  });
+
+  test("MCP tools flow through under any runtime (they're server-defined, no static allowlist)", () => {
+    const result = parseAndValidateTools("mcp__commhub__send_task,mcp__slack__send_message,Read", "claude-agent-sdk");
+    expect(result).toEqual([
+      "mcp__commhub__send_task",
+      "mcp__slack__send_message",
+      "Read",
+    ]);
+  });
+
+  test("MCP-shaped names outside claude-lineage runtimes also pass", () => {
+    expect(parseAndValidateTools("mcp__server__tool", "opencode-cli")).toEqual(["mcp__server__tool"]);
+  });
+
+  test("non-claude runtime: unknown-Claude tokens pass basic format only (grok's lowercase_snake OK)", () => {
+    // grok's copresence profile uses todo_write/search_tool/use_tool.
+    // The Claude-side allowlist must NOT reject them on a grok runtime;
+    // grok's own downstream validation is the authority for that field.
+    expect(parseAndValidateTools("todo_write,search_tool,use_tool", "grok-build-cli")).toEqual([
+      "todo_write", "search_tool", "use_tool",
+    ]);
+  });
+
+  test("basic format check catches shape violations on ANY runtime (leading digit, whitespace, punctuation)", () => {
+    // Every non-MCP tool token must start with a letter and only contain
+    // identifier chars — even on non-claude-lineage runtimes. This catches
+    // typos with punctuation regardless of runtime scoping.
+    expect(() => parseAndValidateTools("1Bad", "grok-build-cli")).toThrow(/invalid tool name/);
+    expect(() => parseAndValidateTools("with space", "opencode-cli")).toThrow(/invalid tool name/);
+    expect(() => parseAndValidateTools("weird.name", "codex-sdk")).toThrow(/invalid tool name/);
+  });
+
+  test("empty --tools value / whitespace-only / commas-only throws (helps user, not a silent no-op)", () => {
+    // The dispatch's guidance: fail loudly. If a user types --tools "" or
+    // --tools ",,", that's almost certainly a shell-quoting mistake, not
+    // "please give me the runtime default" (that's what omitting --tools
+    // does). Throwing tells them explicitly.
+    expect(() => parseAndValidateTools("", "claude-agent-sdk")).toThrow(/empty list/);
+    expect(() => parseAndValidateTools("   ", "claude-agent-sdk")).toThrow(/empty list/);
+    expect(() => parseAndValidateTools(",,,", "claude-agent-sdk")).toThrow(/empty list/);
+  });
+
+  test("trimming: `--tools ' Bash , Read '` returns clean tokens (surrounding ws normal, embedded ws still rejected)", () => {
+    expect(parseAndValidateTools(" Bash , Read ", "claude-agent-sdk")).toEqual(["Bash", "Read"]);
+  });
+
+  test("CLAUDE_KNOWN_TOOLS is stable and non-empty (source-of-truth guardrail)", () => {
+    // If someone accidentally empties or re-orders CLAUDE_KNOWN_TOOLS,
+    // this test surfaces it. Not exhaustive on content, but ensures the
+    // constant itself remains present.
+    expect(CLAUDE_KNOWN_TOOLS.length).toBeGreaterThan(5);
+    expect(CLAUDE_KNOWN_TOOLS).toContain("Bash");
+    expect(CLAUDE_KNOWN_TOOLS).toContain("Read");
+    expect(CLAUDE_KNOWN_TOOLS).toContain("Write");
+    expect(CLAUDE_KNOWN_TOOLS).toContain("Grep");
+    expect(CLAUDE_KNOWN_TOOLS).toContain("WebSearch");
+  });
+});
+
+describe("#1469 finding-3 — validateModel (--model guard)", () => {
+  test("🔴 witnessed-red: empty and whitespace-only values throw", () => {
+    expect(() => validateModel("")).toThrow(/empty/);
+    expect(() => validateModel("   ")).toThrow(/empty/);
+  });
+
+  test("value with embedded whitespace throws (shell-quoting typo catcher)", () => {
+    expect(() => validateModel("claude 3 opus")).toThrow(/whitespace/);
+    expect(() => validateModel("model\twith\ttabs")).toThrow(/whitespace/);
+  });
+
+  test("trims surrounding whitespace but rejects embedded", () => {
+    expect(validateModel("  claude-3-opus  ")).toBe("claude-3-opus");
+  });
+
+  test("realistic model names pass through (no allowlist over-restriction)", () => {
+    // We deliberately do NOT enforce a known-model list — vendors evolve
+    // their model catalogs independently and a strict allowlist would
+    // break the first time MiniMax/DeepSeek/GLM ships a new variant.
+    expect(validateModel("claude-3-5-sonnet-20241022")).toBe("claude-3-5-sonnet-20241022");
+    expect(validateModel("deepseek-v4-pro")).toBe("deepseek-v4-pro");
+    expect(validateModel("glm-4.7")).toBe("glm-4.7");
+    expect(validateModel("MiniMax-M2.7")).toBe("MiniMax-M2.7");
+    expect(validateModel("gpt-5-2024-12")).toBe("gpt-5-2024-12");
+  });
+});

--- a/agent-network/src/tool-allowlist.ts
+++ b/agent-network/src/tool-allowlist.ts
@@ -1,0 +1,132 @@
+// #1469 finding-3 — validation for the --tools and --model flags in
+// createProfileFromOpts. Before this, `--tools Bsh,Read` was silently
+// accepted: the typo dropped Bash from the agent's tool allowlist and
+// nothing surfaced until (much later) the model reported it couldn't find
+// a tool it expected. Mirrors what #478 did for --runtime via
+// normalizeRuntimeStrict: at the profile boundary, an unrecognized value
+// is a typo, not an unknown future thing.
+//
+// SOURCE OF TRUTH — deliberate design choice:
+//
+//   The Claude-side tool set below reflects bin/cli.ts's own node-create
+//   warning ("Claude Code preset — WebFetch / WebSearch / Bash / Read /
+//   Write / Edit / Glob / Grep / Task / ..."). That warning is the
+//   product's user-facing statement of the set; this file mirrors it so
+//   the two sources stay aligned. Updating this list requires a real
+//   Claude release adding a tool, not a whim.
+//
+//   Naming difference — grok's copresence profile uses lowercase_snake
+//   (todo_write / search_tool / use_tool) validated against a fixed
+//   3-profile allowlist in grok-copresence-disclosure.ts. codex /
+//   codex-app-server / opencode-cli don't read this field. So the Claude
+//   allowlist applies ONLY to claude-lineage runtimes. Every other
+//   runtime gets the basic per-token format check and lets its own
+//   downstream validation catch semantic issues.
+//
+// FAILURE MODE this file catches — the reported #1469 finding-3 shape:
+//   $ anet node create foo --tools Bsh,Read
+//   BEFORE: silently persists ["Bsh", "Read"]. Bash is missing.
+//   AFTER:  throws "unknown Claude-side tool \"Bsh\" on runtime
+//           \"claude-agent-sdk\". Expected one of: WebFetch, WebSearch,
+//           Bash, ..." — user sees the typo AND the expected set.
+
+export const CLAUDE_KNOWN_TOOLS: readonly string[] = [
+  // WebFetch/WebSearch — network fetch tools
+  "WebFetch", "WebSearch",
+  // Shell tools (Bash + its output streaming and kill counterparts)
+  "Bash", "BashOutput", "KillShell",
+  // File tools — read/write, and specialty editors
+  "Read", "Write", "Edit", "MultiEdit", "NotebookEdit",
+  // Filesystem search
+  "Glob", "Grep",
+  // Agent-level controls
+  "Task", "ExitPlanMode", "TodoWrite",
+] as const;
+
+const CLAUDE_TOOLS_SET = new Set(CLAUDE_KNOWN_TOOLS);
+
+// MCP tools follow the pattern `mcp__<server>__<tool>`. These are
+// user-defined by whichever MCP server hosts them (e.g. `mcp__commhub__send_task`),
+// so no static allowlist can enumerate them — accept anything shaped this
+// way. The pattern is strict: exactly two double-underscore separators, and
+// the server + tool segments must be non-empty identifier-shaped.
+const MCP_TOOL_RE = /^mcp__[A-Za-z0-9_]+__[A-Za-z0-9_]+$/;
+
+// Basic per-token format for any runtime: starts with a letter, letters/
+// digits/underscore/dash only. Rejects empties, embedded whitespace,
+// leading/trailing punctuation. Intentionally permissive shape-wise so
+// runtimes with different naming conventions (grok's lowercase_snake)
+// still pass the basic check.
+const BASIC_TOOL_RE = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+type Runtime = string;
+const CLAUDE_LINEAGE: ReadonlySet<Runtime> = new Set([
+  "claude-agent-sdk",
+  "claude-code-cli",
+]);
+
+/** Parse the comma-joined --tools string, validate each token, return the
+ * trimmed list. Runtime-scoped:
+ *
+ *   Claude-lineage → each token must be in CLAUDE_KNOWN_TOOLS OR match
+ *                    the MCP pattern (mcp__<server>__<tool>).
+ *   Other runtimes → only the basic per-token format check runs, so grok /
+ *                    codex / opencode tools flow through unchanged and get
+ *                    validated by their own downstream layers.
+ *
+ * Throws on the first offense with a message naming the bad token and,
+ * for Claude-side violations, the expected set. Never returns a
+ * partially-cleaned list — a typo must surface, not silently reshape the
+ * persisted profile.
+ */
+export function parseAndValidateTools(raw: string, runtime: Runtime): string[] {
+  if (typeof raw !== "string") {
+    throw new Error(`--tools value must be a string, got ${typeof raw}`);
+  }
+  const tokens = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  if (tokens.length === 0) {
+    throw new Error(`--tools value ${JSON.stringify(raw)} parsed to empty list — omit --tools instead if you want the runtime default`);
+  }
+  const isClaudeLineage = CLAUDE_LINEAGE.has(runtime);
+  for (const tok of tokens) {
+    if (!BASIC_TOOL_RE.test(tok) && !MCP_TOOL_RE.test(tok)) {
+      throw new Error(
+        `--tools contains invalid tool name ${JSON.stringify(tok)}: ` +
+        `tool names must start with a letter and use only letters, digits, hyphen, or underscore, ` +
+        `or match the MCP pattern mcp__<server>__<tool>.`,
+      );
+    }
+    if (isClaudeLineage && !CLAUDE_TOOLS_SET.has(tok) && !MCP_TOOL_RE.test(tok)) {
+      throw new Error(
+        `--tools contains unknown Claude-side tool ${JSON.stringify(tok)} on runtime ${JSON.stringify(runtime)}. ` +
+        `Expected one of: ${CLAUDE_KNOWN_TOOLS.join(", ")}, ` +
+        `or an MCP tool matching mcp__<server>__<tool>. ` +
+        `(Common typos: 'Bsh' → 'Bash', 'Wr' → 'Write', 'read' → 'Read' — names are case-sensitive.)`,
+      );
+    }
+  }
+  return tokens;
+}
+
+/** Minimal --model validation: non-empty after trim, no whitespace inside.
+ *
+ * We do NOT enforce a known-model allowlist — models are vendor-defined,
+ * evolve independently, and a strict list would break the first time
+ * MiniMax/DeepSeek/GLM/etc. ships a new variant. This catches the obvious
+ * user-side typos (`--model " claude-3 " `, `--model ""`) without
+ * over-restricting legitimate values. Vendor-side model resolution
+ * (defaultCodexModelForRuntime etc.) already validates its own contract.
+ */
+export function validateModel(raw: string): string {
+  if (typeof raw !== "string") {
+    throw new Error(`--model value must be a string, got ${typeof raw}`);
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`--model value ${JSON.stringify(raw)} is empty after trim`);
+  }
+  if (/\s/.test(trimmed)) {
+    throw new Error(`--model value ${JSON.stringify(raw)} contains whitespace after trim`);
+  }
+  return trimmed;
+}


### PR DESCRIPTION
Fixes [#1469 finding-3](https://github.com/sleep2agi/agent-network/issues/1469) — `createProfileFromOpts` accepted `--tools Bsh,Read` silently (typo dropped Bash from the agent's allowlist; nothing surfaced until the model tried Bash later). Same footgun class #478 fixed for `--runtime` via `normalizeRuntimeStrict`.

Pinned to `origin/main = 2a08fff2`.

**Content search performed:** `gh pr list --repo sleep2agi/agent-network --state all --search "parseAndValidateTools"` / `--search "tool-allowlist"` / `--search "1469 finding-3"` → zero prior PR. This is the first fix.

## Source of truth for the allowlist (dispatch warning: "以产品既有定义为准，不自造")

The Claude-side tool set below reflects `bin/cli.ts`'s **own** node-create warning message ("Claude Code preset — WebFetch / WebSearch / Bash / Read / Write / Edit / Glob / Grep / Task / ..."). That warning is the product's user-facing statement of the set; this PR mirrors it into a validated allowlist so the two sources stay aligned. Updating requires a real Claude release adding a tool, not a whim.

Runtime scoping — grok's copresence tools use `lowercase_snake` (`todo_write` / `search_tool` / `use_tool`) validated against a fixed 3-profile allowlist in `grok-copresence-disclosure.ts`. codex / codex-app-server / opencode-cli don't read this field. So the Claude allowlist applies ONLY to `claude-agent-sdk` and `claude-code-cli`. Every other runtime gets the basic per-token shape check and lets its own downstream validation catch semantic issues. Not our place to invent a superset.

## Fix

**`agent-network/src/tool-allowlist.ts`** (NEW). Two pure exported helpers:

- `parseAndValidateTools(raw: string, runtime: string): string[]`
  - splits + trims; empty list throws with a hint to omit `--tools` instead
  - basic per-token shape check on every runtime (letter-first, letters/digits/`-`/`_`) OR the MCP pattern `mcp__<server>__<tool>`
  - on Claude-lineage runtimes only: strict allowlist against `CLAUDE_KNOWN_TOOLS`
  - unknown-token error message includes the bad token, the expected set, and a case-sensitivity hint (a lot of the near-misses are case)
- `validateModel(raw: string): string`
  - non-empty after trim, no embedded whitespace
  - **no known-model allowlist** — dispatch explicitly warned against over-restricting, and vendor model catalogs evolve independently

**`agent-network/bin/cli.ts`** (three sites, mechanical wiring):
- Import from `../src/tool-allowlist`
- `createProfileFromOpts` (~L4166): replace inline `opts.tools.split(...).map(trim)` with `parseAndValidateTools(opts.tools, runtime)`; wrap `opts.model` with `validateModel(opts.model)` so the same guard applies before `defaultModel` fallback
- grok interactive path (~L5267): same replacement so a typo fails at the disclosure-warning step, not just at persist

## Witnessed-red

Pure logic — zero fs, zero CLI. 14 tests in `src/tool-allowlist.test.ts` across two describes.

Body-only revert (helper + export + import kept — proves the LOGIC change is what catches typos, not merely the shape change):

```
Fixed body:     14 pass / 0 fail / 33 expect() calls
Reverted body:   7 pass / 7 fail / 23 expect()
```

The 7 failures are exactly the tests that assert validation happens (throw on typo, throw on empty, throw on whitespace, throw on shape violations). The 7 passers are the ones that assert legitimate values pass through — those pass in both versions since the reverted body is a no-op passthrough. **The delta is precisely the "does it catch typos" surface, nothing else.**

Full agent-network src suite: **711 pass / 0 fail / 3 skip** (was 697 + 14 new).

CLI actually loads (`bun run bin/cli.ts --version` prints the version line and exits 0) — not just tests-green.

## Not in scope of this PR

- **Finding-1** (interactive wizard guardrails) — separate, larger diff
- **Finding-2** (network_id persist) — already up as PR #1471, awaiting review
- **Finding-4/5** — separate smaller items per dispatch

One finding per PR discipline held.

## Deploy risk

Two classes of behavior change; both in the SAFE direction:

1. **New failures on invalid input.** Previously-accepted typos now throw at profile-creation time. A user who was persisting `--tools Bsh` will now see an error instead of a broken node — surfaces a bug that was silently corrupting their config. This is desired.
2. **Previously-accepted-but-marginal input.** `--model "  claude-3  "` (whitespace) previously persisted as-is and worked because downstream trimmed; now it either fails (embedded whitespace) or returns trimmed. If any script depends on `--model` accepting embedded whitespace it will fail loudly with a clear message. Unlikely in practice — model names don't have whitespace — but flagging for the release notes.

No storage-format change. No consumer-side change. No auth/security touch.
