### PR TITLE
chore(release): bump 消息批次 —— server 0.9.0-preview.41 / agent-node 2.5.0-preview.51 / agent-network 2.3.0-preview.66

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1748,7 +1748,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.40";
+const PINNED_SERVER_VERSION = "0.9.0-preview.41";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.65",
+  "version": "2.3.0-preview.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.65",
+      "version": "2.3.0-preview.66",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.65",
+  "version": "2.3.0-preview.66",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.65";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.50";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.66";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.51";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.50",
+  "version": "2.5.0-preview.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.50",
+      "version": "2.5.0-preview.51",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.50",
+  "version": "2.5.0-preview.51",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -66,10 +66,14 @@ set -uo pipefail
 #   内容 = #1448 f1 门铃补偿(#1450) + #1451 opencode 回复解析(#1452) + #1286 对称收敛(#1453)
 #          + start_node stale-starting reaper(#1456) + send_desktop_message 诚实投递态(#1460)
 #   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
+# 2026-08-30: preview40 → preview41（跟随 PINNED_SERVER_VERSION；消息批次）
+#   内容 = #1459 ① 全套：user_inbox 建表(#1481) + 写入落库(#1485)
+#          + ?scope=user 回读/ack/unread/回读脱敏(#1488) + 写读接缝回归(#1492)
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 #   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
 #      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
 #      在这里标出来，免得下一个人把这份历史当完整的读。
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview40"
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview41"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.66 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.65` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.66` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.65 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.66 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.65`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.66`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.41.md
+++ b/docs/tests/release-v0.9.0-preview.41.md
@@ -1,0 +1,55 @@
+# @sleep2agi/commhub-server 0.9.0-preview.41 — release notes
+
+这一版把 **agent → 用户 desktop message 的读写两侧一次配齐**。上一版（`.40`）只做到「让丢失可见」——
+`send_desktop_message` 不再谎报成功，但消息在用户 dashboard 关着时**仍然会丢**。本版让它不再丢。
+
+- **`user_inbox` 建表打底**（PR #1481，#1459 ① P1，schema-only）。按 `user_id` 寻址的新收件表，
+  不复用按 alias 寻址的 `inbox` —— 复用会让 `/api/messages` / `inbox_count` / SSE gate 那一票
+  alias 域查询隐性开始返回用户消息。`message_id` 即主键，send 重投天然幂等。
+- **写入落库**（PR #1485，#1459 ① P2）。`audit_log` 与 `user_inbox` 放进**同一个事务**，
+  push 在提交之后 —— 此前只写审计不写收件，会出现「审计说发过、用户永远收不到」。
+  返回值里 `persisted` 反映真实落库结果。
+- **回读 + ack + 未读数 + 回读脱敏**（PR #1488，#1459 ① P3）。新增
+  `GET /api/messages?scope=user[&unacked=1][&limit=N]` 与 `POST /api/messages/ack`：
+  - 收件人**取自鉴权上下文**，`?user_id=` 传什么都不生效；复用既有 `addNetworkScope` 网络隔离；
+  - 响应带 `unread` / `pending_count`（同一次计算），**客户端"不显示新消息数"从此有服务端数据源**；
+  - **回读时脱敏**：写入方是 agent、不受信任，回读会遮住
+    `ntok_` / `utok_` / `atok_` / `ghp_` / `github_pat_` / `xox[bpoars]-` / `sk-` 形状的串；
+  - 新增 `idx_user_inbox_user_acked(user_id, acked, created_at)`。
+- **写读接缝的端到端回归**（PR #1492）。此前写侧测试不碰回读、读侧测试用 SQL 播种行，
+  两半各自绿而端到端从没验过。现在有一条测试走完整条：真实 `send_desktop_message` →
+  真实 `GET /api/messages?scope=user`。
+
+🔴 **关于隔离**：同一个 network 里的两个成员之间，`WHERE user_id = ?` 是**唯一**的隔离手段
+（网络 scope 对他们是同一个值）。这一格有专门的夹具和变异证据，见 #1488。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.66 @sleep2agi/agent-node@2.5.0-preview.51
+anet hub start
+```
+
+hub 自己由 `anet` 按 `PINNED_SERVER_VERSION` 拉起（本版 `0.9.0-preview.41`），
+通常不需要单独装 `@sleep2agi/commhub-server@0.9.0-preview.41`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.66
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1481 | #1459 ① P1 | `user_inbox` 建表（schema-only，零行为变化） |
+| #1485 | #1459 ① P2 | 写入落库，audit + inbox 同事务、push 在提交后 |
+| #1488 | #1459 ① P3 | `?scope=user` 回读 + ack + `unread` + 回读脱敏 + 索引 |
+| #1492 | #1459 | 写→读接缝端到端回归；NULL 孤儿行可达性分析（写路径产不出，三道闸） |
+
+**下游可以接了**：客户端拿 `unread` 显示未读数、拿 `?scope=user` 在重连后补齐离线期间的消息。

--- a/docs/tests/release-v2.3.0-preview.66.md
+++ b/docs/tests/release-v2.3.0-preview.66.md
@@ -15,8 +15,10 @@
 
   同一版还修了 Windows 上每一次 `chmod` 的失败路径。
 
-🔴 Windows 用户请连同 `@sleep2agi/agent-node@2.5.0-preview.51` 一起升 —— 那一版修的
-`anet_bin` 路径校验（#1290）是同一类 POSIX-only 假设，只修一个包在 Windows 上仍起不了节点。
+🔴 Windows 用户请连同 `@sleep2agi/agent-node@2.5.0-preview.51` 一起升。那一版有**两条**同类修复
+（`anet_bin` 路径校验 #1290、子进程 `HOME` 解析 #1490），都是「只在 POSIX 成立的假设跑在 Windows 上」。
+三条串联：本包让 `anet` 能调起外部启动器 → `.51` 让 daemon 能过路径检查 fork 出节点 →
+再让 fork 出的节点不立刻崩。**只升其中一个包，Windows 上仍然起不了节点。**
 
 ## Install
 

--- a/docs/tests/release-v2.3.0-preview.66.md
+++ b/docs/tests/release-v2.3.0-preview.66.md
@@ -1,0 +1,45 @@
+# @sleep2agi/agent-network 2.3.0-preview.66 — release notes
+
+一条修复，只影响 Windows —— 但在 Windows 上它影响的是**全部功能**。
+
+- **Windows 上 `anet` 什么都干不了**（PR #1137，修 #1137）。在真机上诊断的
+  （Windows 11 26200 / Node 24.18 / npm 11.16），不是从平台推理出来的。
+
+  根因：`bunx` / `bun` / `npx` / `npm` 在 Windows 上都是 `.cmd`，而 `.cmd` **不是可执行映像**，
+  只有命令解释器能跑它。`spawnSync`/`execFileSync` 直接调它们一律 `ENOENT`；
+  显式写 `npm.cmd` 则撞上 Node ≥18.20/20.12 的 CVE-2024-27980 防护，得到 `EINVAL`。
+  agent-network 里有八处这样的调用点，而整个文件里 `shell: true` **出现零次** ——
+  于是组件探测、`anet hub start`、dashboard、自升级、每一次版本检查**同时失效**。
+  `anet -v` 报「agent-node — not installed yet」而 npm 明明列着已安装，就是这个原因，
+  不是打包问题。
+
+  同一版还修了 Windows 上每一次 `chmod` 的失败路径。
+
+🔴 Windows 用户请连同 `@sleep2agi/agent-node@2.5.0-preview.51` 一起升 —— 那一版修的
+`anet_bin` 路径校验（#1290）是同一类 POSIX-only 假设，只修一个包在 Windows 上仍起不了节点。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.66 @sleep2agi/agent-node@2.5.0-preview.51
+anet hub start
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.66
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+本版把 `PINNED_SERVER_VERSION` 升到 `0.9.0-preview.41`，`anet hub restart` 会拉起新版 hub
+（desktop message 持久化 + 未读数，见 commhub-server `0.9.0-preview.41` 的 release notes）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1137 | #1137 | Windows：外部启动器改走命令解释器、`chmod` 路径修复 |
+| — | — | pin 链同步：`PINNED_SERVER_VERSION` → `0.9.0-preview.41`、`PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.51` |

--- a/docs/tests/release-v2.5.0-preview.51.md
+++ b/docs/tests/release-v2.5.0-preview.51.md
@@ -1,0 +1,47 @@
+# @sleep2agi/agent-node 2.5.0-preview.51 — release notes
+
+两条 daemon 修复，都是「daemon 看起来健康、实际什么都没做」的形状。
+
+- **stop/delete 发信号发的是解析出的真 pgid，不再假设 `pgid == pid`**（PR #1480，修 #1474 finding-2）。
+  `sendGroupSignal` 做的是 `kill(-recorded.pid)`。live 路径上这确实成立（spawn wrapper 时
+  `detached` → setsid → wrapper 是 session leader）。但 **boot rebuild 走 `pgrep` 找到的是孙子进程**，
+  孙子继承 wrapper 的 pgid、`孙子.pid ≠ pgid` —— daemon 重启后 `entry.pid` 记的就是孙子。
+  于是 `kill(-孙子pid)` 命中一个**不存在的进程组** → `ESRCH` → 被当成"组已经没了"静默返回 →
+  wrapper 和孙子**都没收到信号**。表现是 stop/delete 报成功而进程还在跑。
+- **Windows 上 `anet_bin` 路径校验不再只认 POSIX**（PR #1489，修 #1290）。
+  `loadAndVerifyAnetBin` 的第一道闸用 `pin.abs.startsWith('/')` 判断绝对路径 ——
+  Windows 的绝对路径是 `C:\...`，永远不以 `/` 开头，于是**每一个 Windows daemon 的 `create_node`
+  都抛 `anet_bin_unsafe_path: not absolute: C:\...`**。而 daemon 本身看着是健康的
+  （SSE 正常、门铃收到、hub 那边 `ok:true`），只是**一个节点都没 fork 出来**。
+  现在用 `path.isAbsolute()`；Windows 上另加大小写无关的 realpath 等价判断
+  （junction / 大小写归一化过的 realpath 不该在第二道闸被拒）；POSIX 专属的三道模式闸
+  在 Windows 上跳过并每进程警告一次。
+
+🔴 这两条和 #1137（agent-network `2.3.0-preview.66`）是**同一类**：代码里写着只在 POSIX 成立的假设，
+而它也要在 Windows 上跑。Windows 用户请两个包一起升。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.66 @sleep2agi/agent-node@2.5.0-preview.51
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.51
+cd ~/anodes && anet project restart
+```
+
+跑着的节点要重启才会拿到新 agent-node（#117）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1480 | #1474 finding-2 | stop/delete 发解析出的真 pgid，不假设 `pgid == pid` |
+| #1489 | #1290 | Windows 上 `anet_bin` 绝对路径校验（`path.isAbsolute` + 大小写无关 realpath 等价） |
+
+**注意 issue 编号容易串**：#1474 finding-1（删节点后密钥残留，PR #1478）已在 `2.5.0-preview.50`；
+本版是 finding-2。而 #1469 finding-2 是另一码事（network_id），在 agent-network `2.3.0-preview.65` 里。

