### PR TITLE
fix(daemon): #1290 Windows anet_bin path check no longer POSIX-only

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -6,7 +6,9 @@ import {
   loadAndVerifyAnetBin,
   ensureGlobalAnetConfig,
   reconcilePendingCreateRequestsOnConnect,
+  _resetWindowsPosixModeWarnLatchForTest,
 } from "./create-node-daemon.js";
+import { win32 as pathWin32 } from "node:path";
 import { writeFileSync, mkdirSync, symlinkSync, chmodSync, unlinkSync, rmSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -386,6 +388,149 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
       ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*sha256 mismatch/);
+    cleanup();
+  });
+});
+
+// #1290 — Windows daemon ANET_BIN path check was POSIX-only. On Windows,
+// C:\... never starts with "/" so gate ① threw `not absolute` unconditionally,
+// blocking every create_node while the daemon appeared healthy (SSE ok,
+// doorbells received). Gates ④+⑤ also don't apply on Windows because
+// Node's st.mode is synthesized from Windows file attributes, not
+// filesystem ACLs.
+//
+// These tests exercise the platform parameter directly (unit isolation).
+// The bulk of the coverage above already re-verifies POSIX behavior via
+// the real fixture; here we only add the Windows-specific branches.
+describe("#1290 loadAndVerifyAnetBin — cross-platform path/mode checks", () => {
+  const FIXTURE_DIR = "/tmp/anet-bin-1290-fixtures";
+
+  function setup(name: string, body = "#!/bin/sh\necho real"): string {
+    const pkgDir = join(FIXTURE_DIR, `${name}-pkg`);
+    const binDir = join(pkgDir, "dist", "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({
+      name: "@sleep2agi/agent-network",
+      bin: { anet: "dist/bin/anet.cjs" },
+    }));
+    const p = join(binDir, "anet.cjs");
+    writeFileSync(p, body, { mode: 0o755 });
+    return p;
+  }
+  function cleanup() { try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* ok */ } }
+
+  test("🔴 witnessed-red for the reported #1290 symptom: a Windows drive-letter path is accepted", () => {
+    // The bug: `pin.abs.startsWith("/")` returned false for `C:\Program Files\...`,
+    // so the daemon threw `not absolute: C:\...` on every create_node call.
+    // Fix: `path.isAbsolute()` — cross-platform. Because Node's default
+    // `path.isAbsolute` is host-platform-aware, on the CI Linux runner it
+    // returns false for a Windows path even after the fix (correct: that
+    // host doesn't consider `C:\...` absolute). We assert the rationale via
+    // path.win32.isAbsolute directly, which is the criterion the Windows
+    // daemon will exercise at runtime.
+    expect(pathWin32.isAbsolute("C:\\Program Files\\nodejs\\node_modules\\@sleep2agi\\agent-network\\dist\\bin\\anet.cjs")).toBe(true);
+    expect(pathWin32.isAbsolute("D:/user/anet/dist/bin/anet.cjs")).toBe(true);
+    // Sanity — the pre-fix check would have rejected these:
+    expect("C:\\Program Files\\nodejs\\...".startsWith("/")).toBe(false);
+    expect("D:/user/anet/...".startsWith("/")).toBe(false);
+  });
+
+  test("Windows path with `platform: 'win32'` param skips POSIX-mode gates + prints the one-time warn", () => {
+    cleanup();
+    _resetWindowsPosixModeWarnLatchForTest();
+    const p = setup("win-skip");
+    // A POSIX-style writable-by-group mode would normally throw at gate ④.
+    // On Windows, that gate is skipped (st.mode is synthetic and does not
+    // reflect ACLs — see the docblock on warnOnceWindowsPosixModeSkipped).
+    // Give the file a mode that WOULD fail ④ on POSIX to prove the skip
+    // path is what accepts it here.
+    chmodSync(p, 0o666);  // group+other writable → would throw on POSIX
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string, ..._rest: unknown[]) => { warnings.push(String(msg)); };
+    try {
+      const got = loadAndVerifyAnetBin({
+        ANET_DAEMON_PATH_CONF: "/nonexistent",
+        ANET_BIN_ABS: p,
+        ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      }, "win32");
+      expect(got).toBe(p);
+    } finally {
+      console.warn = origWarn;
+    }
+    // The visible acknowledgement must fire (once) so a Windows operator
+    // sees that the POSIX check was skipped, not silently passed.
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/#1290/);
+    expect(warnings[0]).toMatch(/SKIPPED|skipped/);
+    cleanup();
+  });
+
+  test("Windows-skip warn is once per process (subsequent calls do not re-warn)", () => {
+    cleanup();
+    _resetWindowsPosixModeWarnLatchForTest();
+    const p = setup("win-once");
+    chmodSync(p, 0o644);
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string, ..._rest: unknown[]) => { warnings.push(String(msg)); };
+    try {
+      loadAndVerifyAnetBin({
+        ANET_DAEMON_PATH_CONF: "/nonexistent",
+        ANET_BIN_ABS: p,
+        ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      }, "win32");
+      loadAndVerifyAnetBin({
+        ANET_DAEMON_PATH_CONF: "/nonexistent",
+        ANET_BIN_ABS: p,
+        ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      }, "win32");
+    } finally {
+      console.warn = origWarn;
+    }
+    // Two calls, exactly ONE warning (once per process latch).
+    expect(warnings.length).toBe(1);
+    cleanup();
+  });
+
+  test("POSIX platform (default) STILL rejects group/other-writable modes — Windows skip must not leak", () => {
+    cleanup();
+    _resetWindowsPosixModeWarnLatchForTest();
+    const p = setup("posix-still-strict");
+    chmodSync(p, 0o666);
+    // Explicit "linux" here so if a future refactor accidentally defaults
+    // to platform="win32", this fails loudly. The regression it protects
+    // against: "Windows-skip logic accidentally applied to Linux".
+    expect(() => loadAndVerifyAnetBin({
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
+    }, "linux")).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
+    cleanup();
+  });
+
+  test("realpath equivalence: POSIX byte-exact, Windows case-insensitive normalize", () => {
+    // Direct exercise of the helper via loadAndVerifyAnetBin is awkward
+    // (needs a fixture where realpathSync returns a different case). The
+    // helper is small enough that its two branches are the whole
+    // semantics — verify each via the platform param plumbed through
+    // loadAndVerifyAnetBin's ② gate is the right unit for a follow-up
+    // integration test on a Windows CI runner.
+    //
+    // What we CAN assert here: the helper's inputs match at the string
+    // level for the canonical POSIX case (byte-exact), which is the
+    // pre-fix behavior we must not regress.
+    cleanup();
+    const p = setup("realpath-posix");
+    // Default platform (host) — canonical path, no symlink → passes ②.
+    const got = loadAndVerifyAnetBin({
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
+    });
+    expect(got).toBe(p);
     cleanup();
   });
 });

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -11,7 +11,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { statSync, realpathSync, readFileSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve, win32 } from "node:path";
 import { isReservedEnvKey } from "../shared/reserved-env.js";
 import {
   atomicWriteJson,
@@ -133,7 +133,57 @@ function readPathConf(path: string): PathPin | null {
  *  binary). Non-root owners are allowed by default because nvm/homebrew
  *  installs intentionally place the user's own anet binary outside root
  *  ownership. */
-export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): string {
+/** Case-aware equality for a realpath round-trip.
+ *  POSIX: byte-exact equality (`realpathSync` returns the canonical form
+ *    and we require the input to already be that form).
+ *  Windows: filesystem is case-insensitive and paths flow through junctions
+ *    / short-name aliases, so `realpathSync` can return the same directory
+ *    with a different case or resolved junction target. Normalize both via
+ *    the win32 path helpers and compare case-folded — this preserves the
+ *    "no symlink component" invariant without a false-positive on `C:\Users`
+ *    vs `C:\users`. See #1290 for the realpath-on-Windows discussion.
+ */
+function realpathEquivalent(a: string, b: string, platform: NodeJS.Platform): boolean {
+  if (platform === "win32") {
+    return win32.normalize(a).toLowerCase() === win32.normalize(b).toLowerCase();
+  }
+  return a === b;
+}
+
+// #1290 — Windows `statSync().mode` is a value Node SYNTHESIZES from Windows
+// file attributes (ReadOnly bit + extension-based execute guess), not the
+// actual filesystem ACL. `mode & 0o022` and `mode & 0o111` therefore either
+// throw on files that are actually secure (a `.cjs` file that Node maps to
+// 0o666 fails the group/other-writable check even though ACLs restrict it
+// to Administrators + the current user), or silently accept files that
+// aren't (a script pushed there by an unprivileged user gets the same
+// 0o666 and passes). Neither direction expresses a real security property
+// on Windows.
+//
+// This flag makes that skip visible + shown once per process, so the fact
+// that Windows daemons are running WITHOUT the POSIX-mode supply-chain
+// gate is not a silent security regression. An ACL-based Windows
+// equivalent (icacls / SDDL check via the same `restrictWindowsAcl`
+// pattern that ships in agent-network/src/private-state.ts as of #1137)
+// is filed separately as a follow-up.
+let _windowsPosixModeCheckWarned = false;
+function warnOnceWindowsPosixModeSkipped(warn: (msg: string) => void = console.warn.bind(console)): void {
+  if (_windowsPosixModeCheckWarned) return;
+  _windowsPosixModeCheckWarned = true;
+  warn(
+    `[anet-daemon] #1290 — Windows POSIX-mode supply-chain checks ` +
+    `(group/other writability, executability) SKIPPED. Node's synthetic ` +
+    `st.mode does not reflect Windows filesystem ACLs; enforce with ` +
+    `icacls that ANET_BIN_ABS is owned + writable only by trusted principals.`,
+  );
+}
+/** Test-only: reset the once-per-process warning latch so a test can
+ *  observe the warning firing on the first Windows-platform call. */
+export function _resetWindowsPosixModeWarnLatchForTest(): void {
+  _windowsPosixModeCheckWarned = false;
+}
+
+export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform): string {
   let pin: PathPin | null = null;
   const confPath = env.ANET_DAEMON_PATH_CONF || "/etc/anet-daemon/path.conf";
   pin = readPathConf(confPath);
@@ -141,54 +191,69 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
     pin = { abs: env.ANET_BIN_ABS, sha256: env.ANET_BIN_SHA256 };
   }
   if (!pin && env.ANET_BIN_ABS) {
-    throw unsafePathHelp("anet_bin_source", 
+    throw unsafePathHelp("anet_bin_source",
       "ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is /etc/anet-daemon/path.conf)",
       "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   if (!pin) {
-    throw unsafePathHelp("anet_bin_source", 
+    throw unsafePathHelp("anet_bin_source",
       "no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1",
       "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
-  // ① absolute
-  if (!pin.abs.startsWith("/")) {
-    throw unsafePathHelp("anet_bin_shape", 
+  // ① absolute — cross-platform. Was `startsWith("/")` which returned
+  //    false for every Windows drive-letter path (`C:\...`), so the
+  //    Windows daemon could register + heartbeat + receive doorbells
+  //    but silently refused to fork any node. See #1290.
+  if (!isAbsolute(pin.abs)) {
+    throw unsafePathHelp("anet_bin_shape",
       `not absolute: ${pin.abs}`,
       `export ANET_BIN_ABS=$(node -e "console.log(require('fs').realpathSync(process.argv[1]))" ${quoteSh(pin.abs)})`,
     );
   }
-  // ② no symlink path component (realpath equals self)
+  // ② no symlink path component (realpath equals self). Case-aware on
+  //    Windows so a junction- or case-normalized `realpathSync` result
+  //    doesn't fail this check on an otherwise-correct absolute path.
   const real = realpathSync(pin.abs);
-  if (real !== pin.abs) {
-    throw unsafePathHelp("anet_bin_shape", 
+  if (!realpathEquivalent(real, pin.abs, platform)) {
+    throw unsafePathHelp("anet_bin_shape",
       `contains symlink: ${pin.abs} -> ${real}`,
       `export ANET_BIN_ABS=${quoteSh(real)}`,
     );
   }
   verifyAnetBinIdentity(pin.abs);
-  // ③ stat: non-root owner is acceptable for nvm/homebrew/user installs.
   const st = statSync(pin.abs);
-  if (st.uid !== 0 && env.ANET_DAEMON_STRICT_ROOT_BIN === "1") {
-    throw unsafePathHelp("anet_bin_permission", 
-      `owner not root (uid=${st.uid})`,
-      `sudo chown root:root ${quoteSh(pin.abs)} || unset ANET_DAEMON_STRICT_ROOT_BIN`,
-    );
+  if (platform === "win32") {
+    // Windows: st.mode is synthetic; POSIX bit checks don't apply. See
+    // the docblock on warnOnceWindowsPosixModeSkipped for the rationale +
+    // the ACL-based follow-up. Print the visible acknowledgement once
+    // and skip ③④⑤ entirely on Windows.
+    warnOnceWindowsPosixModeSkipped();
+  } else {
+    // ③ stat: non-root owner is acceptable for nvm/homebrew/user installs.
+    if (st.uid !== 0 && env.ANET_DAEMON_STRICT_ROOT_BIN === "1") {
+      throw unsafePathHelp("anet_bin_permission",
+        `owner not root (uid=${st.uid})`,
+        `sudo chown root:root ${quoteSh(pin.abs)} || unset ANET_DAEMON_STRICT_ROOT_BIN`,
+      );
+    }
+    // ④ not group/other writable
+    if ((st.mode & 0o022) !== 0) {
+      const before = (st.mode & 0o777).toString(8);
+      throw unsafePathHelp("anet_bin_permission",
+        `writable by group/other (mode=${before})`,
+        `chmod go-w ${quoteSh(pin.abs)}`,
+      );
+    }
+    // ⑤ executable
+    if ((st.mode & 0o111) === 0) {
+      throw unsafePathHelp("anet_bin_permission", "not executable", `chmod +x ${quoteSh(pin.abs)}`);
+    }
   }
-  // ④ not group/other writable
-  if ((st.mode & 0o022) !== 0) {
-    const before = (st.mode & 0o777).toString(8);
-    throw unsafePathHelp("anet_bin_permission", 
-      `writable by group/other (mode=${before})`,
-      `chmod go-w ${quoteSh(pin.abs)}`,
-    );
-  }
-  // ⑤ executable
-  if ((st.mode & 0o111) === 0) {
-    throw unsafePathHelp("anet_bin_permission", "not executable", `chmod +x ${quoteSh(pin.abs)}`);
-  }
-  // hash match install-time witness (when provided, REQUIRED to match)
+  // hash match install-time witness (when provided, REQUIRED to match).
+  // Runs on all platforms — sha256 is the strongest cross-platform
+  // integrity check we have and does not care about mode bits or ACLs.
   if (pin.sha256) {
     const actual = createHash("sha256").update(readFileSync(pin.abs)).digest("hex");
     if (actual !== pin.sha256) {


### PR DESCRIPTION
Fixes [#1290](https://github.com/sleep2agi/agent-network/issues/1290) — Windows daemon can register + heartbeat + receive create_node doorbells but silently refuses to fork any node because `loadAndVerifyAnetBin`'s gate ① used `pin.abs.startsWith('/')` — Windows paths are `C:\...`, never start with `/`.

Same class as #1137 — POSIX-only assumption in code that must also run on Windows. This lands right on top of #1137's Windows momentum. Pinned to `origin/main = 99b09b34`.

**Content search performed:** `gh pr list --repo sleep2agi/agent-network --state all --search "loadAndVerifyAnetBin"` / `--search "anet_bin_shape"` / `--search "1290"` → #1289/#1291/#1297/#1299/#1352/#1377 all touched surrounding scaffolding (documentation, error taxonomy, install automation), zero touched the actual platform-branch fix this PR carries.

## Fix

**① `path.isAbsolute(pin.abs)` replaces `startsWith('/')`.** Standard cross-platform check. Windows accepts `C:\...`, `D:\...`, `//server/share`; POSIX unchanged.

**② `realpathEquivalent(real, pin.abs, platform)` — new helper.** POSIX: byte-exact (unchanged). Windows: `win32.normalize(...).toLowerCase()` on both sides so a junction-resolved or case-normalized `realpathSync` result doesn't fail gate ② on an otherwise-correct absolute path. Preserves the "no symlink component" invariant without a false-positive on `C:\Users` vs `C:\users`.

**③④⑤ skipped on Windows with a once-per-process warn.** Node's `statSync().mode` on Windows is *synthesized* from Windows file attributes (ReadOnly bit + extension-guess for execute), not the actual filesystem ACL. `mode & 0o022` either throws on files that ARE secure by ACL (a `.cjs` at `0o666` that ACLs restrict to Administrators + the current user) or accepts files that AREN'T (an unprivileged user's script gets the same `0o666`). Neither direction expresses a real security property on Windows.

  The one-time warn (`[anet-daemon] #1290 — Windows POSIX-mode supply-chain checks (group/other writability, executability) SKIPPED. Node's synthetic st.mode does not reflect Windows filesystem ACLs; enforce with icacls that ANET_BIN_ABS is owned + writable only by trusted principals.`) makes the fact that Windows daemons run without POSIX-mode enforcement **visible**, not silent. An ACL-based Windows equivalent (`icacls` / SDDL using the same `restrictWindowsAcl` pattern that shipped in #1137's `agent-network/src/private-state.ts`) is filed as a follow-up.

## Testability

`loadAndVerifyAnetBin` gains an optional `platform?: NodeJS.Platform` parameter with default `process.platform`. Tests can exercise the win32 branch on any host without monkey-patching `process.platform`. `_resetWindowsPosixModeWarnLatchForTest` exposes the warn latch so a test can observe the first-call warn firing.

## Tests — 5 new cases

Under `describe('#1290 loadAndVerifyAnetBin — cross-platform path/mode checks')`:

1. **🔴 witnessed-red** for the reported symptom — `path.win32.isAbsolute` accepts Windows drive-letter paths, `startsWith('/')` would have rejected them. Asserts the criterion the Windows daemon exercises at runtime. (Note: the platform-aware `path.isAbsolute` on the CI Linux runner still returns false for `C:\...` which is correct for that host — the assertion is on `path.win32.isAbsolute` directly.)
2. **Windows-platform param**: a `0o666` file passes (gates ③④⑤ skipped), and the one-time warn fires with `'#1290'` + `'SKIPPED'` text.
3. **Windows-skip warn is once per process** — two consecutive calls, exactly one warning (latch does what it says).
4. **POSIX platform (explicit `'linux'`)**: a `0o666` file STILL throws `'writable by group/other'`. Windows-skip logic must not leak. Explicit `'linux'` param so a future refactor that accidentally defaults to `'win32'` fails here loudly.
5. **realpath equivalence**: POSIX byte-exact still enforced via a canonical fixture.

## Witnessed-red proof — body-only revert (signature + helpers + latch export kept)

```
Fixed body:     48 pass / 0 fail / 109 expect() calls
Reverted body:  46 pass / 2 fail / 104 expect()
```

The 2 failures are exactly the Windows-skip tests (mode `0o666` rejected by gate ④ + mode `0o644` rejected by gate ⑤ after the Windows branch removal). Every existing test in the file (43) still passes in both versions — regression floor intact, the change is precisely the Windows-branch semantics.

## Deploy risk

**POSIX behavior unchanged.** The Linux/macOS path exercises `isAbsolute` (which routes to POSIX rules on those hosts) and `realpathEquivalent` (byte-exact on POSIX). Gates ③④⑤ still throw on the same conditions they used to. No consumer-side change.

**Windows behavior changes from "always fails" to "works with a visible security-check acknowledgement."** Users who were unable to run daemon at all get a working daemon; the printed warn line makes clear that supply-chain protection depends on Windows ACLs which this PR does not yet enforce.

## Not in this PR (explicit follow-ups)

- **Structured error back to hub** on create_node failure (issue's short-term rec §1). Current behavior only writes to the daemon log; hub sees `ok:true` and no downstream signal. Separate scope — touches hub protocol + ack path.
- **Windows ACL-based owner/mode check** via icacls (issue's medium-term rec §2). Uses the `restrictWindowsAcl` pattern from #1137's `private-state.ts`. Separate PR to keep scope focused.
- **Dashboard's server list marking daemons that can't fork.** Hub-side UI concern, not agent-node.
