### PR TITLE
docs(api): 去掉 rest.md 里指错地方的 tools.ts:521（并附一份同类问题的普查）

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -92,7 +92,7 @@ curl http://localhost:9200/health
 - 普通 `utok_` / `ntok_` 只看到其有权访问网络的 session；无网络成员关系时返回空对象。
 
 ::: tip `license` 字段是 v0.6 legacy
-`license: "trial"` 是 v0.6 时代 14 天试用机制的残留字段，Apache 2.0 OSS 后**不再作为商业功能门控**（自部署没有"过期"概念）。`send_task` 路径仍跑 trial 检查仅为后向兼容（verify [`server/src/tools.ts:521`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) `license_expired` 仍 emit），若命中见 [troubleshooting](/troubleshooting)。**v0.9.x / v0.10.x scope 都未动**（Recovery & Observability 主题为先），整段移除排到 v0.11+ / 未排期。
+`license: "trial"` 是 v0.6 时代 14 天试用机制的残留字段，Apache 2.0 OSS 后**不再作为商业功能门控**（自部署没有"过期"概念）。`send_task` 路径仍跑 trial 检查仅为后向兼容（verify [`server/src/tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 里 `license_expired` 仍 emit），若命中见 [troubleshooting](/troubleshooting)。**v0.9.x / v0.10.x scope 都未动**（Recovery & Observability 主题为先），整段移除排到 v0.11+ / 未排期。
 :::
 
 ---

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -102,7 +102,7 @@ sessions from networks they may access (or an empty object when they belong to
 none).
 
 ::: tip The `license` field is a v0.6 legacy
-`license: "trial"` is a leftover from the v0.6 era 14-day trial mechanism. After the Apache 2.0 OSS transition it is **no longer a commercial feature gate** (self-hosted has no notion of "expired"). The `send_task` path still runs the trial check only for backward compatibility (verify [`server/src/tools.ts:521`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) where `license_expired` is still emitted); if you hit it, see [troubleshooting](/en/troubleshooting). **The v0.9.x and v0.10.x scopes did not touch this** (Recovery & Observability took priority); full removal is queued for v0.11+ / unscheduled.
+`license: "trial"` is a leftover from the v0.6 era 14-day trial mechanism. After the Apache 2.0 OSS transition it is **no longer a commercial feature gate** (self-hosted has no notion of "expired"). The `send_task` path still runs the trial check only for backward compatibility (verify [`server/src/tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) where `license_expired` is still emitted); if you hit it, see [troubleshooting](/en/troubleshooting). **The v0.9.x and v0.10.x scopes did not touch this** (Recovery & Observability took priority); full removal is queued for v0.11+ / unscheduled.
 :::
 
 ---


### PR DESCRIPTION
## 改了什么

`docs-site/docs/{,en/}api/rest.md` 里 `license: "trial"` 那段写着「verify `server/src/tools.ts:521` 里 `license_expired` 仍 emit」。

量出来：`license_expired` 在 **main 上是第 1432 行**；521 行是 `hostname: z.string().max(200).optional()`。**差九百多行，而且在我碰 tools.ts 之前就已经是错的**（这条是 @通信龙 在排查 #1498 的 doc 门时顺手点到的，排查方向不对但戳中了一个真问题）。

**修法是去掉行号、保留符号，不是把 521 换成 1432。** 链接的 URL 本来就指着整个文件（没有 `#L` 锚），行号只活在链接文字里；而 `license_expired` 这个符号名就在同一句里，`git grep` 一下就到。换成 1432 只是把"错"挪成"下一次改动之后的错"。

中英各一处。

## 关于 `.vitepress/dist/`

那里面还有同样的旧字符串，但**那个目录没有被 git 跟踪**（`.gitignore:14`），是本地构建产物，`git log -- docs-site/docs/.vitepress/dist` 是空的。下次 build 自然刷新，仓库里没有东西要改。

## 🔴 顺手做了普查：这不是一条，是一类

写这个修复时我把**活文档**（排除 `changelog.md` 这类冻结记录、排除未跟踪的 dist）里的**纯文字 `file:NNN` 引用**全部枚举 + 逐条对了真实源码。

**修完这一处之后还剩 26 条**，其中 **8 条落在空行或纯注释行上** —— 这一类不需要任何判据就能确定是错的。剩下 18 条要人读一眼才能判（有几条可能只是偏了几行、仍在正确的代码块里），我没有把它们一律算成错。

🔴 **更正我自己**：第一版这里写的是「46 条」。那个数字来自一个更松的正则，它把 markdown 链接 URL 里的 `…/auth.ts:113` 那一半也数了进去、并且同一处被数了两遍。按「反引号里的纯文字行号」这个明确口径重数是 **26**。数字本身没错，错在它量的不是我想说的那个对象。

几条不需要判据的例子：

| 文档里的引用 | 声称指向 | 那一行实际是什么 |
|---|---|---|
| `tools.ts:286/646` | `chained_reply` | `const showPending = !!include_pending && reviewer;` |
| `push.ts:38-44` | heartbeat 事件的更正 | `//         up.`（一句注释的下半行） |
| `create-node-validate.ts:20` | `RUNTIMES` | `// #1298 —— daemon 远程创建允许的 runtime。…` |
| `create-node-daemon.ts:310` | `throw new Error("runtime_invalid")` | 一行 JSDoc |
| `auth.ts:346` | `invite_code` 生成 | **空行** |
| `auth.ts:382` | `networks` 数组字段 | `const role = getUserNetworkRole(userId, networkId);` |
| `client.ts:265` | SDK 自动 `ack_inbox` | `const messages: InboxMessage[] = result?.messages \|\| [];` |

**为什么没有任何门抓到**：这些是**纯文字行号**（`` [`auth.ts:267-282 changePassword`](…/auth.ts) `` 这种形态），链接 URL 里**没有 `#L`**，而 `scripts/check-doc-symbol-pins.py` 解析的正是 blob URL 的 `#L`。所以它们**根本不在那道门的取集里** —— 门是绿的，因为它没在看这些。

`check-doc-symbol-pins.py` 的文件头其实自己写了这件事：它刻意保守（"宁可跳过也不误报"），并且明说「跳过的那些不是通过 …… 定期照它手工扫一遍即可」。**上一次手工扫是 2026-08-28，这次这份就是那个手工扫，而且它确实又扫出一批。**

## 我没有在这个 PR 里一次改完这 26 条，理由

1. 把 46 个行号更新成今天的值，**下一次有人改这几个文件就又全错了** —— 这正是仓库自己已经得出过的结论：`docs/stale-issue-review.md:164` 记着他们把 `#L` pin 迁成符号锚就是为了这个，只**故意**留了 db.ts 那一条行号式当 test846 的 witnessed-red 夹具。
2. 正确的终态是**符号锚**（"`tools.ts` 里的 `chained_reply`"），跟这个 PR 对 521 做的一样 —— 但那是中英两份、26 处的机械迁移，值得单独一条、单独 review。
3. 要不要把纯文字 `file:NNN` 也纳入 check-doc-symbol-pins 的取集，**需要先量误报率再决定**，不能凭感觉加：那道门的文件头记着他们量过三个 window（±2/±5/±25），最好的窗口下仍有一条是误报，并据此决定"这条留在注释里靠读、不做成门"。**新加的检查要匹配产品既有的立场，而不是顺手收紧它。**

已开 issue 跟这条（含完整 26 条逐条测量），本 PR 只收被点名的那一处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
