### PR TITLE
chore(tests): 孤儿基线 60 → 58（qa-rfc024 / qa-rfc027 已接进 CI）

### DIFF
--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -14,9 +14,7 @@
 
 qa-222-cross-host-attachments
 qa-hub-18-delivery-semantics
-qa-rfc024-config-apply
 qa-rfc026-create-node
-qa-rfc027-stop-delete
 qa-rfc028-provider-probe
 test-rfc029-pr1-registration
 test-rfc029-pr2-acp-shim


### PR DESCRIPTION
`check-test-suite-registration.py` 每次跑都会在 note 里点名这两条已经不再是孤儿。核过它们**真的**已经被引用，不是"看起来像"：

- `.github/workflows/qa.yml:103-104` / `:268-269` —— 两处 `paths:` 过滤
- `.github/workflows/qa.yml:533-544` —— `Build qa-rfc024-config-apply` / `Run …` 步骤

楼层只降不回填，符合这个文件自己写的立场：基线是**上限**不是目标，作用是让**新增**变红而不是让**存量**变红。

门：

```
suites=230 registered=159 exempt=13 orphans=58 baseline=58 new=0   rc=0
--selftest 10/10
```

（在 #1503 里我提过这条与那个 PR 无关、在干净 `origin/main` 上同样提示，所以单开在这里。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)