--- a/docs/tests/release-v2.5.0-preview.51.md
+++ b/docs/tests/release-v2.5.0-preview.51.md
@@ -1,6 +1,6 @@
 # @sleep2agi/agent-node 2.5.0-preview.51 — release notes
 
-两条 daemon 修复，都是「daemon 看起来健康、实际什么都没做」的形状。
+三条 daemon 修复。两条是「daemon 看起来健康、实际什么都没做」的形状，第三条是它们被修好之后**才露出来**的下一个坑。
 
 - **stop/delete 发信号发的是解析出的真 pgid，不再假设 `pgid == pid`**（PR #1480，修 #1474 finding-2）。
   `sendGroupSignal` 做的是 `kill(-recorded.pid)`。live 路径上这确实成立（spawn wrapper 时
@@ -16,8 +16,21 @@
   现在用 `path.isAbsolute()`；Windows 上另加大小写无关的 realpath 等价判断
   （junction / 大小写归一化过的 realpath 不该在第二道闸被拒）；POSIX 专属的三道模式闸
   在 Windows 上跳过并每进程警告一次。
+- **Windows 上被 fork 出来的子 agent-node 因 `HOME=undefined` 立刻崩**（PR #1494，修 #1490）。
+  这条是上一条修好之后才轮到的：#1489 放行了 `loadAndVerifyAnetBin`，Windows daemon 终于能
+  fork 出子进程 —— 然后子进程立刻在 `undefined/.anet/config.json` 上崩掉，因为
+  `process.env.HOME!` 的非空断言只骗过 TypeScript，运行时照样把 `undefined` 传下去。
+  Windows 用的是 `USERPROFILE` / `HOMEDRIVE`+`HOMEPATH`，没有 `HOME`。
+  现在有 `resolveChildHome(env, platform)`：Windows 依次取 `USERPROFILE` > `HOME` >
+  `HOMEDRIVE`+`HOMEPATH`，POSIX 仍只认 `HOME`；**解析不出来就抛**（fail-closed —— 静默的
+  `undefined` 只是把崩溃推迟到子进程第一次拼路径的地方，那时更难归因）。
+  Windows 上 `USERPROFILE`/`HOMEDRIVE`/`HOMEPATH` 一并进 `FIXED_ENV_KEYS`，
+  调用方不能再通过 `extra` 把子进程的 home 指到别处 —— 和 `PATH` 同一条信任根保证。
 
