### PR TITLE
fix(daemon): #1490 Windows daemon child agent-node no longer crashes on HOME=undefined

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -626,8 +626,8 @@ describe("#1490 minimalEnv — cross-platform HOME resolution", () => {
     // Explicit 'linux' param so a future refactor that accidentally
     // defaults to 'win32' fails here loudly — same defensive pattern
     // as #1290's POSIX-mode gate test.
-    const env = minimalEnv({}, "linux", { HOME: "/home/carol" });
-    expect(env.HOME).toBe("/home/carol");
+    const env = minimalEnv({}, "linux", { HOME: "/home/user" });
+    expect(env.HOME).toBe("/home/user");
     expect(env.USERPROFILE).toBeUndefined();
     expect(env.HOMEDRIVE).toBeUndefined();
     expect(env.HOMEPATH).toBeUndefined();
@@ -657,10 +657,10 @@ describe("#1490 minimalEnv — cross-platform HOME resolution", () => {
     const env = minimalEnv(
       { USERPROFILE: "/some/path" },
       "linux",
-      { HOME: "/home/carol" },
+      { HOME: "/home/user" },
     );
     expect(env.USERPROFILE).toBe("/some/path");
-    expect(env.HOME).toBe("/home/carol");
+    expect(env.HOME).toBe("/home/user");
   });
 
   test("resolveChildHome: Windows cascade priority USERPROFILE > HOME > HOMEDRIVE+HOMEPATH", () => {

--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -6,6 +6,7 @@ import {
   loadAndVerifyAnetBin,
   ensureGlobalAnetConfig,
   reconcilePendingCreateRequestsOnConnect,
+  resolveChildHome,
   _resetWindowsPosixModeWarnLatchForTest,
 } from "./create-node-daemon.js";
 import { win32 as pathWin32 } from "node:path";
@@ -582,6 +583,111 @@ describe("minimalEnv defensive compose (BLOCKER #1+#2 lineage — kept stable)",
       expect(m[0]).toContain("process.execPath");
       expect(m[0]).not.toMatch(/process\.env\.PATH/);   // explicit anti-C1 invariant
     }
+  });
+});
+
+// #1490 — Windows daemon spawned children got HOME=undefined because
+// Windows doesn't populate env.HOME (USERPROFILE / HOMEDRIVE+HOMEPATH
+// instead). Same class as #1290: POSIX-only assumption in code that
+// must also run on Windows. Follow #1290's platform-param injection so
+// the Windows branch runs on the Linux CI runner too.
+describe("#1490 minimalEnv — cross-platform HOME resolution", () => {
+  // 🔴 witnessed-red: Windows env cascade must find USERPROFILE.
+  // Under the old `process.env.HOME!` it would have returned undefined
+  // for a Windows parent env that has no HOME key.
+  test("🔴 witnessed-red: Windows parent env with USERPROFILE only → child HOME = USERPROFILE", () => {
+    const parentEnv = { USERPROFILE: "C:\\Users\\alice" };
+    const env = minimalEnv({}, "win32", parentEnv);
+    expect(env.HOME).toBe("C:\\Users\\alice");
+    expect(env.USERPROFILE).toBe("C:\\Users\\alice");
+    // HOMEDRIVE / HOMEPATH derived from the drive-letter split so
+    // .bat wrappers and legacy Windows APIs still resolve %HOMEPATH%.
+    expect(env.HOMEDRIVE).toBe("C:");
+    expect(env.HOMEPATH).toBe("\\Users\\alice");
+  });
+
+  test("Windows: HOMEDRIVE+HOMEPATH-only parent env resolves via that cascade branch", () => {
+    const parentEnv = { HOMEDRIVE: "D:", HOMEPATH: "\\Users\\bob" };
+    const env = minimalEnv({}, "win32", parentEnv);
+    expect(env.HOME).toBe("D:\\Users\\bob");
+    expect(env.USERPROFILE).toBe("D:\\Users\\bob");
+    expect(env.HOMEDRIVE).toBe("D:");
+    expect(env.HOMEPATH).toBe("\\Users\\bob");
+  });
+
+  test("Windows: stripped env (no USERPROFILE / HOME / HOMEDRIVE) THROWS with a diagnostic message", () => {
+    // Fail-closed. A silently-empty HOME just moves the crash from
+    // minimalEnv() to the child's first path operation; catching it
+    // here makes the misconfiguration attributable.
+    expect(() => minimalEnv({}, "win32", {})).toThrow(/cannot resolve Windows child HOME/);
+  });
+
+  test("POSIX (explicit 'linux'): env.HOME resolution unchanged, no Windows-only keys leak", () => {
+    // Explicit 'linux' param so a future refactor that accidentally
+    // defaults to 'win32' fails here loudly — same defensive pattern
+    // as #1290's POSIX-mode gate test.
+    const env = minimalEnv({}, "linux", { HOME: "/home/carol" });
+    expect(env.HOME).toBe("/home/carol");
+    expect(env.USERPROFILE).toBeUndefined();
+    expect(env.HOMEDRIVE).toBeUndefined();
+    expect(env.HOMEPATH).toBeUndefined();
+  });
+
+  test("POSIX (explicit 'linux'): missing env.HOME THROWS (fail-closed, not undefined-passthrough)", () => {
+    expect(() => minimalEnv({}, "linux", {})).toThrow(/cannot resolve POSIX child HOME/);
+  });
+
+  test("Windows: USERPROFILE is a fixed key on that platform — smuggling it in extra THROWS", () => {
+    // Same guarantee as PATH on POSIX: a caller cannot override the
+    // trust-root home path via extra. On POSIX USERPROFILE is not fixed
+    // (POSIX doesn't use it) so the check must be platform-branched.
+    expect(() =>
+      minimalEnv(
+        { USERPROFILE: "C:\\Users\\attacker" },
+        "win32",
+        { USERPROFILE: "C:\\Users\\alice" },
+      ),
+    ).toThrow(/fixed env key/);
+  });
+
+  test("POSIX (explicit 'linux'): USERPROFILE is NOT fixed there — passes through as ordinary extra", () => {
+    // Symmetric to the previous test: platform-branched fixed set.
+    // A POSIX child that happens to want USERPROFILE forwarded (unusual,
+    // but not a supply-chain risk on POSIX) can receive it.
+    const env = minimalEnv(
+      { USERPROFILE: "/some/path" },
+      "linux",
+      { HOME: "/home/carol" },
+    );
+    expect(env.USERPROFILE).toBe("/some/path");
+    expect(env.HOME).toBe("/home/carol");
+  });
+
+  test("resolveChildHome: Windows cascade priority USERPROFILE > HOME > HOMEDRIVE+HOMEPATH", () => {
+    // Direct unit test on the helper. USERPROFILE wins because that's
+    // what os.homedir() and every modern Windows tool reads first.
+    expect(
+      resolveChildHome(
+        {
+          USERPROFILE: "C:\\Users\\up",
+          HOME: "C:\\Users\\h",
+          HOMEDRIVE: "D:",
+          HOMEPATH: "\\Users\\hd",
+        },
+        "win32",
+      ),
+    ).toBe("C:\\Users\\up");
+    // Missing USERPROFILE: HOME wins.
+    expect(
+      resolveChildHome(
+        { HOME: "C:\\Users\\h", HOMEDRIVE: "D:", HOMEPATH: "\\Users\\hd" },
+        "win32",
+      ),
+    ).toBe("C:\\Users\\h");
+    // Missing USERPROFILE + HOME: HOMEDRIVE+HOMEPATH is the last resort.
+    expect(
+      resolveChildHome({ HOMEDRIVE: "D:", HOMEPATH: "\\Users\\hd" }, "win32"),
+    ).toBe("D:\\Users\\hd");
   });
 });
 

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -277,7 +277,61 @@ export function _resetAnetBinAbsForTest(): void { _anetBinAbs = null; }
 // ── §4.2.6 B1 — minimalEnv (filter + fixed-keys-last + throw-on-collision) ──
 
 const SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-const FIXED_ENV_KEYS = new Set(["PATH", "HOME", "LANG"]);
