### PR TITLE
docs(api): 补 per-user 消息 API（#1488）—— rest.md 此前只有旧的 alias 分支

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1110,6 +1110,108 @@ SELECT 暂未包含 `in_reply_to` 字段；轮询匹配回复消息时按 `from_
 
 ---
 
+### GET /api/messages?scope=user
+
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · 自 `@sleep2agi/commhub-server` `0.9.0-preview.41` 起
+
+**按用户读的收件箱**，与上面那节按 alias 寻址的分支是两条路：上面那条给 Dashboard 读全网 inbox，这条给**某个人**读自己的私信（桌面端未读角标的数据源）。
+
+```bash
+curl "http://localhost:9200/api/messages?scope=user&unacked=1&limit=50" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+🔴 **收件人取自鉴权上下文，不接受 query 指定。** 传 `?user_id=<别人>` **不会生效** —— 否则任何人都能读走别人的私信。没有用户上下文时返回 **401** `{"ok":false,"error":"auth_required"}`。
+
+**查询参数**：
+
+| 参数 | 说明 |
+|------|------|
+| `scope=user` | **必须**，否则走上面那条按 alias 的分支 |
+| `unacked=1` | 只返回未 ack 的（**严格等于 `1`** 才生效） |
+| `limit` | 最大条数，默认 100，最大 500 |
+
+**响应**：
+
+```json
+{
+  "ok": true,
+  "messages": [
+    {
+      "message_id": "dm_abc123",
+      "network_id": "net_xxxxx",
+      "user_id": "u_xxxxx",
+      "from_session": "代码1号",
+      "kind": "dm",
+      "title": "构建失败",
+      "content": "……",
+      "severity": "info",
+      "meta_json": null,
+      "acked": 0,
+      "created_at": "2026-08-30 10:00:00",
+      "acked_at": null
+    }
+  ],
+  "unread": 3,
+  "pending_count": 3
+}
+```
+
+🔴 **`unread` 与 `pending_count` 恒等** —— 是**同一个数的两个名字**（`unread` 给角标读，`pending_count` 与上面 alias 分支的字段名保持一致），**一处计算**，不是两处实现。**不要拿它们互相比对**去判断状态。
+
+字段对照 server SELECT：`message_id, network_id, user_id, from_session, kind, title, content, severity, meta_json, acked, created_at, acked_at`，按 `created_at DESC` 排序。主键是 **`message_id`**（不是上面那节的 `id`）。
+
+**数据源**：`user_inbox` 表，主键 `message_id`（同一条 send 重投是幂等的），索引 `idx_user_inbox_user_acked(user_id, acked, created_at)`。
+
+**网络作用域**：与 alias 分支复用同一个 `addNetworkScope` 助手 —— 列表与未读数用**同一个 `user_id` + 同一个 scope 助手**计算，避免两处口径漂开。
+
+::: danger 回读脱敏（redact-at-read）
+写入方是 agent，**不受信任**。回读时对 `content` / `title` / `meta_json` 做凭据形状遮蔽，**存储侧留原文**：
+
+| 形状 | 说明 |
+|---|---|
+| `(ntok_\|utok_\|atok_)[A-Za-z0-9_-]{6,}` | 本仓自己的 token |
+| `(github_pat_)[A-Za-z0-9_]{20,}` | GitHub fine-grained PAT |
+| `(ghp_)[A-Za-z0-9]{20,}` | GitHub classic PAT |
+| `(xox[bpoars]-)[A-Za-z0-9-]{10,}` | Slack |
+| `(sk-)[A-Za-z0-9_-]{16,}` | OpenAI 风格 |
+
+替换成 `<前缀>***redacted***` —— **保留前缀**，让读者知道被遮的是哪一类凭据。
+:::
+
+---
+
+### POST /api/messages/ack
+
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · 自 `0.9.0-preview.41` 起
+
+把自己收件箱里的消息标记为已读。
+
+```bash
+curl -X POST "http://localhost:9200/api/messages/ack" \
+  -H "Authorization: Bearer utok_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"message_ids": ["dm_abc123", "dm_def456"]}'
+```
+
+**请求体**：`{"message_id": "dm_x"}` 或 `{"message_ids": ["dm_x", "dm_y"]}`（二选一，后者**上限 500 条**）。
+
+**响应**：`{"ok": true, "acked": 2}` —— `acked` 是**实际改动的行数**，不是你传了几个 id。已经 ack 过的、不属于你的、不存在的，都不计入。
+
+**错误**：
+
+| 状态 | 响应 | 何时 |
+|---|---|---|
+| 401 | `{"ok":false,"error":"auth_required"}` | 没有用户上下文 |
+| 400 | `{"ok":false,"error":"message_id_required"}` | 两个字段都没给，或给了空数组 |
+| 400 | `{"ok":false,"error":"too_many_ids","limit":500}` | `message_ids` 超过 500 |
+
+🔴 **隔离**：UPDATE 带 `AND user_id = <鉴权上下文>`。传别人的 `message_id` 进来**匹配不到行** —— 所以既改不到别人的状态，**也不会因为返回值不同而泄漏那条消息是否存在**（不存在和不属于你，返回都是 `acked: 0`）。
+
+同网络的两个成员之间，`WHERE user_id = ?` 是**唯一**的隔离依据：admin 绕过 network scope，但仍然只能读/改自己 `user_id` 的行。
+
+---
+
 ### GET /api/completions
 
 

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -1061,6 +1061,108 @@ The SELECT doesn't include `in_reply_to` yet; reply-polling uses a heuristic of 
 
 ---
 
