### PR TITLE
docs: 给 daemon-lifecycle-reliability 挂入口（我上个 PR 造了第 14 个孤儿页）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -463,3 +463,4 @@ curl -fsS http://127.0.0.1:9200/health
 - [升级指南](/guide/upgrade)
 - [故障排查](/troubleshooting)
 - [`deploy/` — 本仓部署资产的 Git 权威](https://github.com/sleep2agi/agent-network/blob/main/deploy)
+- [daemon ↔ hub 生命周期请求的可靠性模型](https://github.com/sleep2agi/agent-network/blob/main/docs/daemon-lifecycle-reliability.md) —— 开发者向:门铃为什么会丢、重连补偿怎么补、三个 stuck-state 各自的收敛路径

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -498,3 +498,4 @@ unclear, stop and identify which supervisor controls the Hub first.
 - [Upgrade guide](/en/guide/upgrade)
 - [Troubleshooting](/en/troubleshooting)
 - [`deploy/` — the Git authority for this repo's deployment assets](https://github.com/sleep2agi/agent-network/blob/main/deploy)
+- [Lifecycle-request reliability model (daemon ↔ hub)](https://github.com/sleep2agi/agent-network/blob/main/docs/daemon-lifecycle-reliability.md) — developer-facing: why a doorbell can be dropped, how reconnect compensation replays it, and how each of the three stuck states converges


### PR DESCRIPTION
一行改动 ×2（中英）。**起因是我照自己刚立的规矩 grep 了一遍收工，grep 到自己身上。**

## 怎么发现的

刚跟 通信龙 说完「grep 仓不只开工前、收工前也跑一遍」，然后照做：

```
$ git grep -l 'daemon-lifecycle-reliability' origin/main
（零命中）
```

`docs/daemon-lifecycle-reliability.md`（#1461，昨天合的）**在 main 上零入链**。

⇒ 我在 #1226 里**刚统计过 13 个「搜得到、走不回来」的孤儿页**，转头自己造了第 14 个。

## 修

从 `docs-site/docs/{,en/}deploy/daemon.md` 的「相关 / Related」挂过去 —— 读者把 daemon 那页读到底，正是想往深里看的那一刻。

链接文字写清它是**开发者向**、以及里面有什么（门铃为什么会丢 / 重连补偿怎么补 / 三个 stuck-state 各自的收敛），而不是只丢一个文件名 —— 否则读者点不点由运气决定。

## 为什么不并进 `architecture.md`

原始 brief 给过两个选项：新建独立文件，**或**并入 `docs/architecture.md` 的 daemon 段。

实测：**`docs/architecture.md` 里没有 daemon 段**（`git grep daemon -- docs/architecture.md` 零命中）。所以"并入"那条路今天不存在 —— 保持独立文件，从 daemon 页挂入口。

## 门

```
check-docs-integrity / check-doc-symbol-anchors / check-release-channel-assertions   全 rc=0
入链数：改前 0 → 改后 中英各 1
```