-🔴 这两条和 #1137（agent-network `2.3.0-preview.66`）是**同一类**：代码里写着只在 POSIX 成立的假设，
+🔴 **Windows 用户必须升到本版**：#1489 和 #1494 是串联的，只装了 #1489 的构建会
+「过了路径检查、但 fork 出来的节点立刻崩」—— 看起来比修之前更像坏了。两条在同一版里。
+
+🔴 这三条和 #1137（agent-network `2.3.0-preview.66`）是**同一类**：代码里写着只在 POSIX 成立的假设，
 而它也要在 Windows 上跑。Windows 用户请两个包一起升。
 
 ## Install
@@ -42,6 +55,7 @@ cd ~/anodes && anet project restart
 |---|---|---|
 | #1480 | #1474 finding-2 | stop/delete 发解析出的真 pgid，不假设 `pgid == pid` |
 | #1489 | #1290 | Windows 上 `anet_bin` 绝对路径校验（`path.isAbsolute` + 大小写无关 realpath 等价） |
+| #1494 | #1490 | Windows 子 agent-node 的 `HOME` 解析（`USERPROFILE`/`HOMEDRIVE`+`HOMEPATH`），解析不出即 fail-closed |
 
 **注意 issue 编号容易串**：#1474 finding-1（删节点后密钥残留，PR #1478）已在 `2.5.0-preview.50`；
 本版是 finding-2。而 #1469 finding-2 是另一码事（network_id），在 agent-network `2.3.0-preview.65` 里。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.40",
