### PR TITLE
fix(daemon): #1491 Windows daemon ANET path.conf default is now %ProgramData%\anet-daemon, not POSIX /etc/

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -7,6 +7,7 @@ import {
   ensureGlobalAnetConfig,
   reconcilePendingCreateRequestsOnConnect,
   resolveChildHome,
+  defaultPathConf,
   _resetWindowsPosixModeWarnLatchForTest,
 } from "./create-node-daemon.js";
 import { win32 as pathWin32 } from "node:path";
@@ -688,6 +689,116 @@ describe("#1490 minimalEnv — cross-platform HOME resolution", () => {
     expect(
       resolveChildHome({ HOMEDRIVE: "D:", HOMEPATH: "\\Users\\hd" }, "win32"),
     ).toBe("D:\\Users\\hd");
+  });
+});
+
+// #1491 — Windows daemon default ANET_DAEMON_PATH_CONF was
+// `/etc/anet-daemon/path.conf` — a POSIX-only path that never resolves
+// on Windows filesystems, so the default silently failed and users
+// had to know about the ANET_BIN_ABS + ANET_DAEMON_ALLOW_ENV_BIN=1
+// env fallback (documented per #1291) to make anything work. Same
+// class as #1290 / #1490 — POSIX-only default in code that must also
+// run on Windows.
+describe("#1491 defaultPathConf — platform-aware ANET path.conf trust root", () => {
+  // 🔴 witnessed-red — the reported symptom is that the default on
+  // Windows was the POSIX literal. Assert the platform-branch fixes it.
+  test("🔴 witnessed-red: Windows default is under %ProgramData%, NOT /etc/", () => {
+    const conf = defaultPathConf({ PROGRAMDATA: "C:\\ProgramData" }, "win32");
+    // Cross-platform assertion: win32.join produces backslash separators
+    // on any host, so this check is portable to Linux CI.
+    expect(conf).toBe("C:\\ProgramData\\anet-daemon\\path.conf");
+    expect(conf).not.toBe("/etc/anet-daemon/path.conf");
+    expect(conf.startsWith("/etc/")).toBe(false);
+  });
+
+  test("Windows: PROGRAMDATA unset falls back to C:\\ProgramData", () => {
+    // Stripped-env service context — Windows normally sets PROGRAMDATA
+    // but a bare fork/exec with a scrubbed env can lose it. The fallback
+    // keeps the daemon addressable rather than throwing.
+    const conf = defaultPathConf({}, "win32");
+    expect(conf).toBe("C:\\ProgramData\\anet-daemon\\path.conf");
+  });
+
+  test("Windows: non-default PROGRAMDATA is honored (Server Core / relocated system drive)", () => {
+    // Some Windows Server installs relocate ProgramData to D:\ etc.
+    // The default must follow the OS's own PROGRAMDATA, not hardcode C:.
+    const conf = defaultPathConf({ PROGRAMDATA: "D:\\ProgramData" }, "win32");
+    expect(conf).toBe("D:\\ProgramData\\anet-daemon\\path.conf");
+  });
+
+  test("POSIX (explicit 'linux'): default is /etc/anet-daemon/path.conf (unchanged from pre-#1491)", () => {
+    // Explicit 'linux' so a future refactor that accidentally defaults
+    // to 'win32' fails here loudly — same defensive pattern as #1290 /
+    // #1490's POSIX-branch tests. PROGRAMDATA is (rightly) ignored on POSIX.
+    expect(defaultPathConf({}, "linux")).toBe("/etc/anet-daemon/path.conf");
+    expect(defaultPathConf({ PROGRAMDATA: "C:\\ProgramData" }, "linux")).toBe(
+      "/etc/anet-daemon/path.conf",
+    );
+  });
+
+  test("POSIX (explicit 'darwin'): default is /etc/anet-daemon/path.conf (unchanged)", () => {
+    // macOS daemons follow the POSIX branch — no separate macOS path
+    // (there's no equivalent to the POSIX-vs-Windows split for macOS
+    // that would warrant a third case).
+    expect(defaultPathConf({}, "darwin")).toBe("/etc/anet-daemon/path.conf");
+  });
+
+  test("loadAndVerifyAnetBin: Windows error mentions the %ProgramData% trust root, NOT /etc/", () => {
+    // The diagnostic thrown when no pin resolves. Before this fix the
+    // message hardcoded /etc/anet-daemon/path.conf, which is nonsense
+    // to a Windows operator trying to figure out where to write it.
+    // Env fallback disabled + no ANET_BIN_ABS → the "no ANET_BIN_ABS
+    // resolved from <trust root>" branch fires.
+    try {
+      loadAndVerifyAnetBin(
+        { PROGRAMDATA: "C:\\ProgramData" },
+        "win32",
+      );
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    } catch (e: any) {
+      expect(e.message).toMatch(/C:\\ProgramData\\anet-daemon\\path\.conf/);
+      // 🔴 anti-regression: the message must NOT still carry the POSIX
+      // literal on Windows. Catching this if a future refactor
+      // inlines the string constant back.
+      expect(e.message).not.toMatch(/\/etc\/anet-daemon/);
+    }
+  });
+
+  test("loadAndVerifyAnetBin: POSIX error still mentions /etc/anet-daemon (unchanged)", () => {
+    try {
+      loadAndVerifyAnetBin({}, "linux");
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    } catch (e: any) {
+      expect(e.message).toMatch(/\/etc\/anet-daemon\/path\.conf/);
+      // Anti-cross-contamination: the POSIX branch must NOT leak
+      // Windows path syntax.
+      expect(e.message).not.toMatch(/ProgramData/);
+    }
+  });
+
+  test("loadAndVerifyAnetBin: Windows Fix command uses PowerShell (Set-Content), NOT sudo/tee", () => {
+    // Downstream of the trust-root platform branch: telling a Windows
+    // operator to run `sudo tee /etc/...` is nonsense. Anti-regression
+    // for the paired Fix command.
+    try {
+      loadAndVerifyAnetBin({ PROGRAMDATA: "C:\\ProgramData" }, "win32");
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    } catch (e: any) {
+      expect(e.message).toMatch(/Set-Content/);
+      expect(e.message).not.toMatch(/sudo tee/);
+      expect(e.message).not.toMatch(/install -d -m 0755/);
+    }
+  });
+
+  test("loadAndVerifyAnetBin: POSIX Fix command is unchanged sudo/tee shell recipe", () => {
+    try {
+      loadAndVerifyAnetBin({}, "linux");
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    } catch (e: any) {
+      expect(e.message).toMatch(/sudo tee/);
+      expect(e.message).toMatch(/install -d -m 0755/);
+      expect(e.message).not.toMatch(/Set-Content/);
+    }
   });
 });
 

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -183,23 +183,55 @@ export function _resetWindowsPosixModeWarnLatchForTest(): void {
   _windowsPosixModeCheckWarned = false;
 }
 
