### PR TITLE
docs(api): 补 GET /api/host-supervisors —— 审计出的唯一一个没文档的 REST 端点

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -749,6 +749,69 @@ curl http://localhost:9200/api/nodes \
 
 ---
 
+### GET /api/host-supervisors
+
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · RFC-026 §9.2.2 / #338
+
+列出本网络里的 **host_supervisor daemon**（`anet daemon` 起的那种节点）。这是 `list_host_supervisors` **MCP 工具的 REST 镜像**，给不走 MCP 的调用方用（Dashboard 的「建节点向导」选服务器就是读它）。
+
+```bash
+curl "http://localhost:9200/api/host-supervisors" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+**网络怎么定**（不用传 `network_id`）：
+
+| 情况 | 行为 |
+|---|---|
+| ntok 绑定了网络，或已显式指定并验证过访问权 | 用那个网络 |
+| utok 用户**只属于 1 个**网络 | 用那个网络（安全的无歧义兜底） |
+| 用户属于 **0 个或 ≥2 个**网络 | **400，不猜** |
+
+🔴 **属于多个网络时不会替你挑一个** —— 返回 400，并用两个不同的 error 把原因分开，客户端据此可以恢复（显式带上 `network_id` 再来一次）：
+
+| 状态 | 响应 | 何时 |
+|---|---|---|
+| 400 | `{"ok":false,"error":"network_id_required_multi","memberships":N}` | 属于 N ≥ 2 个网络 |
+| 400 | `{"ok":false,"error":"missing_network_id","memberships":0}` | 没有可访问的网络 |
+
+**响应**：
+
+```json
+{
+  "ok": true,
+  "daemons": [
+    {
+      "daemon_node_id": "node_daemon_xxxxx",
+      "alias": "daemon",
+      "hostname": "build-1",
+      "online": true,
+      "last_seen_at": "2026-08-30 10:00:00",
+      "runtimes_supported": ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+      "allowed_secret_keys": [],
+      "host_telemetry": {
+        "alert_level": "green",
+        "cpu_cores": 8,
+        "mem_gb": 16,
+        "ip_internal": "10.x.x.x"
+      }
+    }
+  ],
+  "count": 1
+}
+```
+
+🔴 **`host_telemetry` 按角色遮蔽**：所有人都能看到 `alert_level`（`green` = 在线 / `gray` = 不在线）；**只有该网络的 `admin` / `owner`（或用 network token 调用）**才拿得到 `cpu_cores` / `mem_gb` / `ip_internal`。普通成员看到的 `host_telemetry` 里**只有 `alert_level`**，不是这些字段为 null。
+
+🔴 **`online` 的窗口是 5 分钟**，不是心跳周期本身。agent-node 的 `report_status` 每 **3 分钟**一次，窗口必须大于它 —— 否则每次心跳之后的 60~180 秒必然抖成 `offline`。
+
+**只列"还有活 token"的 daemon**：SQL 里的 `EXISTS` 子查询要求存在未吊销的 `node:<alias>` token。吊销过（或行已被删）的不会出现；同一个 daemon 轮换过 token 也只出现一次。
+
+**网络作用域**：走 REST auth pipeline 的 `restScope`（SEC-1）。
+
+
+---
+
 ### DELETE /api/nodes/:ref
 
 > [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -760,6 +760,69 @@ The `nodes` table is **persistent node identity** (written at creation, deleted 
 
 ---
 
+### GET /api/host-supervisors
+
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · RFC-026 §9.2.2 / #338
+
+List the **host_supervisor daemons** in this network (the node kind that `anet daemon` starts). This is the **REST mirror of the `list_host_supervisors` MCP tool**, for callers that don't speak MCP — the Dashboard's create-node wizard reads it to offer a server.
+
+```bash
+curl "http://localhost:9200/api/host-supervisors" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+**How the network is resolved** (you don't pass `network_id`):
+
+| Case | Behaviour |
+|---|---|
+| ntok bound to a network, or one explicitly requested and access-verified | use that network |
+| utok user belongs to **exactly one** network | use it (safe, unambiguous fallback) |
+| user belongs to **zero or ≥2** networks | **400 — it will not guess** |
+
+🔴 **With multiple memberships it does not pick one for you.** It returns 400 and separates the two causes with distinct errors, so a client can recover (retry with an explicit `network_id`):
+
+| Status | Response | When |
+|---|---|---|
+| 400 | `{"ok":false,"error":"network_id_required_multi","memberships":N}` | member of N ≥ 2 networks |
+| 400 | `{"ok":false,"error":"missing_network_id","memberships":0}` | no accessible network |
+
+**Response**:
+
+```json
+{
+  "ok": true,
+  "daemons": [
+    {
+      "daemon_node_id": "node_daemon_xxxxx",
+      "alias": "daemon",
+      "hostname": "build-1",
+      "online": true,
+      "last_seen_at": "2026-08-30 10:00:00",
+      "runtimes_supported": ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+      "allowed_secret_keys": [],
+      "host_telemetry": {
+        "alert_level": "green",
+        "cpu_cores": 8,
+        "mem_gb": 16,
+        "ip_internal": "10.x.x.x"
+      }
+    }
+  ],
+  "count": 1
+}
+```
+
+🔴 **`host_telemetry` is masked by role.** Everyone sees `alert_level` (`green` = online, `gray` = not). Only a network `admin` / `owner` — or a network-token caller — receives `cpu_cores` / `mem_gb` / `ip_internal`. For an ordinary member those keys are **absent**, not null.
+
+🔴 **The `online` window is 5 minutes**, not the heartbeat period. agent-node's `report_status` fires every **3 minutes**, and the window must exceed it — otherwise a daemon would flap to `offline` for the 60–180 s after every heartbeat.
+
+**Only daemons with a live token are listed**: the SQL requires an `EXISTS` match on a non-revoked `node:<alias>` token. Revoked (or deleted) rows drop out, and a daemon whose token was rotated still appears only once.
+
+**Network scope**: the REST auth pipeline's `restScope` (SEC-1).
+
+
+---
+
 ### DELETE /api/nodes/:ref
 
 > [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)


### PR DESCRIPTION
起因是 通信龙 让我看「rest.md 还有没有别的 `.41` 新端点没文档化」。做了一次全量对账。

**按内容搜过**：`host-supervisors` ⇒ rest.md 中英**零命中**（确认没写过）· `list_host_supervisors` ⇒ 仅 MCP 工具文档。

---

## 审计结果：没有 `.41` 缺口，但有一个老缺口

```
server.ts 路由族      38
rest.md 已记录        37
唯一缺的              GET /api/host-supervisors
```

🔴 **`.41` 的新端点一个都不缺**（#1497 已补齐）。这一条是**长期遗留** —— #338 / RFC-026 §9.2.2 时就有了，不是这次发版带来的。所以对你的问题，准确回答是「没有 .41 缺口，但顺手挖出一个老的」。

⚠️ **顺带记一次我自己的取集缺陷**：第一版只抽字面量路由（`url.pathname === "/api/x"`），漏掉 10 个 `pathname.match(/^\/api\/…/)` 的动态族，分母是 35。补上动态那一支后是 38。**又一次「盲区在怎么取，不在判什么」** —— 而且这次是在我自己的审计脚本上。

## 写进去的四件事（都从源码核出来）

**① 网络怎么定**（调用方不用传 `network_id`）

| 情况 | 行为 |
|---|---|
| ntok 绑定网络 / 已显式指定并验证访问权 | 用它 |
| utok 用户**只属于 1 个**网络 | 用它（安全的无歧义兜底） |
| **0 个或 ≥2 个** | **400，不猜** |

两个 error 分开、都带 `memberships`，客户端据此能恢复（显式带 `network_id` 重试）：`network_id_required_multi` vs `missing_network_id`。

**② 🔴 `host_telemetry` 按角色遮蔽**

所有人拿 `alert_level`；`cpu_cores` / `mem_gb` / `ip_internal` **只给该网络 admin/owner 或 network-token 调用方**。

对普通成员这几个键是**缺席**，**不是 null** —— 客户端若按 `=== null` 判会判错，所以文档明写。

**③ 🔴 `online` 窗口是 5 分钟，不是心跳周期**

`report_status` 每 **3 分钟**一次，窗口必须大于它 —— 否则每次心跳后的 60–180 秒必然抖成 `offline`。（源码注释记着这是 #1279 独审④ 的结论。）

**④ 只列"还有活 token"的 daemon**

`EXISTS` 要求存在未吊销的 `node:<alias>` token；吊销/删除的不出现，轮换过 token 的 daemon 也只出现一次。

## 门

```
docs-integrity / doc-symbol-anchors / release-channel-assertions / docs-site-orphans   全 rc=0
```

中英两份，风格跟同页其它节一致（curl 例 + 参数表 + 响应 + 作用域说明）。