+### GET /api/messages?scope=user
+
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · since `@sleep2agi/commhub-server` `0.9.0-preview.41`
+
+**Per-user inbox read.** This is a different path from the alias-addressed branch above: that one lets the Dashboard read the network-wide inbox, this one lets **one person** read their own direct messages (it is the data source for the desktop unread badge).
+
+```bash
+curl "http://localhost:9200/api/messages?scope=user&unacked=1&limit=50" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+🔴 **The recipient comes from the authentication context and cannot be set by query.** Passing `?user_id=<someone else>` **has no effect** — otherwise anyone could read anyone's direct messages. With no user context the response is **401** `{"ok":false,"error":"auth_required"}`.
+
+**Query parameters**:
+
+| Parameter | Meaning |
+|---|---|
+| `scope=user` | **Required**; without it you get the alias-addressed branch above |
+| `unacked=1` | Only un-acked rows (**must equal `1` exactly**) |
+| `limit` | Max rows, default 100, capped at 500 |
+
+**Response**:
+
+```json
+{
+  "ok": true,
+  "messages": [
+    {
+      "message_id": "dm_abc123",
+      "network_id": "net_xxxxx",
+      "user_id": "u_xxxxx",
+      "from_session": "代码1号",
+      "kind": "dm",
+      "title": "Build failed",
+      "content": "…",
+      "severity": "info",
+      "meta_json": null,
+      "acked": 0,
+      "created_at": "2026-08-30 10:00:00",
+      "acked_at": null
+    }
+  ],
+  "unread": 3,
+  "pending_count": 3
+}
+```
+
+🔴 **`unread` and `pending_count` are always equal** — they are **two names for one number** (`unread` reads naturally for a badge; `pending_count` matches the field name used by the alias branch above). It is computed **once**, not twice. **Do not compare them against each other** to infer state.
+
+Field mapping to the server `SELECT`: `message_id, network_id, user_id, from_session, kind, title, content, severity, meta_json, acked, created_at, acked_at`, ordered by `created_at DESC`. The primary key is **`message_id`** (not `id`, as in the section above).
+
+**Data source**: the `user_inbox` table, primary key `message_id` (so re-delivering the same send is idempotent), index `idx_user_inbox_user_acked(user_id, acked, created_at)`.
+
+**Network scope**: reuses the same `addNetworkScope` helper as the alias branch — and the list and the unread count are computed from **the same `user_id` and the same scope helper**, so the two cannot drift apart.
+
+::: danger Redact-at-read
+The writer is an agent and is **not trusted**. On read, credential-shaped strings in `content` / `title` / `meta_json` are masked; **storage keeps the original**:
+
+| Shape | What it is |
+|---|---|
+| `(ntok_\|utok_\|atok_)[A-Za-z0-9_-]{6,}` | this repo's own tokens |
+| `(github_pat_)[A-Za-z0-9_]{20,}` | GitHub fine-grained PAT |
+| `(ghp_)[A-Za-z0-9]{20,}` | GitHub classic PAT |
+| `(xox[bpoars]-)[A-Za-z0-9-]{10,}` | Slack |
+| `(sk-)[A-Za-z0-9_-]{16,}` | OpenAI-style |
+
+Replaced with `<prefix>***redacted***` — **the prefix is kept** so the reader still knows which class of credential was masked.
+:::
+
+---
+
+### POST /api/messages/ack
+
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · since `0.9.0-preview.41`
+
+Mark messages in your own inbox as read.
+
+```bash
+curl -X POST "http://localhost:9200/api/messages/ack" \
+  -H "Authorization: Bearer utok_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"message_ids": ["dm_abc123", "dm_def456"]}'
+```
+
+**Body**: either `{"message_id": "dm_x"}` or `{"message_ids": ["dm_x", "dm_y"]}` (the latter **capped at 500**).
+
+**Response**: `{"ok": true, "acked": 2}` — `acked` is the number of rows **actually changed**, not how many ids you sent. Rows already acked, not yours, or nonexistent do not count.
+
+**Errors**:
+
+| Status | Response | When |
+|---|---|---|
+| 401 | `{"ok":false,"error":"auth_required"}` | no user context |
+| 400 | `{"ok":false,"error":"message_id_required"}` | neither field given, or an empty array |
+| 400 | `{"ok":false,"error":"too_many_ids","limit":500}` | `message_ids` longer than 500 |
+
+🔴 **Isolation**: the UPDATE carries `AND user_id = <auth context>`. Someone else's `message_id` simply **matches no row** — so it can neither change their state **nor leak whether that message exists** (nonexistent and not-yours both return `acked: 0`).
+
+Between two members of the same network, `WHERE user_id = ?` is the **only** isolation: admin bypasses network scope but still reads and writes only rows carrying their own `user_id`.
+
+---
+
 ### GET /api/completions
 
 


### PR DESCRIPTION
桌面端修「不显示新消息数」BUG 要读的接口，在 `rest.md` 里**完全没有文档** —— 那一节只写了旧的 `GET /api/messages?limit=N`（按 alias 寻址）。中英各补一节。

**按内容搜过**：`scope=user` ⇒ rest.md 零命中（确认没写过）· `messages/ack` ⇒ 零命中 · `user_inbox` ⇒ 零命中。

---

## 规格逐条对着 `origin/main` 实现写，不是照 brief 抄

动笔前把每一条核到 `server/src/server.ts` / `db.ts`，并**从源码补了 brief 没给的细节**：

| 细节 | 来源 |
|---|---|
| `limit` **默认 100、上限 500** | `Math.min(Number(...) \|\| 100, 500)` |
| `unacked` 必须**严格等于 `1`** | `=== "1"` |
| 完整 SELECT 列 + `created_at DESC` | handler |
| 500 上限 → 400 `too_many_ids` | ack handler |
| `.41` 确已发布 | `npm view @sleep2agi/commhub-server@0.9.0-preview.41` → 存在 |

## 三处写得比 brief 更准

1. **`unread` 与 `pending_count` 恒等** —— 源码注释原话「同一个数的两个名字……**一处计算**」。brief 说"同一次计算"没错，但读者可能以为是两个口径 ⇒ 文档**明写别拿它们互相比对**（dsh 侧尤其容易踩）。
2. **ack 返回字段叫 `acked`**，且是**实际改动行数**，不是"你传了几个 id" —— 已 ack 的 / 不属于你的 / 不存在的都不计入。
3. **脱敏正则用实现那版**：`github_pat_` 必须排在 `ghp_` 前、各自最小长度、替换成 `<前缀>***redacted***`（**保留前缀**，让读者知道被遮的是哪一类凭据）。

## 隔离按源码注释写

`AND user_id = <ctx>` 不只是"改不到别人的" —— 源码注释点明它**同时避免存在性泄漏**：不存在和不属于你，返回**都是** `acked: 0`，区分不出来。这一点写进了文档。

以及：同网两成员之间 `WHERE user_id = ?` 是**唯一**隔离（admin 绕 network scope，但仍只读/改自己 `user_id` 的行）。

## 没写进去的（说明理由）

`desktop-message-seam.test.ts` 那条「写路径与读路径的接缝」——它是**已被 #1492 闭合的**（那个文件本身就是补接缝的测试：真 send → 真 `scope=user` 读），**不是开放风险**。而且测试拓扑 ≠ API 规格，写进用户文档只会让读者困惑。

## 风格

跟着上面那节走：curl 例 + 字段对照 server SELECT + 网络作用域说明 + 错误码表。

## 门

```
docs-integrity / doc-symbol-anchors / release-channel-assertions /
docs-site-orphans / home-path-baseline          全 rc=0
```

（`rest.md` 已在 RELEASE-SOP 的信道断言清单里，新增的 `0.9.0-preview.41` 是**版本下界**式的「自某版起」，不是"当前通道是 X"的现时断言。）