+  "version": "0.9.0-preview.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.40",
+      "version": "0.9.0-preview.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.40",
+  "version": "0.9.0-preview.41",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.40' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.41' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## 三包 bump

| 包 | 从 | 到 | 本版内容 |
|---|---|---|---|
| `@sleep2agi/commhub-server` | `0.9.0-preview.40` | **`.41`** | #1459 ① 全套：`user_inbox` 建表(#1481) + 写入落库(#1485) + `?scope=user` 回读/ack/`unread`/回读脱敏(#1488) + 写读接缝回归(#1492) |
| `@sleep2agi/agent-node` | `2.5.0-preview.50` | **`.51`** | #1474 finding-2 真 pgid(#1480) + #1290 Windows `anet_bin` 路径校验(#1489) |
| `@sleep2agi/agent-network` | `2.3.0-preview.65` | **`.66`** | #1137 Windows 上每个外部启动器和每次 `chmod` 都失败 |

**基线不是照转述**：三个 `from` 都用 `npm view <pkg> dist-tags.preview` 现取过，`.40/.50/.65` 与树里 `package.json` 逐个对上。
**本版内容也不是照转述**：用 `git log <上次 bump commit>..origin/main -- <pkg>/` 逐包数出来的。

🔴 **一处更正**：派工里 agent-node `.51` 写的是「finding-1 #1478 / finding-2 #1480 / #1290 #1489」，**#1478 是上一版 `.50` 的**（`.50` 的 release notes 自己写着「finding-2 走 preview.51 fast-follow」）。本版是 **#1480 + #1489** 两条。#1474 finding-1/finding-2 与 #1469 finding-2 编号相近但是三码事，release notes 里已经点名区分。

