### PR TITLE
chore(release): follow-up bump — agent-node .50 / agent-network .65

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.64",
+  "version": "2.3.0-preview.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.64",
+      "version": "2.3.0-preview.65",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.64",
+  "version": "2.3.0-preview.65",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.64";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.49";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.65";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.50";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.49",
+  "version": "2.5.0-preview.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.49",
+      "version": "2.5.0-preview.50",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.49",
+  "version": "2.5.0-preview.50",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.64 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.64` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.65` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.64 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.64`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.65`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.65.md
+++ b/docs/tests/release-v2.3.0-preview.65.md
@@ -1,0 +1,48 @@
+# @sleep2agi/agent-network 2.3.0-preview.65 — release notes
+
+四条 create/edit 修复，主题是**「傻瓜路径不该比带 flag 的路径设防更少」**。
+
+- **`network_id` 现在会被持久化**（PR #1471，#1469 finding-2）：`saveProfile` 的白名单漏了它。
+- **交互向导补上带名路径的护栏**（PR #1473，#1469 finding-1）：无名的 `anet node create` 在
+  `createCommand` 里被 `if (!id) return createInteractiveCommand()` 短路，短路点**位于三道护栏之上**，
+  于是面向新手的入口设防最少 —— 本地 hub 自探没跑、「先验 hub 再问 model/key」的顺序反了、
+  `network_id` 缺失时抛未捕获错而不是给下一步。现在两条路径共用同一道门，**向导在打出任何东西
+  之前先验环境**；带名路径的调用点位置未变，行为逐字不变。
+- **裸 `--resume` 不再被静默丢弃**（PR #1475，#1469 finding-4）：无值 flag 被记成 `"true"`，
+  而它此前被排除在「resume 请求」之外 ⇒ runtime 保持默认 ⇒ 整块 session 绑定逻辑被跳过，
+  **连 TTY 的选单都进不去**。现在它算请求；非 TTY 且没给 id 时报错并给出两条可执行的下一步。
+- **`--tools` / `--model` 在 `createProfileFromOpts` 里校验**（PR #1477，#1469 finding-3）。
+
+本版把配套 pin 推到 `PAIRED_AGENT_NODE_VERSION = 2.5.0-preview.50`。
+`PINNED_SERVER_VERSION` **保持 `0.9.0-preview.40`** —— 本批没有 server 改动。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.65 @sleep2agi/agent-node@2.5.0-preview.50
+anet login
+anet hub start
+```
+
+需要 Node.js ≥ 22.13。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.65
+cd ~/anodes && anet project restart
+```
+
+hub 不需要重启：server 版本本批未变（仍是 `0.9.0-preview.40`）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1471 | #1469 finding-2 | `saveProfile` 白名单补上 `network_id` |
+| #1473 | #1469 finding-1 | 交互向导与带名路径共用环境护栏，且先验环境再要输入 |
+| #1475 | #1469 finding-4 | 裸 `--resume` 视为 resume 请求，非 TTY 无 id 时可操作退出 |
+| #1477 | #1469 finding-3 | `--tools` / `--model` 校验 |
+| — | — | pin：agent-node `2.5.0-preview.50`；server 保持 `.40` |
+
+**未包含**：issue #1474 finding-2（pgid）尚未合入 main，走 agent-node `2.5.0-preview.51` fast-follow。

