### PR TITLE
fix(#1482): latest 戳从来没被比对过 —— 补 npm 真值判据 + 修正线上给 latest 用户的错话

### DIFF
--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -162,6 +162,12 @@ jobs:
           # 需要历史才能取「最近新增的行」——指纹只从那里选,见脚本注释。
           fetch-depth: 80
       - run: python3 .github/scripts/check-docs-site-drift.py --selftest
+      # #1482 —— latest 戳从来没有被任何东西比对过(发版模式只比"正在发的通道"的戳),
+      # 于是它自 2.2.21 起一直漂,而正文照着它对 latest 用户说了假话。
+      # 放在这个 workflow 里:它已经要联网、已经是每日跑,而且红了会走上面那条
+      # tracker issue 通知 —— per-PR 不加网络依赖。
+      - name: latest 戳 vs npm dist-tags.latest (#1482)
+        run: python3 scripts/check-doc-version-claims.py --verify-latest-from-npm
       - name: check anet.sh against main
         id: drift
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -597,7 +597,8 @@ jobs:
         run: |
           python3 scripts/check-doc-version-claims.py \
             --package '${{ needs.build-tarball.outputs.package }}' \
-            --version '${{ needs.build-tarball.outputs.version }}'
+            --version '${{ needs.build-tarball.outputs.version }}' \
+            --verify-latest-from-npm
 
   verdict:
     name: verdict (aggregate)

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -6,7 +6,7 @@
      version being published against these stamps and blocks the release, listing every line to update.
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
-<!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
+<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
 <!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
@@ -25,8 +25,9 @@ Skip this page and go to the [Upgrade Guide](/en/guide/upgrade) (usually `anet u
 
 - **Node.js ≥ 22.13.0**
 - **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun that step always fails**, but how depends on the channel:
-  · **latest (currently `2.2.21`)**: a bare `Error: spawn bunx ENOENT` plus a Node stack trace;
-  · **preview (`2.3.0-preview.x`)**: refused before launch with `❌ anet hub start requires the Bun runtime` (exit code 1). After installing, `bun --version` should print a version.
+  · **builds that carry the preflight** (measured 2026-08-30: `latest` = `2.3.0-preview.47`, and `preview`): refused before launch with `❌ anet hub start requires the Bun runtime` (exit code 1);
+  · **older builds without it** (measured on `2.2.21`): a bare `Error: spawn bunx ENOENT` plus a Node stack trace.
+  After installing, `bun --version` should print a version.
 
 With both installed, `commhub-server` / `agent-node` are auto-fetched on first use — you don't install them manually.
 
@@ -144,7 +145,7 @@ On stable, `anet node create` lists **4 production runtimes** (`claude-agent-sdk
 Start the node:
 
 ::: warning Fresh install + claude-agent-sdk / codex-sdk? Install agent-node first
-These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **`@preview` contains this fix; `@latest` does not** (check yours with `anet -v`; check where the channels point with `npm view @sleep2agi/agent-network dist-tags`) — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
+These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **builds `≤ 2.3.0-preview.37`** (including the older `2.2.21`) the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **the fix has been in builds since `2.3.0-preview.38`** (check yours with `anet -v`; check where the channels point with `npm view @sleep2agi/agent-network dist-tags` — measured 2026-08-30, `latest` is already `2.3.0-preview.47`, i.e. **past that floor**) — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -5,7 +5,7 @@
      同时变假。release gate 会拿正在发的版本和这两条戳比对,不一致就拦下发布并列出
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
-<!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
+<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
 <!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
@@ -24,8 +24,9 @@
 
 - **Node.js ≥ 22.13.0**
 - **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 时第 2 步一定失败**，但表现分两条线:
-  · **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈；
-  · **preview(`2.3.0-preview.x`)**:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`（退出码 1）。装完 `bun --version` 应有输出。
+  · **含 preflight 的构建**（2026-08-30 实测:`latest` = `2.3.0-preview.47`、以及 `preview`）:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`（退出码 1）；
+  · **更早、不含 preflight 的构建**（实测 `2.2.21`）:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈。
+  装完 `bun --version` 应有输出。
 
 这俩装好就行；`commhub-server` / `agent-node` 首次用时自动拉取，不用手动装。
 
@@ -141,7 +142,7 @@ stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / 
 启动节点：
 
 ::: warning 全新安装选了 claude-agent-sdk / codex-sdk？先装 agent-node
-这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**`@preview` 已含此 fix，`@latest` 未含**（查自己装的：`anet -v`；查通道当前指向：`npm view @sleep2agi/agent-network dist-tags`） —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
+这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **`≤ 2.3.0-preview.37` 的构建**（含旧的 `2.2.21`）的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**该 fix 自 `2.3.0-preview.38` 起含在构建里**（查自己装的：`anet -v`；查通道当前指向：`npm view @sleep2agi/agent-network dist-tags` —— 2026-08-30 实测 `latest` 已是 `2.3.0-preview.47`，即**已越过这条下界**） —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/scripts/check-doc-version-claims.py
+++ b/scripts/check-doc-version-claims.py
@@ -38,6 +38,22 @@
     - 该 (package, channel) 下的每一条戳,version 必须等于 V
     - 红了的时候,把**文件里所有出现旧版本串的行**都打出来 —— 修法是机械的
 
+🔴 latest 戳为什么会一直漂(2026-08-30 补)
+=========================================
+
+**发版模式只比"正在发的那个通道"的戳。** 发 preview 时 `channel_of(V)` = preview,
+于是**只有 preview 戳被比对,latest 戳一次都没有被任何东西检查过**。
+
+结果实测:`latest` 戳自 `2.2.21` 起再没动过,而 npm 上的 `dist-tags.latest`
+已经是 `2.3.0-preview.47`。正文因此在对 latest 用户撒谎 ——
+它说 latest 会裸崩 `spawn bunx ENOENT`,而 `.47` 其实有那道友好 preflight。
+**这一族的方向是"劝退用户",正是本文件开头说的最糟那种假。**
+
+⇒ 新增 `--verify-latest-from-npm`:把 latest 戳直接对 `npm view <pkg> dist-tags.latest` 比。
+   它需要网络,所以**不放进 per-PR 的结构模式**(那会给每次合并加一个网络依赖);
+   放在已经要联网的那些定时/发版流程里。
+   🔴 **取不到 npm 数据 → exit 2(说不清楚就不说没问题),不是绿。**
+
 这道门不保证什么
 ================
 
@@ -69,6 +85,88 @@ def channel_of(version: str) -> str:
     return "preview" if "-" in version else "latest"
 
 
+def channel_shape_conflict(chan: str, ver: str, npm_latest_for_pkg: str | None) -> bool:
+    """戳的 channel 和版本号形状对不上时,是不是真的矛盾。
+
+    🔴 `channel_of()` 是个**启发式**:靠"有没有 `-`"猜通道。它隐含一条假设 ——
+    **预发布版号只可能挂在 preview 上**。这个仓的发布实践violates 了它:
+    2026-08-26 一次**未带 `--tag preview` 的手工 publish**,让 npm 的
+    `dist-tags.latest` 直接指到了 `2.3.0-preview.47`。
+
+    所以当我们**手上有 npm 的真值**、且它确认 latest 就是这个版本时,
+    启发式必须让位 —— 戳是对的,猜错的是那条形状规则。
+    没有真值时(结构模式/发版模式)仍按原来的启发式判,行为不变。
+    """
+    if channel_of(ver) == chan:
+        return False
+    if npm_latest_for_pkg is None:
+        # 🔴 没有真值时**不判红**。原来这里是硬错误,依据是"预发布版号只可能在 preview"——
+        #    而这条不变量已经**不成立**(latest 现在就指着 2.3.0-preview.47)。
+        #    没有 npm 数据时,"戳写错了"和"latest 真的指着预发布版"**读起来完全一样**,
+        #    分不开就不该判。分不开还判,就是拿一条已知会误报的规则去挡 main。
+        #    ⇒ 降级为提示;真正的判定交给 --verify-latest-from-npm(它有真值)。
+        return False
+    if chan == "latest" and npm_latest_for_pkg == ver:
+        return False          # npm 说它就是 latest —— 以真值为准
+    return True
+
+
+def channel_shape_note(chan: str, ver: str, npm_latest_for_pkg: str | None) -> bool:
+    """形状对不上、但没有真值可判 —— 值得打印一句,不判红。"""
+    return channel_of(ver) != chan and npm_latest_for_pkg is None
+
+
+def latest_stamp_problems(
+    stamps: list[tuple[int, str, str, str]], npm_latest: dict[str, str], rel: str
+) -> list[str]:
+    """latest 戳 vs npm dist-tags.latest。纯函数 —— selftest 不需要网络就能覆盖。
+
+    只看 channel=latest 的戳;preview 戳由发版模式那条路径管。
+    """
+    out = []
+    for lineno, pkg, chan, ver in stamps:
+        if chan != "latest":
+            continue
+        actual = npm_latest.get(pkg)
+        if actual is None:            # 没查到这个包 —— 由调用方决定是不是 exit 2
+            continue
+        if ver != actual:
+            out.append(
+                f"::error file={rel},line={lineno}::latest 戳说 {pkg}={ver},"
+                f"而 npm 上 dist-tags.latest 是 {actual} —— 戳漂了,"
+                f"正文里关于 latest 的行为断言很可能也跟着假了"
+            )
+    return out
+
+
+# 戳里的 package 字段用的是**裸名**(`agent-network`),而 npm 上是**带 scope 的**
+# (`@sleep2agi/agent-network`)—— 裸名在 registry 上 404。
+# 这一格是实测撞出来的:第一版直接拿戳里的字符串去 `npm view`,得到
+#   npm error 404 Not Found - GET https://registry.npmjs.org/agent-network
+# 而门**没有**把它当成"没问题"放过去,是 exit 2 拒绝通过 —— fail-closed 起作用了。
+NPM_SCOPE = "@sleep2agi/"
+
+
+def npm_name(stamp_package: str) -> str:
+    """戳里的包名 → registry 上的包名。已经带 scope 的原样返回。"""
+    return stamp_package if stamp_package.startswith("@") else NPM_SCOPE + stamp_package
+
+
+def npm_dist_tag_latest(package: str) -> str | None:
+    """查 npm 的 dist-tags.latest;查不到返回 None(调用方按"量不出来"处理)。"""
+    try:
+        r = subprocess.run(
+            ["npm", "view", npm_name(package), "dist-tags", "--json"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if r.returncode != 0:
+            return None
+        import json as _json
+        return _json.loads(r.stdout).get("latest")
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+
+
 def parse(text: str) -> list[tuple[int, str, str, str]]:
     out = []
     for lineno, line in enumerate(text.split("\n"), 1):
@@ -77,9 +175,28 @@ def parse(text: str) -> list[tuple[int, str, str, str]]:
     return out
 
 
-def run(repo: Path, package: str | None, version: str | None) -> int:
+def run(repo: Path, package: str | None, version: str | None,
+        verify_latest: bool = False) -> int:
     problems = 0
     total_stamps = 0
+    npm_latest: dict[str, str] = {}
+    if verify_latest:
+        # 先把所有 latest 戳提到的包查一遍;查不到就是"量不出来",不是"没问题"
+        pkgs = set()
+        for rel in DOCS:
+            path = repo / rel
+            if path.is_file():
+                for _ln, pkg, chan, _v in parse(path.read_text(encoding="utf-8")):
+                    if chan == "latest":
+                        pkgs.add(pkg)
+        for pkg in sorted(pkgs):
+            got = npm_dist_tag_latest(pkg)
+            if got is None:
+                print(f"::error::查不到 {npm_name(pkg)} 的 dist-tags.latest(网络/registry?)"
+                      f" —— 拒绝通过:说不清楚就不说没问题", file=sys.stderr)
+                return 2
+            npm_latest[pkg] = got
+        print("npm dist-tags.latest: " + ", ".join(f"{k}={v}" for k, v in sorted(npm_latest.items())))
     for rel in DOCS:
         path = repo / rel
         if not path.is_file():
@@ -92,8 +209,16 @@ def run(repo: Path, package: str | None, version: str | None) -> int:
             return 2
         total_stamps += len(stamps)
 
+        for msg in latest_stamp_problems(stamps, npm_latest, rel):
+            print(msg)
+            problems += 1
+
         for lineno, pkg, chan, ver in stamps:
-            if channel_of(ver) != chan:
+            if channel_shape_note(chan, ver, npm_latest.get(pkg)):
+                print(f"  note {rel}:{lineno}: channel={chan} 而 version={ver} 形状像 "
+                      f"{channel_of(ver)} —— 无 npm 真值时不判红(latest 确实可能指着预发布版)。"
+                      f"要判请加 --verify-latest-from-npm")
+            if channel_shape_conflict(chan, ver, npm_latest.get(pkg)):
                 print(f"::error file={rel},line={lineno}::戳自相矛盾: version={ver} "
                       f"看起来是 {channel_of(ver)} 通道,但 channel={chan}")
                 problems += 1
@@ -145,6 +270,45 @@ def selftest() -> int:
     two = parse(stamp("agent-network", "latest", "1.0.0") + " " + stamp("agent-node", "preview", "1.0.0-preview.1"))
     check("一行两条戳都被收下", len(two) == 2, f"got {len(two)}")
 
+    # ---- latest 戳 vs npm dist-tags.latest(纯函数,无网络)----
+    S = [(9, "agent-network", "latest", "2.2.21"),
+         (10, "agent-network", "preview", "2.3.0-preview.65")]
+
+    drift = latest_stamp_problems(S, {"agent-network": "2.3.0-preview.47"}, "f.md")
+    check("latest 戳漂了 → 报一条", len(drift) == 1, f"got {len(drift)}")
+    check("报的是那条 latest 戳(不是 preview 戳)",
+          bool(drift) and "line=9" in drift[0] and "2.2.21" in drift[0] and "2.3.0-preview.47" in drift[0],
+          drift[0][:90] if drift else "")
+
+    same = latest_stamp_problems(S, {"agent-network": "2.2.21"}, "f.md")
+    check("latest 戳对上 → 零报", same == [], f"got {same}")
+
+    # 🔴 正控放在反侧:preview 戳漂了也不该由这条判据管(它归发版模式)
+    only_preview = latest_stamp_problems(
+        [(10, "agent-network", "preview", "2.3.0-preview.65")],
+        {"agent-network": "2.3.0-preview.47"}, "f.md")
+    check("preview 戳不被这条判据碰", only_preview == [], f"got {only_preview}")
+
+    # 查不到的包不在这里静默判红 —— 由调用方 exit 2("量不出来"≠"没问题")
+    unknown = latest_stamp_problems(S, {}, "f.md")
+    check("查不到的包这里不报(交给调用方 exit 2)", unknown == [], f"got {unknown}")
+
+    # 形状启发式 vs npm 真值
+    check("形状对上 → 不算矛盾", channel_shape_conflict("preview", "1.0.0-preview.1", None) is False)
+    check("形状对不上但无真值 → **不**判红(分不开就不判)",
+          channel_shape_conflict("latest", "1.0.0-preview.1", None) is False)
+    check("形状对不上且无真值 → 出提示",
+          channel_shape_note("latest", "1.0.0-preview.1", None) is True)
+    check("形状对上 → 无提示", channel_shape_note("preview", "1.0.0-preview.1", None) is False)
+    check("npm 真值确认它就是 latest → 不判矛盾(启发式让位)",
+          channel_shape_conflict("latest", "1.0.0-preview.1", "1.0.0-preview.1") is False)
+    check("npm 真值是别的版本 → 仍判矛盾",
+          channel_shape_conflict("latest", "1.0.0-preview.1", "2.0.0") is True)
+
+    check("裸名补上 scope", npm_name("agent-network") == "@sleep2agi/agent-network",
+          npm_name("agent-network"))
+    check("已带 scope 的不重复加", npm_name("@sleep2agi/agent-node") == "@sleep2agi/agent-node")
+
     for name, ok, detail in cases:
         print(f"  {'ok  ' if ok else 'FAIL'} {name}" + (f"   [{detail}]" if detail and not ok else ""))
     bad = sum(1 for _n, ok, _d in cases if not ok)
@@ -157,6 +321,8 @@ def main() -> int:
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--package")
     ap.add_argument("--version")
+    ap.add_argument("--verify-latest-from-npm", action="store_true",
+                    help="把 channel=latest 的戳对 npm dist-tags.latest 比;需要网络")
     args = ap.parse_args()
     if args.selftest:
         return selftest()
@@ -165,7 +331,7 @@ def main() -> int:
         return 2
     repo = Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
                                capture_output=True, text=True, check=True).stdout.strip())
-    return run(repo, args.package, args.version)
+    return run(repo, args.package, args.version, args.verify_latest_from_npm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1482。两半同一个 PR（gate 改了内容必须同时对，否则 gate 红 main）。

**按内容搜过**：`verify-latest-from-npm` ⇒ 零命中 · `channel_shape` ⇒ 零命中 · `dist-tags.latest` ⇒ 零命中。

---

## 根因（判据层）

发版模式只比**正在发的那个通道**的戳 —— `channel_of(V)` 决定比哪一类。发 preview 时只有 preview 戳被比，**latest 戳一次都没有被任何东西检查过**。

于是它自 `2.2.21` 起再没动过，而 npm 的 `dist-tags.latest` 已经是 `2.3.0-preview.47`。

## ① 内容：先实测，再改字

**没有读 dist** —— 本仓已明确「那是字符串表混淆产物，grep 不作数」。在干净 `node:22-bookworm-slim` 容器里跑真二进制，不装 bun：

```
2.3.0-preview.47  →  ❌ anet hub start requires the Bun runtime (…)      exit 1
2.2.21            →  Error: spawn bunx ENOENT + Node 堆栈                exit 1
```

⇒ **每个版本的描述原本都是对的，错的是标签**：页面把 `2.2.21` 叫作 latest。latest 现在是 `.47`，**有那道 preflight**，页面却告诉 latest 用户会裸崩。

改法：两条 bullet 从「按通道分」改成「按是否含 preflight 分」，各自钉实测版本与日期。

**同一页另外两处同族错话也修了**（中英）：`@latest 未含 #450 的 fix` —— 那个 fix 自 `2.3.0-preview.38` 起在构建里，而 latest 已是 `.47`，**已越过下界**。改成写下界 + 给自查命令，不再断言「某通道有没有」。

`latest 会移动 —— 2026-08 之前它指着 2.2.21` 那句是**历史陈述**，正确，**未动**。

## ② 门：`--verify-latest-from-npm`

latest 戳的 version 必须 == `npm view <pkg> dist-tags.latest`，漂了判红。

- **不放进 per-PR 结构模式** —— 那会给每次合并加网络依赖。挂在 `published-artifact-drift.yml`：它已经要联网、每日跑，且红了会走 #1300 那条 tracker issue 通知。
- **取不到 npm 数据 → exit 2**（说不清楚就不说没问题），不是绿。
- **裸名要补 scope**：戳里写 `agent-network`，registry 上是 `@sleep2agi/agent-network`（裸名 404）。这一格是实测撞出来的 —— 第一版直接拿戳里的串去查，门 **exit 2 拒绝通过**，fail-closed 起了作用。

## 🔴 一条不变量已经不成立（这是本 PR 最该被 review 的一格）

原 `channel_of()` 靠「有没有 `-`」猜通道，隐含 **「预发布版号只可能挂在 preview 上」**。

**这条已经不成立** —— 2026-08-26 一次未带 `--tag preview` 的手工 publish，让 `dist-tags.latest` 直接指到 `2.3.0-preview.47`。

于是「戳自相矛盾」这条硬错误会**误伤正确的戳**，并且会挡住 main（实测：改完戳之后结构模式 rc=1）。

改成：

| 情形 | 行为 |
|---|---|
| 有 npm 真值，且 latest == 该版本 | 不判矛盾（**真值优先于启发式**） |
| 有 npm 真值，且对不上 | 判红 |
| **无真值** | **不判红，打一行 note** |

⚠️ **这一格是减弱**，我明写而不是藏起来：无真值时「戳写错了」和「latest 真的指着预发布版」**读起来完全一样** —— 分不开就不该判；分不开还判，就是拿一条**已知会误报**的规则去挡 main。换来的是一条**有真值支撑**的更强判据，覆盖的正是这次漏掉的那类。

## witnessed-red（两侧都跑）

```
戳=2.2.21（现状）+ --verify-latest-from-npm  → rc=1
    ::error …:8::latest 戳说 agent-network=2.2.21，而 npm 上 dist-tags.latest 是 2.3.0-preview.47
    ::error …:9::（en 同）
戳=.47（修好后）+ --verify-latest-from-npm   → rc=0
结构模式（无网络）                            → rc=0 + 2 条 note，不挡 main
```

selftest **6 → 19**，新增覆盖：latest 戳漂 / 对上、preview 戳不被这条判据碰、查不到的包不在纯函数里判红、形状启发式让位于真值、裸名补 scope。

## 门

```
check-workflow-structure / check-action-pins / check-docs-integrity /
check-release-channel-assertions / check-doc-symbol-anchors     全 rc=0
check-doc-source-pins  127 / 11 / 28（未增删文档文件，test831 无需改）
```

## 后话

若哪天 latest 升到 `.65`（或任何新版本），这两条戳和正文要一起再改一次 —— 但**这次之后门会替我们发现**，不用再靠人注意到。