+// #1490 — fixed env keys split by platform. Windows children need
+// USERPROFILE / HOMEDRIVE / HOMEPATH populated to resolve the home
+// directory; POSIX children only need HOME. Both platforms get PATH +
+// HOME + LANG. Extra keys passed to minimalEnv must NOT collide with any
+// key we own — smuggling USERPROFILE on Windows would let an untrusted
+// caller point the child at a different home, so it's fixed there too.
+const FIXED_ENV_KEYS_POSIX = new Set(["PATH", "HOME", "LANG"]);
+const FIXED_ENV_KEYS_WIN32 = new Set(["PATH", "HOME", "LANG", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"]);
+function fixedEnvKeysFor(platform: NodeJS.Platform): ReadonlySet<string> {
+  return platform === "win32" ? FIXED_ENV_KEYS_WIN32 : FIXED_ENV_KEYS_POSIX;
+}
+// Back-compat export for anything still reading the old constant (kept
+// as the union of both sets — matches "what keys minimalEnv WILL fix"
+// across all supported platforms, which is what a caller sanity-checking
+// the denylist actually wants).
+const FIXED_ENV_KEYS = new Set([...FIXED_ENV_KEYS_POSIX, ...FIXED_ENV_KEYS_WIN32]);
+
+/** #1490 — resolve the correct home directory for a spawned child, per
+ *  platform. Windows populates USERPROFILE / HOMEDRIVE+HOMEPATH, NOT
+ *  HOME — the existing `process.env.HOME!` was undefined-passed-through
+ *  and crashed the child on the first path operation. Precedent + comment
+ *  in agent-node/src/runtime/grok-child-env.ts:53-58.
+ *
+ *  Throws when no home can be resolved (rare — stripped env / non-root
+ *  container / etc). Fail-closed is correct here: silently forking a
+ *  child with an unresolved home leads to the same undefined-path crash
+ *  we're trying to eliminate, just later.
+ *
+ *  Takes env as a parameter (not process.env directly) so the Windows
+ *  branch can be exercised on a Linux CI runner via unit test injection —
+ *  same testability pattern used by #1290's platform-param plumb-through.
+ */
+export function resolveChildHome(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  if (platform === "win32") {
+    const home = env.USERPROFILE
+      || env.HOME
+      || (env.HOMEDRIVE && env.HOMEPATH ? env.HOMEDRIVE + env.HOMEPATH : "");
+    if (!home) {
+      throw new Error(
+        "minimalEnv: cannot resolve Windows child HOME " +
+        "(USERPROFILE, HOME, and HOMEDRIVE+HOMEPATH all missing). " +
+        "Configure at least USERPROFILE for the daemon service account.",
+      );
+    }
+    return home;
+  }
+  const home = env.HOME;
+  if (!home) {
+    throw new Error(
+      "minimalEnv: cannot resolve POSIX child HOME (env.HOME missing). " +
+      "Ensure the daemon service unit sets HOME.",
+    );
+  }
+  return home;
+}
 
 /** #301 nvm fix (issue: spawned child shebang `#!/usr/bin/env node`
  *  finds no node when daemon runs under nvm / pnpm / Bun / custom
@@ -301,23 +355,51 @@ function computeChildPath(): string {
   return `${execDir}:${SAFE_PATH}`;
 }
 
-export function minimalEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+export function minimalEnv(
+  extra: Record<string, string> = {},
+  platform: NodeJS.Platform = process.platform,
+  parentEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   const filtered: Record<string, string> = {};
+  const fixedKeys = fixedEnvKeysFor(platform);
   for (const [k, v] of Object.entries(extra)) {
     if (isReservedEnvKey(k)) {
       throw new Error(`minimalEnv: reserved env key ${k} reached fork (denylist gap — investigate)`);
     }
-    if (FIXED_ENV_KEYS.has(k)) {
+    if (fixedKeys.has(k)) {
       throw new Error(`minimalEnv: fixed env key ${k} reached fork`);
     }
     filtered[k] = v;
   }
-  return {
+  const home = resolveChildHome(parentEnv, platform);
+  const base: NodeJS.ProcessEnv = {
     ...filtered,
     PATH: computeChildPath(),
-    HOME: process.env.HOME!,
-    LANG: process.env.LANG || "C.UTF-8",
+    HOME: home,
+    LANG: parentEnv.LANG || "C.UTF-8",
   };
+  if (platform === "win32") {
+    // #1490 — Windows-only. Node's os.homedir() and most tools read
+    // USERPROFILE first; grok / claude / codex CLIs invoked as
+    // grandchildren also need HOMEDRIVE+HOMEPATH to resolve %HOMEPATH%
+    // in .bat wrappers and legacy Windows APIs.
+    base.USERPROFILE = home;
+    if (/^[A-Za-z]:/.test(home)) {
+      // Standard drive-letter path — split at the 2nd char.
+      // C:\Users\alice → HOMEDRIVE=C: HOMEPATH=\Users\alice
+      base.HOMEDRIVE = home.slice(0, 2);
+      base.HOMEPATH = home.slice(2);
+    } else if (parentEnv.HOMEDRIVE && parentEnv.HOMEPATH) {
+      // Non-drive-letter home (UNC path, weird service context) — fall
+      // back to whatever the daemon inherited, on the assumption that
+      // if the daemon is running with those values the child needs the
+      // same. If neither branch fires the child just doesn't get
+      // HOMEDRIVE/HOMEPATH — tools that need them will fail loudly.
+      base.HOMEDRIVE = parentEnv.HOMEDRIVE;
+      base.HOMEPATH = parentEnv.HOMEPATH;
+    }
+  }
+  return base;
 }
 
 // ── §4.2.2 daemon-side spec validators (mirror of create-node-validate) ──
@@ -572,7 +654,10 @@ export async function handleCreateNodeDoorbell(
 
   // P1: ensure global ~/.anet/config.json has hub so `anet node start`
   // can resolve the hub even when called from minimalEnv. Idempotent.
-  try { ensureGlobalAnetConfig(process.env.HOME!, deps.hubUrl); }
+  // #1490 — was `process.env.HOME!` which passed undefined on Windows and
+  // crashed the write with `undefined/.anet/config.json`. resolveChildHome
+  // reads Windows env cascade (USERPROFILE / HOMEDRIVE+HOMEPATH / HOME).
+  try { ensureGlobalAnetConfig(resolveChildHome(process.env, process.platform), deps.hubUrl); }
   catch (e: any) { deps.warn(`[create-node] global config write failed (continuing): ${e?.message || e}`); }
 
   // Step 1 — write child config.json directly.


### PR DESCRIPTION
Fixes [#1490](https://github.com/sleep2agi/agent-network/issues/1490) — after [#1489](https://github.com/sleep2agi/agent-network/pull/1489) unblocked `loadAndVerifyAnetBin` on Windows, the daemon successfully forks children but they immediately crash trying to write `undefined/.anet/config.json`. `process.env.HOME!` bypasses the null check and passes `undefined` through at runtime because Windows uses `USERPROFILE` / `HOMEDRIVE`+`HOMEPATH`, not `HOME`.

Same class as #1290 — POSIX-only assumption in code that must also run on Windows. Pinned to `origin/main = 71469b2a` (includes #1489).

**Content search performed:** `gh pr list --search "1490"` / `--search "resolveChildHome"` / `--search "minimalEnv HOME"` → only #297/#299 (original RFC-026 create-node origin scaffolding from June) match; zero PRs open or merged touching this fix.

## Precedent already in-repo

`agent-node/src/runtime/grok-child-env.ts:53-58` explicitly documents this exact Windows env-var quirk and populates all four vars for grok-spawned children:

```ts
export const GROK_CHILD_CONTROLLED_ENV_KEYS = [
  \"HOME\",
  // 🔴 Windows 用 USERPROFILE / HOMEDRIVE+HOMEPATH 解析家目录，**不看 HOME**。
  \"USERPROFILE\",
  \"HOMEDRIVE\",
  \"HOMEPATH\",
  ...
```

`minimalEnv` should follow the same pattern. This PR does.

## Fix

**① New `resolveChildHome(env, platform)` helper.** Windows cascade: `USERPROFILE > HOME > HOMEDRIVE+HOMEPATH`. POSIX: `env.HOME` only. **Throws** with a diagnostic on unresolvable — fail-closed, since silently passing `undefined` just moves the crash to the child's first path operation where it's harder to attribute.

**② `FIXED_ENV_KEYS` split by platform.** POSIX still fixes `PATH`/`HOME`/`LANG`; Windows additionally fixes `USERPROFILE`/`HOMEDRIVE`/`HOMEPATH` so a caller cannot smuggle them via `extra` and repoint the child at a different home. Same trust-root guarantee we already give `PATH`.

**③ `minimalEnv` gains optional `platform` + `parentEnv` params.** Default to `process.platform` / `process.env`, so the Windows branch is testable on a Linux CI runner (same platform-parameter injection pattern as #1290's `loadAndVerifyAnetBin`).

**④ Populate USERPROFILE + HOMEDRIVE + HOMEPATH on Windows children.** Drive-letter homes split cleanly (`C:\Users\alice` → `HOMEDRIVE=C:`, `HOMEPATH=\Users\alice`); UNC / non-drive homes fall through to whatever the daemon inherited. Grok/Claude/Codex CLIs invoked as grandchildren need those to resolve `%HOMEPATH%` in .bat wrappers and legacy Windows APIs.

**⑤ Second site fixed too.** `ensureGlobalAnetConfig(process.env.HOME!, ...)` at L575 had the same undefined-passthrough bug — swapped to `resolveChildHome(process.env, process.platform)`.

## Tests — 8 new cases

Under `describe('#1490 minimalEnv — cross-platform HOME resolution')`:

1. **🔴 witnessed-red** Windows USERPROFILE-only parent → HOME + USERPROFILE + HOMEDRIVE(`C:`) + HOMEPATH(`\Users\alice`).
2. Windows HOMEDRIVE+HOMEPATH-only → cascade branch resolves.
3. Windows stripped env → throws `/cannot resolve Windows child HOME/`.
4. POSIX (explicit `'linux'`): HOME resolution unchanged, Windows keys do not leak.
5. POSIX (explicit `'linux'`): missing HOME → throws `/cannot resolve POSIX child HOME/`. Explicit `'linux'` so a future refactor that accidentally defaults to `'win32'` fails loudly here.
6. Windows: USERPROFILE is fixed there — smuggling via `extra` throws.
7. POSIX: USERPROFILE NOT fixed — passes through as ordinary extra. Symmetric to (6), proves the platform branch on the fixed-key set.
8. `resolveChildHome` unit: Windows cascade priority `USERPROFILE > HOME > HOMEDRIVE+HOMEPATH`.

## Witnessed-red proof — body-only revert (signature + helpers + fixed-key partitioning preserved)

\`\`\`
Fixed body:     56 pass / 0 fail / 129 expect() calls
Reverted body:  52 pass / 4 fail / 123 expect() calls
\`\`\`

The 4 failures are exactly the Windows cascades + fail-closed throws. Every existing test in the file (48) still passes in both versions — regression floor intact, the change is precisely the Windows-HOME-resolution semantics.

Kept as scaffolding across the revert (not the bug):
- The exported `resolveChildHome` helper
- `FIXED_ENV_KEYS_WIN32` / `FIXED_ENV_KEYS_POSIX` split (test 6 asserts USERPROFILE-in-extra throws on Windows — proves this partitioning is wired, not just declared)
- `platform` / `parentEnv` params on `minimalEnv`

Reverting these too would give a broader red than the fix scope actually justifies.

## Deploy risk

**POSIX behavior unchanged.** The Linux/macOS default-platform path reads `env.HOME` just as before. Fail-closed on missing `HOME` is a behavior change on paper but in practice the previous code passed `undefined` down to the child which crashed anyway — this just attributes the failure at the daemon layer.

**Windows behavior changes from \"always crashes at child startup\" to \"works with correct HOME + USERPROFILE + HOMEDRIVE + HOMEPATH.\"**

## Not in this PR (explicit follow-ups)

- **#1491** — `/etc/anet-daemon/path.conf` platform-aware default (POSIX-only default is silently wrong on Windows but has env fallback so not a crash). Same-class UX cleanup, separate scope.

## Related

- #1490 (this issue) — Windows HOME=undefined crash
- #1290 (PR #1489) — Windows anet_bin POSIX-only path check — unblocks reaching this code path
- #1137 — Windows launchers + chmod fixes
- `agent-node/src/runtime/grok-child-env.ts:53-58` — established pattern this PR follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)