+/** #1491 — platform-aware default for the ANET path.conf trust root.
+ *
+ *  POSIX: `/etc/anet-daemon/path.conf` (unchanged — the value that has
+ *   shipped since RFC-026 §4.2.6 B2 and that install scripts write).
+ *
+ *  Windows: `%ProgramData%\anet-daemon\path.conf`, falling back to
+ *   `C:\ProgramData\anet-daemon\path.conf` if `PROGRAMDATA` isn't set
+ *   (rare — Windows always sets it on interactive sessions, but a
+ *   stripped-env service context can lack it). `%ProgramData%` is the
+ *   documented Windows location for system-wide daemon config
+ *   (equivalent role to `/etc` on POSIX).
+ *
+ *  Before this fix the POSIX literal was the default on every platform,
+ *  so on Windows the default `confPath` pointed at `/etc/anet-daemon/...`
+ *  — a path that cannot exist on Windows filesystems and never
+ *  resolves. Users had to know about the `ANET_BIN_ABS` +
+ *  `ANET_DAEMON_ALLOW_ENV_BIN=1` env fallback (documented per #1291) to
+ *  get anywhere. This makes the default do the right thing.
+ */
+export function defaultPathConf(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  if (platform === "win32") {
+    const programData = env.PROGRAMDATA || "C:\\ProgramData";
+    return win32.join(programData, "anet-daemon", "path.conf");
+  }
+  return "/etc/anet-daemon/path.conf";
+}
+
 export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform): string {
   let pin: PathPin | null = null;
-  const confPath = env.ANET_DAEMON_PATH_CONF || "/etc/anet-daemon/path.conf";
+  const trustRoot = defaultPathConf(env, platform);
+  const confPath = env.ANET_DAEMON_PATH_CONF || trustRoot;
   pin = readPathConf(confPath);
   if (!pin && env.ANET_BIN_ABS && env.ANET_DAEMON_ALLOW_ENV_BIN === "1") {
     pin = { abs: env.ANET_BIN_ABS, sha256: env.ANET_BIN_SHA256 };
   }
   if (!pin && env.ANET_BIN_ABS) {
     throw unsafePathHelp("anet_bin_source",
-      "ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is /etc/anet-daemon/path.conf)",
-      "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+      `ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is ${trustRoot})`,
+      platform === "win32"
+        ? `New-Item -ItemType Directory -Force -Path "${win32.dirname(trustRoot)}" | Out-Null; "ANET_BIN_ABS=<absolute path to anet.cjs>" | Set-Content -Path "${trustRoot}" -Encoding ascii`
+        : "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   if (!pin) {
     throw unsafePathHelp("anet_bin_source",
-      "no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1",
-      "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+      `no ANET_BIN_ABS resolved from ${trustRoot}; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1`,
+      platform === "win32"
+        ? `New-Item -ItemType Directory -Force -Path "${win32.dirname(trustRoot)}" | Out-Null; "ANET_BIN_ABS=<absolute path to anet.cjs>" | Set-Content -Path "${trustRoot}" -Encoding ascii`
+        : "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   // ① absolute — cross-platform. Was `startsWith("/")` which returned


### PR DESCRIPTION
Fixes [#1491](https://github.com/sleep2agi/agent-network/issues/1491) — after [#1489](https://github.com/sleep2agi/agent-network/pull/1489) and [#1494](https://github.com/sleep2agi/agent-network/pull/1494) unblocked the earlier Windows crashes, the daemon can fork + register + heartbeat — but the default `ANET_DAEMON_PATH_CONF` still pointed at `/etc/anet-daemon/path.conf`, a path that cannot exist on a Windows filesystem. Windows operators had to know about the `ANET_BIN_ABS` + `ANET_DAEMON_ALLOW_ENV_BIN=1` env fallback (documented per #1291) to get anywhere.

Same class as #1290 / #1490 — POSIX-only default in code that must also run on Windows. Third and last piece of the \"Windows daemon is usable out of the box\" chain (#1137 → #1489/#1290 → #1494/#1490 → this).

Pinned to `origin/main = bc6131f6`.

**Content search performed:** `gh pr list --search \"1491\"` / `--search \"defaultPathConf\"` / `--search \"ProgramData path.conf\"` → only my own recently-merged #1494 matches (via its follow-up reference). Zero PRs open touching this fix.

## Fix

**① New `defaultPathConf(env, platform)` helper.**
- POSIX: returns the unchanged `/etc/anet-daemon/path.conf` literal.
- Windows: returns `${env.PROGRAMDATA || 'C:\ProgramData'}\anet-daemon\path.conf`, joined via `win32.join` so the separator is correct on any host.

`%ProgramData%` is the Windows convention for system-wide daemon config (equivalent role to POSIX `/etc`). PROGRAMDATA-unset fallback covers stripped-env service contexts; PROGRAMDATA-set honors Server Core / relocated system drive.

**② `loadAndVerifyAnetBin` uses it for the confPath default.** The `env.ANET_DAEMON_PATH_CONF` override still wins when set, so existing operator scripts that set it explicitly are unaffected.

**③ Error messages platform-branched.** The \"trust root is X\" phrase now names the platform-appropriate default so a Windows operator reading the error knows where to write the file. The Fix command is PowerShell (`New-Item -ItemType Directory ... | Set-Content`) on Windows, unchanged POSIX shell recipe on Linux/macOS.

**④ No new function param on `loadAndVerifyAnetBin`.** It already accepts `env` + `platform` (from #1290 / #1494 lineage). Testability infrastructure was already in place — no widening of the surface area.

## Tests — 7 new cases

Under `describe('#1491 defaultPathConf — platform-aware ANET path.conf trust root')`:

1. **🔴 witnessed-red** Windows default is under `%ProgramData%`, NOT `/etc/`.
2. Windows PROGRAMDATA-unset falls back to `C:\ProgramData\anet-daemon\path.conf`.
3. Windows non-default PROGRAMDATA honored (Server Core / D:\ etc.).
4. POSIX (explicit `'linux'`): default is `/etc/anet-daemon/path.conf` (unchanged from pre-#1491). Explicit `'linux'` so a future refactor that accidentally defaults to `'win32'` fails loudly here.
5. POSIX (explicit `'darwin'`): default unchanged (macOS follows POSIX branch).
6. `loadAndVerifyAnetBin` on Windows: error mentions `%ProgramData%` trust root, NOT `/etc/`.
7. `loadAndVerifyAnetBin` on Windows: Fix command uses PowerShell (`Set-Content`), NOT `sudo`/`tee`.

Plus anti-cross-contamination on POSIX side (unchanged: `sudo tee` shell recipe, no PowerShell leakage).

## Witnessed-red proof — body-only revert (defaultPathConf helper preserved as scaffolding)

\`\`\`
Fixed body:     65 pass / 0 fail / 147 expect() calls
Reverted body:  63 pass / 2 fail / 144 expect() calls
\`\`\`

The 2 failures are exactly the Windows-error-mentions-`%ProgramData%` + Windows-Fix-uses-PowerShell tests. The 5 `defaultPathConf`-unit-tests kept passing on revert because the helper stays scaffolding across the revert — that isolates the signal onto precisely the wire-up (`loadAndVerifyAnetBin` actually calling and threading the trust root into the error messages), which is exactly what the fix does.

Kept as scaffolding across the revert (not the bug): the exported `defaultPathConf` helper. Reverting it too would give a broader red than the fix scope actually justifies.

## Deploy risk

**POSIX behavior unchanged.** `defaultPathConf({}, 'linux')` returns the same string that was inlined before, and the POSIX error text + Fix command are byte-identical to the pre-fix values. Existing installers writing `/etc/anet-daemon/path.conf` continue to work with no change.

**Windows behavior changes from \"default silently fails, requires env fallback\" to \"default resolves to `%ProgramData%\anet-daemon\path.conf`, error text + Fix command are platform-appropriate.\"**

The `env.ANET_DAEMON_PATH_CONF` explicit override still wins on any platform, so anyone setting it in a systemd unit / install script continues to behave as before.

## Not in this PR

None — this closes out the Windows-daemon-usability chain from #1137 → #1290 → #1490 → this.

## Related

- #1491 (this issue) — Windows daemon `/etc/` path.conf default is POSIX-only
- #1494 (PR #1494) — Windows HOME=undefined crash — most recent Windows-daemon merge
- #1290 (PR #1489) — Windows anet_bin POSIX-only path check
- #1137 — Windows launchers + chmod fixes
- #1291 — docs pointing Windows users at the env fallback (still valid; this PR makes the default path work too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)