### PR TITLE
fix(daemon): workdir 根从 workDir 派生消除删后密钥残留 (#1474 finding-1, 安全)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -6136,6 +6136,7 @@ async function connectSSE() {
                     recentlyHandledStartRequestIds,
                     handleStopDoorbell: (event: { request_id: string }) => handleStopDoorbell(event, {
                       callCommHub,
+                      workDir: process.cwd(),
                       log: (m: string) => log(m),
                       warn: (m: string) => warn(m),
                     }),
@@ -6244,6 +6245,7 @@ async function connectSSE() {
                   { request_id: stopReqId },
                   {
                     callCommHub,
+                    workDir: process.cwd(),
                     log: (m: string) => log(m),
                     warn: (m: string) => warn(m),
                   },

--- a/agent-node/src/runtime/start-daemon.ts
+++ b/agent-node/src/runtime/start-daemon.ts
@@ -5,7 +5,6 @@
 import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { join, resolve, sep } from "node:path";
-import { homedir } from "node:os";
 import { getAnetBinAbs, minimalEnv } from "./create-node-daemon.js";
 import { getChildrenSnapshot, recordSpawnedChild } from "./stop-daemon.js";
 
@@ -90,7 +89,10 @@ export async function handleStartDoorbell(
     return;
   }
 
-  const nodesRoot = deps.nodesRoot ?? join(homedir(), ".anet", "nodes");
+  // #1474 finding-1 — 根从 create 用的 cwd 基准(deps.workDir=daemon process.cwd())派生,
+  // 不硬编码 homedir():create 写 $CWD/.anet/nodes(create-node-daemon:525),daemon 从非
+  // $HOME 目录跑时 homedir() 会指向错目录 → 找不到 config → 假 start_failed。
+  const nodesRoot = deps.nodesRoot ?? join(deps.workDir, ".anet", "nodes");
   try {
     verifyStoppedChildConfig(nodesRoot, req.child_node_id, req.child_alias);
   } catch (e: any) {

--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -241,6 +241,47 @@ describe("handleStopDoorbell — delete action with delete_config", () => {
   });
 });
 
+// #1474 finding-1(安全) — delete/stop 的 workdir 根从 deps.workDir(=create 用的
+// cwd 基准)派生,不硬编码 homedir()。daemon 从非 $HOME 目录跑时,create 落
+// $CWD/.anet/nodes(含 child ntok+env 密钥),按 homedir 去搬会扑空 → warn → 仍 ack
+// stopped → hub 以为删了、密钥原地残留(违背"删后密钥不残留")。
+//
+// witnessed-red:workDir 设成一个 ≠ homedir 的临时目录、**不**注入 workdirRoot/
+// deletedRoot(强制走派生),盘上放好 config。改后:密钥目录被搬进 <workDir>/.anet/
+// deleted、原地清空;改前(homedir 派生)扑空 → childDir 仍在(残留)、无 backup_path。
+describe("#1474 finding-1 — workdir root derives from workDir, not homedir (secret residue)", () => {
+  test("delete with no injected root cleans $workDir/.anet/nodes/<alias> (not $HOME)", async () => {
+    const workDir = mkdtempSync(join(tmpdir(), "anet-1474-cwd-"));   // ≠ homedir
+    const alias = "cwd-child-1474";
+    const childDir = join(workDir, ".anet", "nodes", alias);
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(join(childDir, "config.json"), JSON.stringify({ token: "ntok_secret", env_local: "leak" }), { mode: 0o600 });
+
+    const acks: any[] = [];
+    const deps: any = {
+      workDir,   // ← create 的 cwd 基准;故意不注入 workdirRoot/deletedRoot → 测派生
+      callCommHub: async (tool: string, args: any) => {
+        if (tool === "get_stop_request") {
+          return { ok: true, request_id: "sr_cwd", child_node_id: "node_cwd", child_alias: alias, action: "delete", delete_config: true, grace_seconds: 10, force: false };
+        }
+        acks.push(args); return { ok: true };
+      },
+      signalProcess: () => {}, log: () => {}, warn: () => {},
+    };
+    await handleStopDoorbell({ request_id: "sr_cwd" }, deps);
+
+    expect(acks.at(-1)!.status).toBe("stopped");
+    // 密钥目录被清出 $workDir/.anet/nodes(改前 homedir 派生 → 扑空 → 仍在 → 红)
+    expect(existsSync(childDir)).toBe(false);
+    // 搬进了从 workDir 派生的回收站(不是 homedir)
+    const trash = join(workDir, ".anet", "deleted");
+    expect(existsSync(trash) && readdirSync(trash).some(n => n.endsWith(alias))).toBe(true);
+    expect((acks.at(-1)!.backup_path as string | undefined)?.startsWith(trash)).toBe(true);
+
+    rmSync(workDir, { recursive: true, force: true });
+  });
+});
+
 describe("handleStopDoorbell — real subprocess primitive (no mocks)", () => {
   // Mirror PR3 #338 discipline: lock the actual kill-0 + signal
   // semantics against a real node subprocess so a runtime drift

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -21,7 +21,6 @@
 
 import { chmodSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { execFile } from "node:child_process";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -76,8 +75,12 @@ export interface StopDoorbellDeps {
   warn: (msg: string) => void;
   // Path roots. Defaulted from process.env.HOME in cli wiring; tests
   // can override to a temp dir.
-  workdirRoot?: string;       // <home>/.anet/nodes — where child config dirs live
-  deletedRoot?: string;       // <home>/.anet/deleted — backup target
+  // #1474 finding-1 — daemon 的 cwd 基准(= process.cwd(),与 create-node-daemon 写
+  // config 用的 deps.workDir 同源)。根从它派生,不硬编码 homedir()——daemon 从非 $HOME
+  // 目录跑时,create 落 $CWD/.anet/nodes 而按 homedir 去删/搬会扑空、密钥原地残留。
+  workDir?: string;
+  workdirRoot?: string;       // 默认 <workDir>/.anet/nodes — child config 目录
+  deletedRoot?: string;       // 默认 <workDir>/.anet/deleted — 回收站
   // Allow tests to inject a fake kill / sleep / rename / clock so we
   // can drive the state machine without burning real wall-clock or
   // spawning real subprocesses. Production wires these to node:process
@@ -181,8 +184,8 @@ export async function handleStopDoorbell(
   const renameDir = deps.renameDir ?? ((src, dst) => renameSync(src, dst));
   const ensureDir = deps.ensureDir ?? ((p, mode) => { mkdirSync(p, { recursive: true, mode }); });
   const chmod = deps.chmod ?? ((p, mode) => chmodSync(p, mode));
-  const workdirRoot = deps.workdirRoot ?? join(homedir(), ".anet", "nodes");
-  const deletedRoot = deps.deletedRoot ?? join(homedir(), ".anet", "deleted");
+  const workdirRoot = deps.workdirRoot ?? join(deps.workDir ?? process.cwd(), ".anet", "nodes");
+  const deletedRoot = deps.deletedRoot ?? join(deps.workDir ?? process.cwd(), ".anet", "deleted");
 
   let req: GetStopRequestResult;
   try {


### PR DESCRIPTION
Addresses **#1474 finding-1** (HIGH · **security** · credential residue after delete). Shipped alone for fast review; finding-2 (pgid role after daemon restart) follows in a separate PR.

## 缺陷（CONFIRMED，origin/main 913253bd 代码复核 + witnessed-red）
create 写 **cwd 相对**:`create-node-daemon.ts:525` `join(deps.workDir, ".anet", "nodes", <name>)`(+ `.env.local` :554),`deps.workDir = daemon process.cwd()`(cli 6110/6144)。但 stop/delete/start handler 的根**硬编码 homedir()**:
- `start-daemon.ts:93` `nodesRoot ?? join(homedir(), ".anet", "nodes")`
- `stop-daemon.ts:184-185` `workdirRoot / deletedRoot ?? join(homedir(), ...)`

且 cli 装配**不传**这三个根(grep 空)→ 生产恒用 homedir 默认。

**daemon 从非 $HOME 目录跑时**(cwd ≠ home):
- `delete_node` → `moveWorkdirToTrash` 去 rename 不存在的 `$HOME/.anet/nodes/<alias>` → 扑空 warn → **仍 ack `stopped`** → hub 删 nodes 行 + 撤 ntok,而真实 `$CWD/.anet/nodes/<alias>/{config.json,.env.local}`(**child ntok + env 密钥**)原地残留 → **违背「删后密钥不残留」**。
- `start_node` → 在 `$HOME` 找不到 config → `verifyStoppedChildConfig` throw → **假 `start_failed`**。

被单测注入 root + `cd ~` workaround 掩盖(所以 CI 绿但生产从 systemd/pm2 等非 $HOME cwd 起时会中招)。

## 修复
根从 **create 用的 cwd 基准**派生,不硬编码 homedir():
- `start-daemon.ts`:用现成的 `deps.workDir`(必填,cli 已传 `process.cwd()`)。
- `stop-daemon.ts`:`StopDoorbellDeps` 加可选 `workDir?`(不破现有注入 root 的测试),根默认 `join(deps.workDir ?? process.cwd(), ".anet", "nodes" | "deleted")`。
- `cli.ts`:两个 `handleStopDoorbell` 调用点(重连补投注入闭包 + live 门铃)补 `workDir: process.cwd()`。
- 删两文件 unused 的 `homedir` import。

`process.cwd()` 在 daemon handler = daemon 启动 cwd = create-node-daemon 写 config 用的 `deps.workDir`(同进程、不 chdir),所以派生根命中 create 落盘处。cwd==home 时与旧行为一致(无回归),cwd≠home 时修正。

## Witnessed-red
`stop-daemon.test.ts`:`workDir` 设一个 **≠ homedir 的临时目录**、**不**注入 `workdirRoot/deletedRoot`(强制走派生),盘上放好 `$workDir/.anet/nodes/<alias>/config.json`。delete 后断言:密钥目录**被清**、backup 落 `$workDir/.anet/deleted`。改前(homedir 派生扑空)→ childDir **残留** + 无 `backup_path` → 红。还原三个产品文件到 origin/main 即见红。

## 验证
- `tsc --noEmit` agent-node 0 error
- `stop-daemon` 23/23、`start-daemon` 7/7(现有测试注入 root/workDir,派生改动无回归)
- `doc-symbol-pins` 两变体(默认 + `--doc-root docs-site`)均 OK