## pin 链

用 `scripts/sync-pinned-versions.sh <pkg> <ver> --apply` 改的，**没有手改**（三个包各跑一次，先 dry-run 看 diff 再 apply）：

- `package.json` ×3
- `package-lock.json` 顶层 `version` + `packages[""].version`，×3
- `agent-network/bin/cli.ts` → `PINNED_SERVER_VERSION = "0.9.0-preview.41"`
- `agent-network/src/opencode-agent-node-pair.ts` → `PAIRED_AGENT_NODE_VERSION` / `PAIRED_AGENT_NETWORK_VERSION`
- `tests/test766-bunx-preflight/run.sh` 里的字面量（脚本注释写明它必须跟着改，否则该套件红）

**脚本不碰的三处，手改**：

1. `deploy/hub/hub-daemon.sh` 的 `RUNTIME_DIR`：`runtime-v34-preview40` → `preview41`，并按该文件的惯例补了一行历史（内容 + 回滚目标）。
2. `docs-site/docs/{,en/}guide/getting-started.md` 的版本戳：机器读的 `<!-- version-claim: ... -->` **和**人读的那张表，两处都改，中英都改。
3. `docs/tests/release-v{0.9.0-preview.41,2.5.0-preview.51,2.3.0-preview.66}.md` 三份 release notes。

## 本地按 CI 口径跑过的门

| 门 | 结果 |
|---|---|
| `check-hub-launcher-pin.py` | rc=0 —— launcher `preview41` == `PINNED_SERVER_VERSION` `preview.41` |
| `check-doc-version-claims.py --selftest` | 19/19 |
| `check-doc-version-claims.py --package agent-network --version 2.3.0-preview.66 --verify-latest-from-npm` | rc=0（CI 的 gate-4 就是这条） |
| release.yml gate-3 的三条判据（`^## Install` / `^## Upgrade` / Install 块内含 `@<ver>`） | 三份 notes 逐个跑过，全过 |
| `package-version-consistency.test.ts` ×2 + `opencode-agent-node-pair.test.ts` | 10 pass / 0 fail |

**顺带核了一句最容易在发版那一刻变假的话**：getting-started 里「生成密码的 `server/src/auth.ts` 自 `.49` 发布起零提交」——
`git log --since=2026-08-27T02:25Z -- server/src/auth.ts` 数出来是 **0**，这句在 `.66` 上仍然成立，所以只改版本号、不改结论。

**顺带确认**：`dist-tags.latest` 目前确实是 `2.3.0-preview.47`，所以 getting-started 里那条 `channel=latest version=2.3.0-preview.47` 的戳没过期，本次不动它。

## 没做的事

- **没有 trigger `release.yml`、没有实发 npm、没有碰生产**。发布顺序（server → agent-node → agent-network）和 `-f publish=true` 由 @通信龙 编排。
- `docs-site` 的 vitepress build 本地没跑（这个 worktree 里没有 `docs-site/node_modules`）—— 交给 CI 的 `docs-site-build` 门。改动只有版本字符串，没有结构变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
