### PR TITLE
fix(daemon): stop/delete 信号发解析出的真 pgid 不假设 pgid==pid (#1474 finding-2)

### DIFF
--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -33,6 +33,7 @@ function makeDeps(opts: {
   workdirRoot?: string;
   deletedRoot?: string;
   getStopReturn?: any;
+  readPgid?: (pid: number) => number | null;
 } = {}) {
   const acks = opts.acks ?? [];
   let aliveCalls = 0;
@@ -54,6 +55,7 @@ function makeDeps(opts: {
       warn: (_m: string) => { /* swallow */ },
       workdirRoot: opts.workdirRoot,
       deletedRoot: opts.deletedRoot,
+      readPgid: opts.readPgid,
       signalProcess: (pid: number, sig: NodeJS.Signals | 0) => {
         if (opts.signalThrows && sig !== 0) throw opts.signalThrows;
         fakeSignals.push({ pid, sig });
@@ -183,6 +185,44 @@ describe("handleStopDoorbell — SIGKILL escalation", () => {
     expect(acks[0].args.exit_signal).toBe("SIGKILL");
     expect(fakeSignals.filter(s => s.sig === "SIGTERM").length).toBe(1);
     expect(fakeSignals.filter(s => s.sig === "SIGKILL").length).toBe(1);
+  });
+});
+
+// #1474 finding-2 — 信号发给**解析出的真实 pgid**,不假设 pgid==pid。
+// live 记的是 wrapper(session leader,pgid==pid),但 boot rebuild 用 pgrep 记的是
+// agent-node 孙子(pgid=wrapper.pid≠孙子.pid)。对孙子 kill(-孙子pid) 命中不存在的组
+// → ESRCH 静默吞 → wrapper 逃生、可重生 child → daemon 重启后 stop/delete 不可靠。
+describe("#1474 finding-2 — signals resolved pgid, not kill(-recorded.pid)", () => {
+  test("grandchild pid (pgid≠pid) → SIGTERM goes to the resolved group, not -recorded.pid", async () => {
+    recordSpawnedChild("node_g", "alias-g", 5000);   // rebuild-recorded grandchild pid
+    const { acks, fakeSignals, deps } = makeDeps({
+      // 孙子 pid 5000 的真实 pgid = wrapper 4000(同组)
+      readPgid: (pid: number) => (pid === 5000 ? 4000 : null),
+      getStopReturn: {
+        ok: true, request_id: "sr_g", child_node_id: "node_g", child_alias: "alias-g",
+        action: "stop", delete_config: false, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "sr_g" }, deps);
+    expect(acks.at(-1)!.args.status).toBe("stopped");
+    // SIGTERM 落到解析出的组 -4000(wrapper+孙子一网打尽)
+    expect(fakeSignals.some(s => s.pid === -4000 && s.sig === "SIGTERM")).toBe(true);
+    // 绝不对孙子 pid 本身发组信号 -5000(改前:kill(-5000)→不存在的组→ESRCH→wrapper 逃生)
+    expect(fakeSignals.some(s => s.pid === -5000)).toBe(false);
+  });
+
+  test("pgid unresolvable (readPgid→null) → falls back to old pgid==pid assumption", async () => {
+    recordSpawnedChild("node_w", "alias-w", 7000);   // wrapper pid, pgid==pid
+    const { acks, fakeSignals, deps } = makeDeps({
+      readPgid: () => null,   // 解析不到 → 退回 kill(-pid)
+      getStopReturn: {
+        ok: true, request_id: "sr_w", child_node_id: "node_w", child_alias: "alias-w",
+        action: "stop", delete_config: false, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "sr_w" }, deps);
+    expect(acks.at(-1)!.args.status).toBe("stopped");
+    expect(fakeSignals.some(s => s.pid === -7000 && s.sig === "SIGTERM")).toBe(true);   // 退回 -pid
   });
 });
 

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -86,6 +86,9 @@ export interface StopDoorbellDeps {
   // spawning real subprocesses. Production wires these to node:process
   // / setTimeout / Date.now / node:fs.
   signalProcess?: (pid: number, signal: NodeJS.Signals | 0) => void;
+  // #1474 finding-2 — 解析某 pid 的真实进程组 id(pgrp)。默认读 /proc/<pid>/stat;
+  // 可注入以便测试。返回 null=解析不到(退回 pgid==pid 的旧假设)。
+  readPgid?: (pid: number) => number | null;
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;          // virtual clock for tests; defaults to Date.now
   renameDir?: (src: string, dst: string) => void;
@@ -261,9 +264,22 @@ export async function handleStopDoorbell(
   // platforms where negative-PID isn't supported. The kill-0 liveness
   // check stays bare-PID since the wrapper PID's existence is the
   // authoritative "is the chain still up" signal.
+  // #1474 finding-2 — 解析 pid 的真实 pgid,**不**假设 pgid==pid。
+  // live 路径记的是 `anet node start` wrapper(detached→session leader,pgid==pid),
+  // 但 boot rebuild 用 pgrep 记的是 `agent-node --alias` 孙子(它继承 wrapper 的
+  // pgid,孙子.pid≠pgid)。对孙子 `kill(-孙子pid)` 命中一个不存在的进程组 → ESRCH →
+  // 下面被静默吞 → wrapper 未收信号、可重生 child → daemon 重启后 stop/delete 不可靠。
+  // 读 /proc/<pid>/stat 的 pgrp 字段拿真 pgid:wrapper 和孙子同组,解析哪个 pid 都得
+  // 同一组、都能一网打尽。解析不到就退回旧假设(pgid==pid)。
+  const resolvePgid = (pid: number): number => {
+    const read = deps.readPgid ?? defaultReadProcPgid;
+    const pgid = read(pid);
+    return (pgid && pgid > 0) ? pgid : pid;
+  };
   const sendGroupSignal = (pid: number, sig: NodeJS.Signals | 0) => {
+    const pgid = resolvePgid(pid);
     try {
-      signalProcess(-pid, sig);
+      signalProcess(-pgid, sig);
     } catch (e: any) {
       if (e?.code === "ESRCH") return;     // group gone — caller will see via isAlive
       if (e?.code === "EPERM" || e?.code === "EINVAL") {
@@ -282,7 +298,7 @@ export async function handleStopDoorbell(
     if (isAlive(entry.pid, signalProcess)) {
       sendGroupSignal(entry.pid, "SIGTERM");
       exit_signal = "SIGTERM";
-      deps.log(`[stop-daemon] sent SIGTERM to pgid=${entry.pid} alias=${entry.alias} grace=${grace_seconds}s (covers wrapper + agent-node grandchild)`);
+      deps.log(`[stop-daemon] sent SIGTERM to pgid=${resolvePgid(entry.pid)} (from recorded pid=${entry.pid}) alias=${entry.alias} grace=${grace_seconds}s (covers wrapper + agent-node grandchild)`);
       const reaped = await waitForExit(entry.pid, grace_seconds * 1000, signalProcess, sleep, now);
       if (!reaped) {
         sendGroupSignal(entry.pid, "SIGKILL");
@@ -483,6 +499,20 @@ function defaultReadProcStatState(pid: number): string | null {
     if (close < 0) return null;
     const tail = stat.slice(close + 1).trim().split(/\s+/);
     return tail[0] || null;
+  } catch { return null; }
+}
+
+/** #1474 finding-2 — /proc/<pid>/stat 的 pgrp(进程组 id)。格式
+ *  "PID (comm) STATE PPID PGRP SESSION ..."；comm 可含空格/括号,从末尾 ) 后切,
+ *  切片索引 0=STATE、1=PPID、2=PGRP。 */
+function defaultReadProcPgid(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const close = stat.lastIndexOf(")");
+    if (close < 0) return null;
+    const tail = stat.slice(close + 1).trim().split(/\s+/);
+    const pgrp = parseInt(tail[2] || "", 10);
+    return Number.isFinite(pgrp) && pgrp > 0 ? pgrp : null;
   } catch { return null; }
 }
 


### PR DESCRIPTION
Addresses **#1474 finding-2** (MED-HIGH · daemon 重启后 stop/delete 不可靠). Fast-follow to finding-1 (#1478, merged). Independent commit; #1448/#1455 pid-reuse 家族的孪生。

## 缺陷（CONFIRMED，代码复核 + witnessed-red）
`handleStopDoorbell` 的 `sendGroupSignal` 做 `kill(-recorded.pid)`,**假设 `recorded.pid` 就是进程组长(pgid==pid)**:
- **live 路径**确实如此:`create-node-daemon` spawn wrapper 时 `detached:true` → `setsid` → wrapper 是 session leader,`pgid==pid`,`recordSpawnedChild` 记 wrapper pid。
- **boot rebuild 路径**不然:`rebuildChildrenMapOnBoot` 用 `pgrep` 找的是 `agent-node --alias` **孙子**进程(它继承 wrapper 的 pgid,`孙子.pid ≠ pgid`),记的是孙子 pid。

daemon **重启后** `entry.pid` = 孙子 → `sendGroupSignal(孙子pid)` 做 `kill(-孙子pid)` → 命中一个**不存在的进程组**(没有进程的 `pgid==孙子pid`)→ `ESRCH` → `sendGroupSignal` 里当作「组已没了」**静默 return** → wrapper + 孙子都没收到信号 → child 可重生 → **daemon 重启后 stop/delete 不可靠**。

(是 #1448/#1455 pid-reuse 家族的孪生:那些修「信哪个 pid」,这条修「重建记的 pid 的**组角色** ≠ `kill(-pid)` 的假设」。)

## 修复
`sendGroupSignal` 先从 `recorded.pid` **解析真实 pgid**(读 `/proc/<pid>/stat` 的 `pgrp` 字段,第 5 字段)再 `kill(-pgid)`。wrapper 和孙子**同进程组**,解析哪个 pid 都得同一组、都能一网打尽 → 天然兼容 live(记 wrapper)和 rebuild(记孙子)两种记法。解析不到就退回旧假设(`pgid==pid`),EPERM/EINVAL 仍走单 PID fallback。`readPgid` 可注入以便测试;`defaultReadProcPgid` 与既有 `defaultReadProcStatState` 同款 `/proc/stat` 切法。

## Witnessed-red
`stop-daemon.test.ts`:
- 记一个 `pgid(4000) ≠ pid(5000)` 的孙子,stop 断言 SIGTERM 落到解析出的组 `-4000`(wrapper+孙子一网打尽)、且**绝不**对 `-5000` 发信号。**改前 `kill(-5000)` → 不存在的组 → ESRCH → wrapper 逃生**,此断言红。还原 `stop-daemon.ts` 到 origin/main 即见红。
- 另测 `readPgid → null`(解析不到)退回 `-pid`(回归钉,证明 fallback)。

## 验证
- `tsc --noEmit` agent-node 0 error;`stop-daemon` 25/25;`doc-symbol-pins` 两变体 OK。
