### PR TITLE
fix(#1163): README/SOP/通知器都还在教撞成本红线的命令 + 给 #1435 的部署补上放行判据

### DIFF
--- a/.github/scripts/docs-site-drift-notify.sh
+++ b/.github/scripts/docs-site-drift-notify.sh
@@ -8,7 +8,7 @@
 # ⇒ 「Actions 里变红」**已被实测证明不是一个通知渠道**。
 #
 # 而这道门红了指向的动作是唯一且明确的(从 origin/main 的 worktree 跑
-# `vercel --prod`),所以它值得被送出来。
+# `vercel deploy --prebuilt --prod`),所以它值得被送出来。
 #
 # ## 判据:一条 tracker issue,开/更新/关,不刷屏
 #
@@ -59,7 +59,11 @@ cd /tmp/anet-site/docs-site
 cp -r <主checkout>/docs-site/.vercel .vercel
 ln -sfn <主checkout>/docs-site/node_modules node_modules
 npm run build          # ignoreDeadLinks 未设,有死链会 fail —— 别带着死链上线
-vercel --prod --yes    # 期望结尾 Aliased: https://www.anet.sh
+# 🔴 必须走预构建:绝不让 Vercel 远端 build(成本红线 #1163)
+vercel build --prod
+vercel deploy --prebuilt --prod --yes
+# 期望 Aliased: https://www.anet.sh
+# 🔴 且日志里必须出现 Using prebuilt build artifacts —— 没有它就是走了远端构建
 \`\`\`
 
 ### 验收:验内容,不验状态码

--- a/.github/workflows/deploy-anet-sh.yml
+++ b/.github/workflows/deploy-anet-sh.yml
@@ -1,7 +1,7 @@
 # Auto-deploy docs-site → anet.sh on merge to main.
 #
 # 🔴 anet.sh 一直不接 git 自动部署:合并进 main 不会更新站点,要有人手动
-#    `vercel --prod`(见 deploy/docs-site/README.md)。这个空档反复触发
+#    预构建部署(见 deploy/docs-site/README.md)。这个空档反复触发
 #    published-artifact-drift 的 docs-site-drift 红(#1421 一类),并且是纯重复劳动
 #    (一个 session 里手动重部署过 3 次)。本 workflow 把那步自动化。
 #
@@ -63,5 +63,17 @@ jobs:
           # 死链不会被推上线(与手动流程一致)。
           npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
           npx vercel@latest build --prod --token="$VERCEL_TOKEN"
-          npx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"
-          echo "✅ deployed docs-site → anet.sh"
+          # 🔴 退出码不穿管道:先落盘再看,否则 $? 抓的是 tee/grep 的。
+          npx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN" > deploy.log 2>&1 || rc=$?
+          cat deploy.log
+          [ "${rc:-0}" -eq 0 ] || { echo "::error::部署失败(rc=$rc)"; exit "$rc"; }
+          # 🔴 #1163 是一条成本红线:绝不让 Vercel 远端构建(远端构建费用曾达 100 美元/月)。
+          #    这一行是它的放行判据 —— **做成断言,不是打印给人看**。
+          #    实测 2026-08-30:照旧 README 手工部署 4 次,4 次全走远端构建、0 次 prebuilt,
+          #    而每次日志都在眼前。「靠人看日志」在这件事上是 0/4。
+          grep -Fq 'Using prebuilt build artifacts' deploy.log || {
+            echo "::error::日志里没有 'Using prebuilt build artifacts' —— 这次很可能走了远端构建(#1163 成本红线)。"
+            echo "::error::检查 deploy 是否仍带 --prebuilt、以及 vercel build 是否真的产出了 .vercel/output。"
+            exit 1
+          }
+          echo "✅ deployed docs-site → anet.sh (prebuilt confirmed)"

--- a/.github/workflows/deploy-anet-sh.yml
+++ b/.github/workflows/deploy-anet-sh.yml
@@ -6,10 +6,11 @@
 #    (一个 session 里手动重部署过 3 次)。本 workflow 把那步自动化。
 #
 # 前置(仓库 Settings → Secrets and variables → Actions,一次性):
-#   - VERCEL_TOKEN        Vercel 部署令牌(唯一真·密钥)
-#   - VERCEL_ORG_ID       docs-site/.vercel/project.json 的 orgId
-#   - VERCEL_PROJECT_ID   同上的 projectId
+#   - VERCEL_TOKEN        Vercel 部署令牌(唯一真·密钥)—— ⚠️ 2026-08-30 仍待 owner 配
+#   - VERCEL_ORG_ID       ✅ 已配(非密钥,值见 deploy/docs-site/vercel-project.json)
+#   - VERCEL_PROJECT_ID   ✅ 已配(同上)
 # 未设 VERCEL_TOKEN 时本 workflow **优雅跳过**(打 warning、不判红),设好即生效。
+# 🔴 跳过期间不会造成盲区:站点落后仍由 docs-site-drift 每日发现并开 tracker issue。
 name: deploy-anet-sh
 
 on:

--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -141,13 +141,14 @@ jobs:
 
   docs-site-drift:
     # anet.sh 没有接 git 自动部署:合并进 main 不会让站点更新,必须有人手动
-    # 跑 `vercel --prod`。这条链路的失败方式是**静默分叉** —— 站点照常 200,
+    # 跑预构建部署。这条链路的失败方式是**静默分叉** —— 站点照常 200,
     # 只是内容停在某次部署。仓里记录过停 36 小时、以及冻结近 14 天。
     #
     # 🔴 和上面两个 job 同一个理由放在定时里:它检查的是**已部署的站点**,
     #    PR 不改变它,而且需要外网。放进 per-PR 只会给每次合并加一个网络依赖。
     #
-    # 红了指向的动作是唯一且明确的:从 origin/main 的 worktree 跑 `vercel --prod`。
+    # 红了指向的动作是唯一且明确的:让 `deploy-anet-sh` 跑一次,或从 origin/main 的
+    # worktree 走预构建部署(`vercel build --prod` + `vercel deploy --prebuilt --prod`)。
     name: docs-site-drift
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/deploy/docs-site/README.md
+++ b/deploy/docs-site/README.md
@@ -62,10 +62,27 @@ ln -sfn <主checkout>/docs-site/node_modules node_modules
 #    不要带着死链上线。
 npm run build
 
-# 部署(云端会重新跑 npm run build,含 prebuild 的 skillhub 生成)
-vercel --prod --yes
+# 🔴 产物必须在本地构建,再把**预构建产物**推上去。
+#    绝不让 Vercel 远端构建 —— 那是一条成本红线(远端构建费用一个月到过 100 美元,#1163)。
+vercel build --prod
+vercel deploy --prebuilt --prod --yes
+
 # 期望结尾: Aliased: https://www.anet.sh
+# 🔴 而且日志里**必须**出现这一行,它就是「没走远端 build」的判据:
+#      Building: Using prebuilt build artifacts from .vercel/output
+#    没有它 = 这次走了远端构建 = 撞红线,要停下来查。
 ```
+
+::: danger 不要用 `vercel --prod --yes`
+这条命令**会让 Vercel 在云端重新构建一次** —— 它正是 #1163 立案要修的那条。
+
+**实测 2026-08-30**:照本文件旧版本手工部署 4 次,**4 次全部走远端构建、0 次出现
+prebuilt 标记**,而每次日志都在眼前。照文档做的人不会知道自己在烧钱 ——
+所以这里把它写成明确的禁止,而不是只把正确写法放在上面。
+
+自动化版本见 `.github/workflows/docs-site-deploy.yml`(合并进 main 即自动部署,
+并把上面那条判据做成门)。
+:::
 
 ## 验证:验内容,不验状态码
 
@@ -123,7 +140,7 @@ json.dump({k: src[k] for k in ('projectId', 'orgId', 'projectName')},
 EOF
 ```
 
-之后 `vercel --prod --yes` 就能认到项目;**登录仍需一个有权限的账号**(`vercel login`)。
+之后 `vercel build --prod` / `vercel deploy --prebuilt --prod` 就能认到项目;**登录仍需一个有权限的账号**(`vercel login`)。
 
 🔴 **那三个字段不是密钥** —— 没有 Vercel token,它们不授予任何权限。
 入库的理由是降 bus-factor:在此之前**项目关联只存在于某一台机器上**,

--- a/deploy/docs-site/README.md
+++ b/deploy/docs-site/README.md
@@ -80,8 +80,17 @@ vercel deploy --prebuilt --prod --yes
 prebuilt 标记**,而每次日志都在眼前。照文档做的人不会知道自己在烧钱 ——
 所以这里把它写成明确的禁止,而不是只把正确写法放在上面。
 
-自动化版本见 `.github/workflows/docs-site-deploy.yml`(合并进 main 即自动部署,
-并把上面那条判据做成门)。
+**日常已经不需要手动部署**:`.github/workflows/deploy-anet-sh.yml`(#1435)在
+合并进 `main` 且改动命中 `docs-site/**` 时自动跑上面这套预构建流程,
+并把「日志里必须出现 `Using prebuilt build artifacts`」做成了门。
+
+⚠️ **目前只差一个开关**:repo secrets 里 `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`
+已配好(它们不是密钥,值就在同目录 `vercel-project.json` 里),
+**只剩 `VERCEL_TOKEN` 待 owner 配** —— 在那之前该 workflow 会优雅跳过(打 warning、不判红),
+站点落后仍由 `docs-site-drift` 每日发现并开 tracker issue。
+配好 token 后无需改动任何代码即生效。
+
+本节的手动步骤此后只作**兜底**(workflow 挂了、或要临时验证某个构建)。
 :::
 
 ## 验证:验内容,不验状态码

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -330,7 +330,7 @@ commhub_send_task(alias="通信文档马",
 ```
 
 🔴 **文档 PR 合进 `main` ≠ 文档上线。** `docs-site` 那个 Vercel 项目**没接 git 自动部署**，
-必须有人手动跑一次 `vercel --prod`，步骤见 [`deploy/docs-site/README.md`](../deploy/docs-site/README.md)。
+由 `deploy-anet-sh` workflow 自动部署(合入 main 即触发);手动补跑时**必须走预构建** `vercel build --prod && vercel deploy --prebuilt --prod`(绝不远端 build,成本红线 #1163),步骤见 [`deploy/docs-site/README.md`](../deploy/docs-site/README.md)。
 漏了不会报错，只会让 anet.sh 和 `main` 静默分叉——实测发生过停在 36 小时前、
 以及冻结近 14 天。所以 Step 9 的**终点是站点上线**，不是 PR 被合。
 


### PR DESCRIPTION
Closes #1163。**没有新增 workflow** —— 详见下面第一节。

**按内容搜过（这次是搜仓库本身，不只是搜 PR）**：`vercel --prod` ⇒ 命中 5 个文件（全在本 PR 修）· `deploy-anet-sh` ⇒ **命中一个已存在的 workflow**（见下）· `Using prebuilt` ⇒ 仅 #1163 issue 正文。

---

## 🔴 我差点重造一个已经存在的东西

我本来在写一个新的 `docs-site-deploy.yml`。写到一半发现 **`deploy-anet-sh.yml` 昨天就随 #1435 合进 main 了**，而且**已经是正确的 prebuilt 流**：

```
npx vercel pull → vercel build --prod → vercel deploy --prebuilt --prod
on: push [main] paths: docs-site/**
未设 VERCEL_TOKEN 时优雅跳过
```

新 workflow 已删。**两个部署 workflow = 两个守护者**，正是 `deploy/daemon` 那页开头「只允许一个守护者」的同一个坑。

⇒ 教训：**OPEN 的 issue ≠ 活没做。** 我今天对 PR 做了内容查重，却没对**仓库本身**做 —— 动手前该先 grep `origin/main` 看东西在不在，而不是只读 issue 状态。

⇒ 也因此，我今天 4 次手动远端 build 的根因**不是"没自动化"**：自动化在，只是 `VERCEL_TOKEN` 没配、它一直在优雅跳过，而我不知道 #1435 已经落了。

## ① #1163：文档还在教撞红线的那条命令

`vercel --prod --yes` 会让 Vercel **远端构建** —— 成本红线（远端构建费用一个月到过 $100）。幸存副本全部修掉：

| 文件 | 改动 |
|---|---|
| `deploy/docs-site/README.md` 部署步骤 | → prebuilt 流；并加 **danger 块明确禁止** `vercel --prod --yes`（不只是把正确写法摆上面） |
| `deploy/docs-site/README.md` 恢复项目关联节 | 残句一并改 |
| `docs/RELEASE-SOP.md` | 指向 `deploy-anet-sh` 自动部署；手动仅兜底且必须 prebuilt |
| `.github/workflows/published-artifact-drift.yml` | 注释里的补救动作 |
| 🔴 **`.github/scripts/docs-site-drift-notify.sh`** | **最要紧的一处** |

最后那条为什么最要紧：它把命令**直接写进 tracker issue 的正文**，交到读 issue 的人手里 —— 也就是说**我上一个 PR 建的通知器，一直在教人去撞红线**。修掉注释、留下用户真会照着敲的那份，就是这仓反复抓的那一族。

**实测证据（2026-08-30，我自己）**：照旧 README 手工部署 **4 次，4 次全部远端构建、0 次 prebuilt**：

```
deploy.log    Building 2   Using prebuilt 0
deploy2.log   Building 2   Using prebuilt 0
deploy3b.log  Building 37  Using prebuilt 0
deploy4.log   Building 39  Using prebuilt 0
```

照文档做的人不会知道自己在烧钱。**我就是那个人** —— 这正是 #1163 的立案理由。

## ② 给 #1435 补上它缺的那道断言

`deploy-anet-sh.yml` 走的是正确流程，但**没有任何东西断言它走了**。将来谁删掉 `--prebuilt`、或 `vercel build` 没产出 `.vercel/output`，它会**安静地退回远端构建**，而红线只剩「靠人看日志」。

加：部署后 `grep -Fq 'Using prebuilt build artifacts'`，缺了判红。

🔴 **为什么必须做成断言而不是打印**：今天证明「靠人看日志」在这件事上是 **0/4** —— 四次日志都在眼前，四次都没被发现。

顺带把退出码从管道里取出来（先落盘再 grep，否则 `$?` 抓的是 grep 的）。

## 没做的

- **`VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`**：只有 owner 能加，已列为待 Vincent 项。**token 一到 #1435 立即生效**，手动部署这件事就结束了。
- 没有新增任何 workflow。

## 门

```
check-workflow-structure / check-action-pins / check-docs-integrity /
check-release-channel-assertions / check-home-path-baseline /
check-doc-symbol-anchors                                    全 rc=0
```

通知器 stub 回归：issue 正文现在教 prebuilt（2 处），**教旧命令 0 处**（改前 1 处）。