### PR TITLE
fix(agent-node): 一个可选遥测字段的形状分歧，不该弄死整个节点（#1225 硬化）

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -75,6 +75,7 @@ import {
   PendingReplyQueue,
   type PendingReply,
 } from "./reply-reliability";
+import { isTelemetrySchemaRejection, withoutOptionalTelemetry } from "./register-telemetry-fallback";
 import { resolveGrokAcpTimeout } from "./runtime/grok-build-acp/timeout-resolve";
 import {
   GROK_COPRESENCE_PROFILE_ENV,
@@ -1402,7 +1403,7 @@ const register = async () => {
   const activeSessionId = RUNTIME === "grok"
     ? grokSessionId
     : SESSION_ID || undefined;
-  const result = await callCommHub("report_status", {
+  const payload = {
     resume_id: RESUME_ID, alias, status: "idle",
     server: osHostname(), hostname: osHostname(),
     agent: RUNTIME_AGENT_LABEL, project_dir: process.cwd(),
@@ -1425,7 +1426,23 @@ const register = async () => {
       ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED,
       ownerNodeId: NODE_ID || undefined,
     }),
-  });
+  };
+  // 🔴 启动注册是 `await register()`（本文件底部、顶层、**无 catch**），所以这里
+  //    抛出什么都会让整个进程退出。#1225 实测到的那次就是这样：hub 的
+  //    `host.ip` 少了 `.nullable()`，一台没有非回环 IPv4 的机器上节点直接起不来。
+  //    hub 与 agent-node 分开发版，谁先升都可能出现遥测字段形状对不上 ——
+  //    一个纯展示用的字段不该有能力让节点起不来。
+  //    判据刻意窄（见 register-telemetry-fallback.ts）：只在 -32602 且被拒路径
+  //    落在可选遥测块里才兜底；必需字段被拒仍然照抛 —— 那是本节点自己的 bug，
+  //    盖住它比崩掉更糟。
+  let result;
+  try {
+    result = await callCommHub("report_status", payload);
+  } catch (e) {
+    if (!isTelemetrySchemaRejection(e)) throw e;
+    warn(`[register] hub 拒了可选遥测字段(${e instanceof Error ? e.message : String(e)})；去掉遥测重试一次`);
+    result = await callCommHub("report_status", withoutOptionalTelemetry(payload));
+  }
   // Server is authoritative: if it told us a canonical alias different
   // from what we just sent, treat that as a snapshot update so the
   // resolver doesn't wait another 30 s to reflect it.

--- a/agent-node/src/register-telemetry-fallback.test.ts
+++ b/agent-node/src/register-telemetry-fallback.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  OPTIONAL_TELEMETRY_KEYS,
+  isTelemetrySchemaRejection,
+  withoutOptionalTelemetry,
+} from "./register-telemetry-fallback";
+
+// 实测抓到的那条原文（#1225 复现容器，--network none）。
+const REAL = {
+  code: -32602,
+  message:
+    "tool isError: MCP error -32602: Input validation error: Invalid arguments for tool " +
+    "report_status: Invalid input: expected string, received null at host.ip",
+};
+
+describe("isTelemetrySchemaRejection", () => {
+  test("🔴 认得真实抓到的那条 host.ip 拒绝", () => {
+    expect(isTelemetrySchemaRejection(REAL)).toBe(true);
+  });
+
+  test("三个可选遥测块都算", () => {
+    for (const key of OPTIONAL_TELEMETRY_KEYS) {
+      expect(isTelemetrySchemaRejection({ code: -32602, message: `bad at ${key}.field` })).toBe(true);
+    }
+  });
+
+  test("🔴 必需字段被拒**不**兜底 —— 那是本节点自己的 bug，盖住比崩了更糟", () => {
+    expect(isTelemetrySchemaRejection({
+      code: -32602,
+      message: "Invalid input: expected string, received null at alias",
+    })).toBe(false);
+  });
+
+  test("🔴 只是正文里出现 host 这个词，不算 —— 判据要求带点号的路径", () => {
+    expect(isTelemetrySchemaRejection({
+      code: -32602, message: "cannot reach host, network unreachable",
+    })).toBe(false);
+  });
+
+  test("别的错误码一律不兜底（鉴权失败、传输错误都该照常抛）", () => {
+    expect(isTelemetrySchemaRejection({ code: 401, message: "unauthorized at host.ip" })).toBe(false);
+    expect(isTelemetrySchemaRejection({ code: -32603, message: "internal at host.ip" })).toBe(false);
+    expect(isTelemetrySchemaRejection({ message: "no code at host.ip" })).toBe(false);
+  });
+
+  test("码是字符串形态的 -32602 也认（JSON 里两种都见过）", () => {
+    expect(isTelemetrySchemaRejection({ code: "-32602", message: "x at host.ip" })).toBe(true);
+  });
+
+  test("非对象输入不炸", () => {
+    for (const v of [null, undefined, "boom", 42]) expect(isTelemetrySchemaRejection(v)).toBe(false);
+  });
+});
+
+describe("withoutOptionalTelemetry", () => {
+  test("只摘掉三个遥测块，别的字段原样保留", () => {
+    const params = {
+      resume_id: "r", alias: "a", status: "idle",
+      host: { ip: null }, process_telemetry: { rss: 1 }, external_schedules: { schedules: [] },
+    };
+    const out = withoutOptionalTelemetry(params) as Record<string, unknown>;
+    expect(Object.keys(out).sort()).toEqual(["alias", "resume_id", "status"]);
+  });
+
+  test("🔴 不改原对象 —— 重试路径不能顺手把调用方的负载改掉", () => {
+    const params = { alias: "a", host: { ip: null } };
+    withoutOptionalTelemetry(params);
+    expect(params.host).toEqual({ ip: null });
+  });
+});
+
+// 判据本身对了，还要证明它**接在了那条会打死进程的路径上**。
+// （"存在 / 挂上 / 真的触发"是三件事。）
+describe("register() 的接线", () => {
+  const cli = readFileSync(join(import.meta.dir, "cli.ts"), "utf8");
+
+  test("🔴 启动注册用了这个兜底，而不是别处", () => {
+    const reg = cli.indexOf("const register = async () => {");
+    expect(reg).toBeGreaterThan(-1);
+    const end = cli.indexOf("const reportStatus = async (", reg);
+    expect(end).toBeGreaterThan(reg);
+    const body = cli.slice(reg, end);
+    expect(body).toContain("isTelemetrySchemaRejection");
+    expect(body).toContain("withoutOptionalTelemetry(payload)");
+    // 不认得的错误必须原样抛 —— 否则"注册失败"会退化成一条 warn。
+    expect(body).toContain("if (!isTelemetrySchemaRejection(e)) throw e;");
+  });
+
+  test("兜底只用一次 —— 重试那次再失败就该抛，不许无限降级", () => {
+    const reg = cli.indexOf("const register = async () => {");
+    const end = cli.indexOf("const reportStatus = async (", reg);
+    const body = cli.slice(reg, end);
+    expect(body.split("withoutOptionalTelemetry").length - 1).toBe(1);
+  });
+});

