### PR TITLE
fix(hub): report_status 接受 host.ip = null —— 没有非回环 IPv4 的机器上 agent-node 启动即死（#1225 诊断产物）

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1994 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1994) + [tools.ts:2008 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2008) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2002 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2002) + [tools.ts:2016 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2016) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/report-status-host-schema.test.ts
+++ b/server/src/report-status-host-schema.test.ts
@@ -1,0 +1,76 @@
+// report_status 的 host 遥测 schema 必须接受 agent-node **声明会发**的 null。
+//
+// 来源不是推理，是 #1225 复现容器里量到的一次真崩：`--network none` 里
+// agent-node 一启动就死在
+//   MCP error -32602: Invalid input: expected string, received null at host.ip
+// 而 register() 是 `await callCommHub("report_status", …)` 且没有 catch ——
+// 于是**整个节点进程当场退出**，和 runtime 无关（opencode/claude/codex 一样）。
+//
+// 触发条件不是"容器"，是"这台机器没有非回环 IPv4"：
+// agent-node 的 firstNonInternalIPv4()（host-telemetry.ts:48-59）在那种机器上
+// 返回 null，而 HostTelemetry 的类型本来就写着 `ip: string | null`。
+//
+// 🔴 这里断言的是 **schema 本身**，不是 handler。直接调 handler 会绕过 zod ——
+//    而缺陷恰恰只存在于 zod 那一层，绕过去就永远绿。
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+function captureToolSchemas(): Record<string, any> {
+  const mcp = new McpServer({ name: "schema-probe", version: "0" }) as any;
+  const schemas: Record<string, any> = {};
+  const origTool = mcp.tool.bind(mcp);
+  mcp.tool = (name: string, desc: string, schema: any, handler: any) => {
+    schemas[name] = schema;
+    return origTool(name, desc, schema, handler);
+  };
+  registerTools(mcp, undefined, null, null, null, false, "tok_schema_probe");
+  return schemas;
+}
+
+const schemas = captureToolSchemas();
+
+describe("report_status host telemetry schema", () => {
+  test("前提：抓到的确实是 report_status 的 host 形状", () => {
+    expect(schemas.report_status).toBeTruthy();
+    expect(schemas.report_status.host).toBeTruthy();
+  });
+
+  test("🔴 host.ip = null 必须被接受（没有非回环 IPv4 的机器就是发 null）", () => {
+    const host = schemas.report_status.host;
+    const parsed = host.parse({ hostname: "boxy", ip: null });
+    expect(parsed.ip).toBeNull();
+  });
+
+  test("🔴 host.hostname = null 同样被接受（与 ip 同为字符串字段，一起对齐）", () => {
+    const host = schemas.report_status.host;
+    expect(host.parse({ hostname: null, ip: "10.0.0.2" }).hostname).toBeNull();
+  });
+
+  test("agent-node 那条完整心跳负载整体过 schema", () => {
+    // 形状抄自 agent-node/src/host-telemetry.ts 的 HostTelemetry：
+    // 没有网络、没有 /proc 时每一项都可能是 null。
+    const full = {
+      hostname: "unknown", ip: null,
+      cpu_load_1min: null, cpu_cores: null,
+      mem_total_gb: null, mem_used_gb: null, mem_avail_gb: null,
+      disk_total_gb: null, disk_used_gb: null, disk_avail_gb: null,
+    };
+    expect(() => schemas.report_status.host.parse(full)).not.toThrow();
+  });
+
+  test("放宽的只有 null —— 类型错的值仍然被拒", () => {
+    const host = schemas.report_status.host;
+    expect(() => host.parse({ ip: 12345 })).toThrow();
+    expect(() => host.parse({ ip: "x".repeat(201) })).toThrow();
+  });
+
+  test("整条 report_status 负载（不只是 host 子对象）也接受 ip=null", () => {
+    const full = z.object(schemas.report_status);
+    expect(() => full.parse({
+      resume_id: "probe-resume", alias: "probe-node", status: "idle",
+      host: { hostname: "unknown", ip: null },
+    })).not.toThrow();
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -518,8 +518,16 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       node_name: z.string().max(200).optional().describe("Stable node display name (may differ from alias)"),
       network_id: z.string().max(200).optional().describe("Network this agent belongs to"),
       host: z.object({
-        hostname: z.string().max(200).optional(),
-        ip: z.string().max(200).optional(),
+        // 🔴 `.nullable()` 不是防御性冗余,是**发送方声明的类型**:agent-node 的
+        //    HostTelemetry 是 `ip: string | null`,`firstNonInternalIPv4()` 在没有
+        //    非回环 IPv4 的机器上返回 null(--network none 的容器、断网的笔记本、
+        //    部分 CI runner)。此前这里只有 `.optional()`,于是那台机器上的
+        //    agent-node 一启动就收到 MCP -32602,而 register() 是 await 且无人 catch
+        //    —— **整个节点进程当场死掉**,和 runtime 无关。
+        //    同一个对象里四个数值字段本来就写着 `.nullable().optional()`,
+        //    两个字符串字段是唯一的例外;正确写法一直在隔壁那一行。
+        hostname: z.string().max(200).nullable().optional(),
+        ip: z.string().max(200).nullable().optional(),
         cpu_load_1min: z.number().nullable().optional(),
         cpu_cores: z.number().nullable().optional(),
         mem_total_gb: z.number().nullable().optional(),


### PR DESCRIPTION
## 一句话

`report_status` 的 `host.ip` 只写了 `.optional()` 没写 `.nullable()`，而 agent-node 的类型本来就声明 `ip: string | null` —— 于是**一台没有非回环 IPv4 的机器上，agent-node 一启动就整个进程死掉**。#1225 的 30s 超时只是这件事在 `--copresence` 路径上的表象。

## 怎么找到的

按 @通信龙 的要求，先证明 #1225 在 **当前 origin/main** 上还复不复现。在 Docker 里（`--network none`，绝不碰宿主 9200 生产 hub）搭了完整链路：容器内起自己的 hub + `anet login` + `anet node create --runtime opencode-cli` + **原样跑 issue 里那条 `anet node start <node> --copresence`**。

拿到的输出和 issue 里 08-26 报的**逐字相同**：

```
[anet] ❌ OpenCode copresence server did not produce its attach launcher within 30s.
```

然后把 `--copresence` 塞进 tmux 的那条 bridge 命令**原样拉到前台**跑（tmux 会把它的输出连同会话一起带走，这正是当初什么都看不到的原因），真正的死因才露出来：

```
qr [CommHubError]: tool isError: MCP error -32602: Input validation error:
Invalid arguments for tool report_status:
Invalid input: expected string, received null at host.ip
    at ... dist/cli.js
Node.js v22.23.2
```

## 链路

| 环节 | 事实 |
|---|---|
| 发送方类型 | `agent-node/src/host-telemetry.ts:34` — `ip: string \| null` |
| 什么时候是 null | `firstNonInternalIPv4()`（同文件 48–59）遍历不到非回环 IPv4 时 `return null` |
| 接收方 schema | `server/src/tools.ts` 的 `host` 子对象：`ip: z.string().max(200).optional()` —— **没有 `.nullable()`** |
| 同一个对象里的邻居 | `cpu_load_1min` / `cpu_cores` / `mem_*` / `disk_*` **全都是** `.nullable().optional()` |
| 为什么会死进程 | `agent-node/src/cli.ts:6434` 是 `await register();`，**顶层 await、没有 catch**。同文件 6090 的 re-register 反而写了 `.catch(...)` |

**正确写法一直在隔壁那一行** —— 两个字符串字段是这个对象里唯一的例外。

🔴 **影响范围比 #1225 大**：`register()` 在运行时分发之前、对所有 runtime 都跑。触发条件不是"在容器里"，是**"这台机器没有非回环 IPv4"** —— 断网的笔记本、只有 loopback 的 CI runner、`--network none` 的容器都算。

## 为什么修 hub 而不是 agent-node

只改发送方（null 时不发这个 key）也能让新版本不崩，但**现网已经装好的 agent-node 正是受影响的那些**，它们不会因此被修好。改 hub 一侧，**已部署的节点不需要升级就恢复**。

## 端到端证据

同一个容器、同一条命令，只差这一处改动：

| | 输出 | exit |
|---|---|---|
| 修前 | `❌ OpenCode copresence server did not produce its attach launcher within 30s.` | 1 |
| 修后 | `✅ OpenCode 共存节点 oc-repro 就绪`，`opencode-attach.sh` 5 秒内产出 | 0 |

## 测试

`server/src/report-status-host-schema.test.ts`，6 pass。

🔴 断言的是 **schema 本身**，不是 handler —— 测试直接调 handler 会绕过 zod，而缺陷**只存在于 zod 那一层**，绕过去就永远绿（这个坑我在 #1485 上撞过一次）。所以测试从 `registerTools` 里把 `report_status` 的 schema 抓出来直接 `.parse()`。

**witnessed-red**：把 `.nullable()` 撤回去 → **4 fail**（`ip=null` / `hostname=null` / 完整心跳负载 / 整条 report_status 负载）。另有一条反向断言：放宽的只有 `null`，`ip: 12345` 和超长字符串仍然被拒。

server 全量：`bun run scripts/test-aggregate.ts` → **93 files / 1165 pass / 0 fail**。元门 `check-test-file-coverage.py` rc=0。

## 关于 #1225 本身

**#1225 那条 issue 在 main 上已经不复现了** —— 同样的容器接上网络跑，`anet node start --copresence` 直接 `exit=0`、5 秒产出 attach launcher。报告人当时的环境是 `anet v2.3.0-preview.40`、`node v20.20.0`（低于 engine `>=22.13.0`）、`opencode --version 0.0.55` 而 npm 全局是 `1.18.1`（两个 opencode 装在不同地方）。我不打算把"哪个 commit 修的"编出来。

**但 issue 里的两条验收标准仍然没满足，而且正是这次诊断花掉一整个容器的原因：**

1. **bridge 死掉时用户什么都拿不到。** `agent-network/bin/cli.ts` 超时后用 `tmux capture-pane` 取现场，可等待循环的退出条件之一就是"bridge 会话已经没了"—— 会话没了，`capture-pane` 自然是空，于是只剩那一行泛泛的超时。agent-node 的日志里也没有：崩溃走的是 stderr，日志最后一行停在 `goals scheduler: enabled`。
2. 失败输出不指认是哪一步、也不给日志路径。

这两条我打算**单开一个 agent-network 侧的 PR**（bridge 输出落盘 + 超时时打印落盘日志尾和节点日志路径），不并进这个 hub PR —— 两个包，两条发布链。

## 顺带发现（不在本 PR）

- **`anet node start --copresence` 这条一条龙路径，仓库里没有任何端到端覆盖。** `tests/test227-opencode-tui-copresence` 的 harness 直接调 `openOpenCodeCopresenceRuntime()`，从不经过 anet CLI；而 test227 **在 `.github/` 和 `scripts/` 里的引用是 0 处，根本不在 CI 里跑**。我这次的复现容器正好就是那个缺失的套件，可以整理成正式 suite（要注册进 CI）。
- **建议硬化**：`register()` 遇到 app-level 的 schema 拒绝时，可以去掉 `host` 块重试一次 —— 一个可选遥测字段的形状不匹配，不该有能力弄死一个节点。这条只帮到未来的版本，所以不是本 PR 的重点。

## 隔离

复现和验证全程在 Docker 里、**没有 `--network host`**，容器内自带 hub（端口 9225）和 SQLite；没有碰生产 hub、生产 DB、live 节点、live tmux，也没有发任何真 IM。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