--- a/docs/tests/release-v2.5.0-preview.50.md
+++ b/docs/tests/release-v2.5.0-preview.50.md
@@ -1,0 +1,40 @@
+# @sleep2agi/agent-node 2.5.0-preview.50 — release notes
+
+一条修复，安全相关。
+
+- **删除节点后本地密钥残留**（PR #1478，修 issue #1474 finding-1）。daemon 的 workdir 根此前
+  **硬编码 `homedir()`**，而节点实际的工作目录由 `workDir` 决定。当两者不同（cwd ≠ home）时，
+  delete 去 home 底下找那个目录、找不到、于是**什么都没搬走** —— 节点配置连同其中的凭据
+  留在真实的 workdir 里。现在根从 `workDir` 派生，delete 搬的是节点真正所在的那个目录。
+
+🔴 **升级之后请自查一次**：本版只修「以后不再残留」。**之前**在 cwd ≠ home 的机器上删过的节点，
+残留目录仍在原处，需要手工确认：
+
+```bash
+ls -la <你的 workDir>/.anet/nodes/     # 已删节点的目录若还在，里面可能有凭据
+```
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.65 @sleep2agi/agent-node@2.5.0-preview.50
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.50
+cd ~/anodes && anet project restart
+```
+
+跑着的节点要重启才会拿到新 agent-node（#117）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1478 | #1474 finding-1 | daemon workdir 根从 `workDir` 派生，消除删后密钥残留 |
+
+**未包含**：issue #1474 的 **finding-2（pgid）** 尚未合入 main，走 `2.5.0-preview.51` fast-follow。
+（注意 #1474 finding-2 与 #1469 finding-2 是两码事 —— 后者是 network_id，已在 agent-network `2.3.0-preview.65` 里。）


### PR DESCRIPTION
**Draft —— 我不 trigger、没实发。** 发版由 @通信龙 触发，顺序 `agent-node .50` → `agent-network .65`（pin 链）。

```
agent-node      2.5.0-preview.49 → .50
agent-network   2.3.0-preview.64 → .65
commhub-server  不动，仍 0.9.0-preview.40
```

`PAIRED_AGENT_NODE_VERSION → 2.5.0-preview.50`（`sync-pinned-versions.sh --apply` 写）。
`PINNED_SERVER_VERSION` 保持 `.40`、`hub-daemon.sh` 的 `RUNTIME_DIR` 保持 `preview40` —— **`server/` 本批一行没改，动它们等于声称一次并不存在的 server 发版。**

## bump 前的基线

三包仓内版本与 npm **`dist-tags.preview`** 逐一对齐（`.40` / `.49` / `.64`）才动手。

## 🔴 fix 清单我没照单接受，是枚举出来的

`git log <.64 bump>..HEAD -- agent-node agent-network` ⇒ **正好 5 个提交**，与那 5 个 PR 一一对应。所以这个窗口里没有别的已合改动被漏进 notes。

| PR | 归属 | 落在哪份 notes |
|---|---|---|
| #1471 | #1469 finding-2（network_id） | agent-network |
| #1473 | #1469 finding-1（交互向导护栏） | agent-network |
| #1475 | #1469 finding-4（裸 `--resume`） | agent-network |
| #1477 | #1469 finding-3（`--tools`/`--model` 校验） | agent-network |
| #1478 | **#1474** finding-1（workdir 根） | agent-node |

## 🔴 一个命名陷阱，两份 notes 里都写清楚了

**有两个不同的 "finding-2"：**

- **#1469 finding-2** = #1471，`network_id` 持久化 —— **本批已含**
- **#1474 finding-2** = pgid —— **未合，走 agent-node `.51`**

而且 **#1474 是 issue 不是 PR**（#1478 是它的 finding-1）。两份 notes 都点名说的是哪一个 finding-2，不让读者去猜。

## 其余

- getting-started 版本戳 `.64 → .65`，中英各两处（机器读的注释 + 人读的表格行）。
  那行表格断言「密码随机，因为 `server/src/auth.ts` 自 .49 起零提交」—— **对 .65 重新验过**（`git log --since` 为空），没有因为上一轮验过就免验。
- agent-node 那份 notes 里写了一格给用户的自查：本版只修「以后不再残留」，**之前**在 cwd ≠ home 的机器上删过的节点，残留目录仍在原处，附了查看命令。

## 本地门

```
check-doc-version-claims.py   exit 0（4 个戳，全指向正在发的版本）
check-hub-launcher-pin.py     exit 0（preview40，与未变的 server pin 一致）
```

CI 上的 `release version sync dry-run (Docker)` 是权威判据。

## 查重

按内容搜过：`sync-pinned-versions` / `PAIRED_AGENT_NODE_VERSION` / `preview.65` ⇒ 无 open PR 碰这条路径。按文件查重过：扫 open PR 的两个 `package.json`、`getting-started.md` ⇒ 零重叠。