--- a/agent-node/src/register-telemetry-fallback.ts
+++ b/agent-node/src/register-telemetry-fallback.ts
@@ -1,0 +1,41 @@
+// 启动注册不该被一个**可选遥测字段**的形状分歧弄死。
+//
+// 由 #1225 的诊断催生。实测到的那次：一台没有非回环 IPv4 的机器上，
+// `firstNonInternalIPv4()` 返回 null，而当时 hub 的 `host.ip` 只写了
+// `.optional()` 没写 `.nullable()`（已由 #1498 修好）。于是
+//
+//   MCP error -32602: Invalid input: expected string, received null at host.ip
+//
+// 被抛出，而 `await register()`（cli.ts 顶层、无 catch）让**整个 agent-node
+// 进程当场退出**——与 runtime 无关。
+//
+// #1498 修的是那一次的具体分歧。这里修的是**形状**：hub 与 agent-node 是两个
+// 独立发版的包，谁先升谁后升都可能出现「新节点发了旧 hub 不认的遥测字段」或
+// 反过来。一个**只用于展示**的字段，不该有能力让节点起不来。
+//
+// 🔴 但兜底必须窄。判据要求 -32602 **且** 被拒的路径落在可选遥测块里：
+//    如果 hub 拒的是 `alias` 这种必需字段，那是这个节点自己的调用有 bug，
+//    去掉遥测重试只会把它盖住，让一个真缺陷变成一条 warn 日志。
+
+/** report_status 里纯展示用、可以整块丢掉的字段。 */
+export const OPTIONAL_TELEMETRY_KEYS = ["host", "process_telemetry", "external_schedules"] as const;
+
+const INVALID_PARAMS = -32602;
+
+export function isTelemetrySchemaRejection(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code !== INVALID_PARAMS && String(code) !== String(INVALID_PARAMS)) return false;
+  const message = String((err as { message?: unknown }).message ?? "");
+  if (!message) return false;
+  // 路径形如 `at host.ip` / `at process_telemetry.rss_mb`。要求带点号，
+  // 这样正文里偶然出现 "host" 这个词不会误判成遥测块被拒。
+  return OPTIONAL_TELEMETRY_KEYS.some((key) => message.includes(`${key}.`));
+}
+
+/** 去掉可选遥测块之后的那份负载。原对象不改。 */
+export function withoutOptionalTelemetry<T extends Record<string, unknown>>(params: T): Partial<T> {
+  const out: Record<string, unknown> = { ...params };
+  for (const key of OPTIONAL_TELEMETRY_KEYS) delete out[key];
+  return out as Partial<T>;
+}


