### PR TITLE
feat(hub): persist desktop messages so an offline user's dashboard can catch up

### DIFF
--- a/server/src/desktop-message.test.ts
+++ b/server/src/desktop-message.test.ts
@@ -284,3 +284,85 @@ describe("#1459 send_desktop_message 返回值反映真实投递态", () => {
     expect(offline.delivered).not.toBe(online.delivered);
   });
 });
+
+// #1459 ① P2 —— 写入持久化。
+describe("#1459 ① P2 send_desktop_message 持久化", () => {
+  const rowsFor = (mid: string) =>
+    db.get<{ n: number }>("SELECT COUNT(*) AS n FROM user_inbox WHERE message_id = ?1", mid)?.n ?? 0;
+
+  test("🔴 发一条消息 ⇒ user_inbox 落一行，字段与事件一致", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const r = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_A, message: "persist me", severity: "warning", title: "T", kind: "agent_message",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.persisted).toBe(true);
+    const row = db.get<any>("SELECT * FROM user_inbox WHERE message_id = ?1", r.message_id);
+    expect(row).toBeTruthy();
+    expect(row.user_id).toBe(TARGET_A);
+    expect(row.content).toBe("persist me");
+    expect(row.severity).toBe("warning");
+    expect(row.title).toBe("T");
+    expect(row.from_session).toBe("node-a");
+    expect(row.network_id).toBe(NET_A);
+    expect(row.acked).toBe(0);
+  });
+
+  test("🔴 没有活订阅者时也要落库 —— 「丢了」变成「待补投」的那一格", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const r = await call(tools.send_desktop_message, { to_user_id: TARGET_A, message: "offline body" });
+    expect(r.delivered).toBe(false);
+    expect(r.reason).toBe("no_live_subscriber");
+    expect(r.persisted).toBe(true);
+    expect(rowsFor(r.message_id)).toBe(1);
+  });
+
+  test("🔴 zod 默认值不可依赖：直接调 handler 不传 kind/severity 也必须落库", async () => {
+    // 测试与未来的内部调用方绕过 MCP 的 zod .default()，拿到的是 undefined。
+    // 列上虽有 DEFAULT，但显式传 NULL 会覆盖它 —— 所以写入侧要自己兜。
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const r = await call(tools.send_desktop_message, { to_user_id: TARGET_A, message: "no kind given" });
+    expect(rowsFor(r.message_id)).toBe(1);
+    const row = db.get<any>("SELECT kind, severity FROM user_inbox WHERE message_id = ?1", r.message_id);
+    expect(row.kind).toBe("agent_message");
+    expect(row.severity).toBe("info");
+  });
+
+  test("audit_log 与 user_inbox 同生共死（同一事务，条数一致）", async () => {
+    const before = auditCount();
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const r = await call(tools.send_desktop_message, { to_user_id: TARGET_A, message: "paired" });
+    expect(auditCount()).toBe(before + 1);
+    expect(rowsFor(r.message_id)).toBe(1);
+  });
+});
+
+// #1459 ① P2 —— 幂等写法的选择本身要被钉住。
+//
+// 🔴 实现时踩到的：最初用 `INSERT OR IGNORE`，它对「重投同一 message_id」是对的，
+//    但**连 NOT NULL 违规也一起吞掉** —— kind 为 undefined 时整行被静默丢弃，
+//    而工具照样返回 persisted:true。**一条消息凭空消失且报告成功**，正是本
+//    issue 要消灭的那个形状。改成 ON CONFLICT(message_id) DO NOTHING：
+//    只赦免主键冲突，别的约束照常抛。
+describe("#1459 ① P2 幂等写法：赦免重复，但不吞约束错误", () => {
+  const stmt = `INSERT INTO user_inbox
+      (message_id, network_id, user_id, from_session, kind, title, content, severity, meta_json)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+    ON CONFLICT(message_id) DO NOTHING`;
+
+  test("重复的 message_id ⇒ 不抛错、也不产生第二行", () => {
+    const mid = `dm_dup_${Date.now()}`;
+    const ins = () => db.run(stmt, [mid, NET_A, TARGET_A, "node-a", "info", null, "body", "info", null]);
+    ins();
+    expect(() => ins()).not.toThrow();
+    expect(db.get<{ n: number }>("SELECT COUNT(*) AS n FROM user_inbox WHERE message_id = ?1", mid)?.n).toBe(1);
+  });
+
+  test("🔴 NOT NULL 违规必须抛出来 —— 不能像 OR IGNORE 那样静默丢行", () => {
+    const mid = `dm_bad_${Date.now()}`;
+    expect(() =>
+      db.run(stmt, [mid, NET_A, TARGET_A, "node-a", null, null, "body", "info", null]),
+    ).toThrow();
+    expect(db.get<{ n: number }>("SELECT COUNT(*) AS n FROM user_inbox WHERE message_id = ?1", mid)?.n).toBe(0);
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2363,25 +2363,61 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         ...(meta && Object.keys(meta).length ? { meta } : {}),
       };
 
-      db.run(
-        `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
-         VALUES (?1, ?2, 'send_desktop_message', 'user', ?3, ?4, ?5)`,
-        [
-          enforceUserId || null,
-          callerAlias || null,
-          target.user_id,
-          JSON.stringify({
-            message_id: messageId,
-            to_username: target.username,
-            from: from_session,
-            severity,
-            kind,
-            title: title || null,
-            meta_keys: meta && typeof meta === "object" ? Object.keys(meta) : [],
-          }),
-          effectiveNetId,
-        ],
-      );
+      // #1459 ① P2 —— 审计与收件持久化必须同生共死：只落其中一半，就会出现
+      // 「审计说发过、而用户永远收不到」或者反过来。放进同一个事务。
+      db.transaction(() => {
+        db.run(
+          `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
+           VALUES (?1, ?2, 'send_desktop_message', 'user', ?3, ?4, ?5)`,
+          [
+            enforceUserId || null,
+            callerAlias || null,
+            target.user_id,
+            JSON.stringify({
+              message_id: messageId,
+              to_username: target.username,
+              from: from_session,
+              severity,
+              kind,
+              title: title || null,
+              meta_keys: meta && typeof meta === "object" ? Object.keys(meta) : [],
+            }),
+            effectiveNetId,
+          ],
+        );
+        // 🔴 `ON CONFLICT(message_id) DO NOTHING`，而不是 `INSERT OR IGNORE`：
+        //   两者对"重投同一个 message_id"效果相同（幂等，不产生重复消息），
+        //   但 OR IGNORE 会**连同其它约束错误一起吞掉** —— 我在实现本段时就
+        //   撞上了：`kind` 为 NULL 触发 NOT NULL，OR IGNORE 静默丢弃整行，
+        //   而工具照样返回 `persisted: true`。**一条消息凭空消失且报告成功**，
+        //   正是本 issue 要消灭的那个形状。
+        //   DO NOTHING 只针对主键冲突，别的约束照常抛出、事务回滚。
+        //
+        //   另：普通 INSERT 会让重试抛主键冲突（无害重试变 500）；
+        //   OR REPLACE 会覆盖旧行、把用户已 ack 的状态冲掉。都不取。
+        db.run(
+          `INSERT INTO user_inbox
+             (message_id, network_id, user_id, from_session, kind, title, content, severity, meta_json)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+           ON CONFLICT(message_id) DO NOTHING`,
+          [
+            messageId,
+            effectiveNetId ?? null,
+            target.user_id,
+            from_session,
+            // 🔴 不依赖 zod 的 .default()：直接调用 handler 的调用方（测试、
+            //    未来的内部调用）拿不到 zod 默认值，会把 NULL 写进 NOT NULL 列。
+            //    列上虽有 DEFAULT，但**显式传 NULL 会覆盖列默认值**。
+            kind ?? "agent_message",
+            title || null,
+            message,
+            severity ?? "info",
+            // 存储侧走与 inbox 一致的跨主机脱敏；读取侧另有一道 token 形状
+            // 脱敏（规格 ③ redact-at-read），两层分别防不同的东西。
+            meta && typeof meta === "object" ? normalizeMetaJson(meta) : null,
+          ],
+        );
+      });
       // #1459 — pushUserEvent 在没有订阅者时静默 return，而这个工具既不写
       // inbox、也没有任何 user 级回读路径（/api/messages 只 SELECT FROM inbox）。
       // 也就是说用户 dashboard 关着的时候这条消息就永久没了。
@@ -2395,6 +2431,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       //    变成「已入库、等重连补投」。把值取成 no_live_subscriber 而不是
       //    "lost"/"dropped"，就是为了那天不用改写历史含义 —— 届时按需细分
       //    （如 lost vs queued）即可，现在不预先把语义焊死。
+      // 🔴 push 必须在事务**提交之后**：放进事务里的话，活订阅者可能先收到
+      //    事件、而行还没提交；一旦回滚，用户就看到了一条数据库里不存在的消息。
       const delivered = hasUserSubscribers(effectiveNetId, target.user_id);
       pushUserEvent(effectiveNetId, target.user_id, event);
 
@@ -2402,6 +2440,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         ok: true,
         message_id: messageId,
         delivered,
+        // #1459 ① P2 —— 有了持久化之后，「此刻没人在听」不再等于「丢了」。
+        // `delivered` 说的是实时投递、`persisted` 说的是它已经入库等重连补投。
+        // `reason` 仍报**观测到的事实**而不是它的后果，所以这个中间态没有说错话。
+        persisted: true,
         ...(delivered ? {} : { reason: "no_live_subscriber" }),
         delivered_to_user_id: target.user_id,
         network_id: effectiveNetId,


### PR DESCRIPTION
#1459 ① 的 **P2（写入）**，接在 P1 建表（#1481）之后。回读 + ack 是 P3，单独 PR。

## 改动

`send_desktop_message` 现在把消息写进 `user_inbox`，**与 audit 行在同一个事务**里；`pushUserEvent` 留在事务**之外**。放进事务会让活订阅者可能先看到事件、而行还没提交 —— 一旦回滚，用户就看到了一条数据库里不存在的消息。

返回值新增 `persisted: true`。`delivered` 仍然只说"此刻有没有人在听"，两者现在含义不同，而这正是重点：有了落库，「没有活订阅者」不再等于「丢了」，而是「等重连补投」。`reason` 报的仍是**观测到的事实**而非它的后果，所以无需改动。

## 🔴 实现时撞到两件事，都会静默上线

### 一、`INSERT OR IGNORE` 是错的工具

它对被选中的那个场景是对的（重投同一 `message_id` 不该产生第二行），**但它同时吞掉其它所有约束错误**。

第一版传了 NULL 的 `kind`，SQLite 因 NOT NULL 拒绝该行，`OR IGNORE` 把它丢掉，而工具**照样返回 `persisted: true`**。
**一条消息凭空消失，并被报告成功** —— 正是本 issue 存在的理由那个形状。

改成 `ON CONFLICT(message_id) DO NOTHING`：**只赦免主键冲突**，别的约束照常抛出并回滚事务。

### 二、那个 NULL `kind` 来自依赖 zod 的 `.default()`

直接调用 handler 的调用方（这些测试，以及将来任何内部调用）**不经过 MCP schema**，默认值不生效。列上虽然也有 `DEFAULT`，但**显式传 NULL 会覆盖列默认值**。写入侧现在自己兜底。

## 验证

**15 pass / 0 fail。** 幂等写法本身被两条测试钉住：
- 重复 `message_id` ⇒ 不抛错、也不多一行
- **NOT NULL 违规 ⇒ 必须抛**

**变异**：换回 `INSERT OR IGNORE` ⇒ 精确红掉第二条。另有一条用例专门覆盖 zod 默认值缺口，因为那正是产生"消失的行"的原因。

## 查重

按内容搜过：`user_inbox` / `send_desktop_message` ⇒ 无其它 open PR 碰这条路径（#1481 已合）。按文件查重过：`server/src/tools.ts` 无重叠。