### PR DESCRIPTION
## 背景

#1225 的诊断里实测到：hub 的 `host.ip` 少了 `.nullable()`（根因已由 **#1498** 修掉），于是一台**没有非回环 IPv4** 的机器上，agent-node 一启动就收到

```
MCP error -32602: Invalid input: expected string, received null at host.ip
```

而 `agent-node/src/cli.ts` 底部的 `await register();` 是**顶层 await、没有 catch** —— 整个进程当场退出，与 runtime 无关。（同一个文件里 SSE 重连后的 re-register 反而写了 `.catch(...)`。）

**#1498 修的是那一次的具体分歧；这条修的是形状。** hub 与 agent-node 是两个**独立发版**的包，谁先升谁后升都可能出现「一方发了另一方不认的遥测字段」。一个**纯展示用**的字段不该有能力让节点起不来。

## 做法

`register()` 的 `report_status` 若被拒，且判定为**可选遥测块的 schema 分歧**，就去掉 `host` / `process_telemetry` / `external_schedules` 重试一次；否则原样抛。

## 🔴 判据刻意窄

要求 **`-32602`** 且**被拒路径落在可选遥测块里**（`host.` / `process_telemetry.` / `external_schedules.`，**带点号**）。两条限制各有理由，也各有反向断言：

| 限制 | 不加会怎样 |
|---|---|
| 必须是 `-32602` | 鉴权失败、传输错误也会被当成"遥测分歧"降级 |
| 路径必须落在遥测块里 | `at alias` 这种**必需字段**被拒也会被兜底 —— 那是本节点自己的调用有 bug，**盖成一条 warn 比崩掉更糟** |
| 路径必须带点号 | `cannot reach host, network unreachable` 里的 "host" 会被误判成遥测块被拒 |

**兜底只用一次**：重试那次再失败就抛，不做无限降级（有一条断言钉住 `withoutOptionalTelemetry` 在 `register()` 里只出现 1 次）。

`withoutOptionalTelemetry` **不改原对象** —— 重试路径不该顺手把调用方的负载改掉，也有断言。

## 测试

`agent-node/src/register-telemetry-fallback.test.ts` — **11 pass**：

- 9 条判据（含**实测抓到的那条原文**作为正例，以及必需字段 / 裸 "host" 词 / 其它错误码 / 无 code / 非对象输入五种反例）
- 2 条**接线**断言 —— 「判据对」和「接在了那条会打死进程的路径上」是两件事：断言 `register()` 函数体内用了它、不认得的错误 `throw e`、且兜底只出现一次。

**witnessed-red**：删掉 `if (!isTelemetrySchemaRejection(e)) throw e;` → 接线断言红（变异前 `cmp` 证明非 no-op，跑完逐字还原）。

推之前跑过的门：`check-test-file-coverage.py` rc=0（331 文件 / 0 漏网）、`check-doc-symbol-pins.py` 两个 doc-root 都 0 漂移、`check-doc-source-pins.py` rc=0。

## 说明

- 这条**只帮到升级之后的节点**；现网已经装好的那些是靠 #1498 的 hub 侧修复恢复的。两件事互补，不重复。
- 本地没有 `agent-node/node_modules`，所以只能证到"新增的相对导入解析得动"（`bun build` 的报错全部是 zod/undici 这类第三方依赖缺失，没有一条指向本 PR 的文件）。完整构建交给 CI 的 agent-node unit 套件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)