### PR TITLE
chore(release): bump —— server 0.9.0-preview.42 / agent-node 2.5.0-preview.52 / agent-network 2.3.0-preview.67

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1763,7 +1763,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.41";
+const PINNED_SERVER_VERSION = "0.9.0-preview.42";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.66",
+  "version": "2.3.0-preview.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.66",
+      "version": "2.3.0-preview.67",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.66",
+  "version": "2.3.0-preview.67",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.66";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.51";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.67";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.52";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.51",
+  "version": "2.5.0-preview.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.51",
+      "version": "2.5.0-preview.52",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.51",
+  "version": "2.5.0-preview.52",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -66,6 +66,10 @@ set -uo pipefail
 #   内容 = #1448 f1 门铃补偿(#1450) + #1451 opencode 回复解析(#1452) + #1286 对称收敛(#1453)
 #          + start_node stale-starting reaper(#1456) + send_desktop_message 诚实投递态(#1460)
 #   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
+# 2026-08-30: preview41 → preview42（跟随 PINNED_SERVER_VERSION；host.ip P bug）
+#   内容 = #1498 report_status 接受 host.ip=null —— 此前没有非回环 IPv4 的机器上
+#          agent-node 一启动就被 MCP -32602 打死（与 runtime 无关）
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 # 2026-08-30: preview40 → preview41（跟随 PINNED_SERVER_VERSION；消息批次）
 #   内容 = #1459 ① 全套：user_inbox 建表(#1481) + 写入落库(#1485)
 #          + ?scope=user 回读/ack/unread/回读脱敏(#1488) + 写读接缝回归(#1492)
@@ -73,7 +77,7 @@ set -uo pipefail
 #   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
 #      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
 #      在这里标出来，免得下一个人把这份历史当完整的读。
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview41"
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview42"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.66 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.67 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.66` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.67` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.66 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.67 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.66`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.67`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.42.md
+++ b/docs/tests/release-v0.9.0-preview.42.md
@@ -1,0 +1,56 @@
+# @sleep2agi/commhub-server 0.9.0-preview.42 — release notes
+
+一条修复，但它影响的是**节点能不能起来**，所以建议尽快升。
+
+- **`report_status` 接受 `host.ip = null`**（PR #1498）。此前 `host` 遥测里
+  `ip` 只写了 `.optional()` 没写 `.nullable()`，而 agent-node 的
+  `HostTelemetry` 类型本来就声明 `ip: string | null` ——
+  `firstNonInternalIPv4()` 在**没有非回环 IPv4 的机器**上返回 `null`。
+  于是那台机器上的 agent-node 一启动就收到
+
+  ```
+  MCP error -32602: Invalid input: expected string, received null at host.ip
+  ```
+
+  而 agent-node 的启动注册是顶层 `await register()` 且没有 catch ——
+  **整个节点进程当场退出，与 runtime 无关**（claude / codex / grok / opencode 一样）。
+
+🔴 **触发条件不是"在容器里"，是「这台机器没有非回环 IPv4」**：断网的笔记本、
+只有 loopback 的 CI runner、`--network none` 的容器都算。有正常 IPv4 的机器不受影响。
+
+🔴 **为什么修在 hub 侧**：只改发送方（agent-node 在 null 时不发这个 key）也能让新版本
+不崩，但**现网已经装好的 agent-node 正是受影响的那些**，它们不会因此被修好。
+改 hub 一侧，**已部署的节点不需要升级就恢复**。
+（发送方的额外硬化在 agent-node `2.5.0-preview.52`，两者互补：一个救现在，一个防将来。）
+
+同一个对象里四个数值字段本来就是 `.nullable().optional()`，两个字符串字段是唯一的例外
+—— 正确写法一直在隔壁那一行。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.67 @sleep2agi/agent-node@2.5.0-preview.52
+anet hub start
+```
+
+hub 自己由 `anet` 按 `PINNED_SERVER_VERSION` 拉起（本版 `0.9.0-preview.42`），
+通常不需要单独装 `@sleep2agi/commhub-server@0.9.0-preview.42`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.67
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1498 | #1225 诊断产物 | `report_status` 的 `host.hostname` / `host.ip` 改为 `.nullable()` |
+
+端到端证据（同一个容器、同一条命令，只差这一处改动）：修前 `❌ … within 30s` exit=1，
+修后 `✅ 共存节点就绪` exit=0。

--- a/docs/tests/release-v2.3.0-preview.67.md
+++ b/docs/tests/release-v2.3.0-preview.67.md
@@ -1,0 +1,53 @@
+# @sleep2agi/agent-network 2.3.0-preview.67 — release notes
+
+一条面向用户的改动：**`--copresence` 启动失败时，终于说得清是哪一步、去哪儿看。**
+
+- **OpenCode 共存启动失败的诊断**（PR #1500，#1225 验收 2）。此前失败只有一行
+
+  ```
+  [anet] ❌ OpenCode copresence server did not produce its attach launcher within 30s.
+  ```
+
+  真死因谁都拿不到，因为两条取证路径同时是空的：CLI 用 `tmux capture-pane` 取现场，
+  而等待循环的退出条件之一**就是**「bridge 会话已经没了」—— 会话一没，capture 必然是空；
+  agent-node 的日志文件里也没有（崩溃走 stderr）。
+
+  现在：bridge 的输出**落盘**到 `<node>/logs/copresence-bridge.log`（落盘的东西不随
+  tmux 会话消失），失败输出**区分「bridge 已经退出」和「bridge 还在跑」**（两者排查方向
+  完全不同），并带上落盘日志尾巴、完整日志路径、节点日志目录。两边都没输出时明说
+  「没有留下任何输出」，不留空白让人读成"没异常"。
+
+  实测：那条 `expected string, received null at host.ip`（即 `0.9.0-preview.42` 修的那个
+  P bug）现在直接打在终端上，而当初定位它花掉了一整个复现容器。
+
+- pin 链同步：`PINNED_SERVER_VERSION` → `0.9.0-preview.42`、
+  `PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.52`。
+
+**仅仓库侧、不在这个 npm 包里**（`files: ["dist"]`，说明白免得被读成产品改动）：
+#1501 / #1507 文档引用清理、#1503 新增 `--copresence` 端到端 CI 套件、#1505 孤儿基线收缩。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.67 @sleep2agi/agent-node@2.5.0-preview.52
+anet hub start
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.67
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+本版把 `PINNED_SERVER_VERSION` 升到 `0.9.0-preview.42`，`anet hub restart` 会拉起新版 hub
+（含 `host.ip` 那个 P bug 的修复 —— 没有非回环 IPv4 的机器上节点此前起不来）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1500 | #1225 验收 2 | `--copresence` 失败诊断：bridge 输出落盘 + 指认哪一步 + 日志路径 |
+| — | — | pin 链：`PINNED_SERVER_VERSION` → `.42`、`PAIRED_AGENT_NODE_VERSION` → `.52` |

--- a/docs/tests/release-v2.5.0-preview.52.md
+++ b/docs/tests/release-v2.5.0-preview.52.md
@@ -1,0 +1,43 @@
+# @sleep2agi/agent-node 2.5.0-preview.52 — release notes
+
+两条修复，一条守启动、一条修 Windows。
+
+- **一个可选遥测字段的形状分歧，不再弄死整个节点**（PR #1506）。启动注册是顶层
+  `await register()` 且没有 catch，所以 `report_status` 被拒会让**整个进程退出**。
+  `0.9.0-preview.42` 修的是当时那次具体分歧（`host.ip`）；这一条修的是**形状** ——
+  hub 与 agent-node 独立发版，谁先升都可能出现「一方发了另一方不认的遥测字段」，
+  而一个纯展示用的字段不该有能力让节点起不来。
+  现在若被拒且判定为**可选遥测块**的 schema 分歧，会去掉
+  `host` / `process_telemetry` / `external_schedules` 重试一次。
+  🔴 判据刻意窄：要求 `-32602` **且**被拒路径落在那三个块里（带点号）。
+  `at alias` 这种**必需字段**被拒仍然照抛 —— 那是本节点自己的调用有 bug，
+  盖成一条 warn 比崩掉更糟。兜底只用一次，不做无限降级。
+- **Windows daemon 的 ANET `path.conf` 默认位置改为 `%ProgramData%\anet-daemon`**
+  （PR #1504，修 #1491）。此前默认写的是 POSIX 的 `/etc/…`，在 Windows 上不成立。
+
+🔴 **和 hub 的关系**：#1506 只帮到**升级之后**的节点；**现网已经装好的**那些是靠
+`commhub-server 0.9.0-preview.42`（#1498）从 hub 侧恢复的。两件事互补，不重复 ——
+Windows 用户和 loopback-only 机器上的用户请两个都升。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.67 @sleep2agi/agent-node@2.5.0-preview.52
+anet node create
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.52
+cd ~/anodes && anet project restart
+```
+
+跑着的节点要重启才会拿到新 agent-node（#117）。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1506 | #1225 硬化 | 可选遥测块 schema 被拒 → 去掉重试一次；必需字段被拒仍照抛 |
+| #1504 | #1491 | Windows daemon `path.conf` 默认改 `%ProgramData%\anet-daemon` |

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.41",
+  "version": "0.9.0-preview.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.41",
+      "version": "0.9.0-preview.42",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.41",
+  "version": "0.9.0-preview.42",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.41' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.42' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## 三包 bump

| 包 | 从 | 到 | 进这个 tarball 的内容 |
|---|---|---|---|
| `@sleep2agi/commhub-server` | `0.9.0-preview.41` | **`.42`** | #1498 `report_status` 接受 `host.ip = null` |
| `@sleep2agi/agent-node` | `2.5.0-preview.51` | **`.52`** | #1506 可选遥测块被拒兜底 + #1504 Windows `path.conf` 默认位置 |
| `@sleep2agi/agent-network` | `2.3.0-preview.66` | **`.67`** | #1500 `--copresence` 失败诊断 + pin 链 |

**基线不是照转述**：三个 `from` 都用 `npm view <pkg> dist-tags.preview` 现取过（`.41` / `.51` / `.66`），与树里 `package.json` 逐个对上。
**内容也不是照转述**：逐包 `git log <上次 bump commit>..origin/main -- <pkg>/` 数出来的。

## 🔴 两处与派工清单不同，按量到的写

1. **「daemon env-fallback 硬化」不在 server .42 里。** `server/` 目录下这一段**只有 #1498 一条**；那条硬化是 **#1504，在 `agent-node/` 里**，已计入 `.52`。
2. **agent-network `.67` 只有 #1500 改到了包内容。** #1501 / #1503 / #1505 / #1507 分别落在 `docs-site/` / `tests/` / `docs/` 下，而 agent-network 的 `files` 是 `["dist"]` —— **它们不进这个 tarball**。release notes 里单列一节标明「仅仓库侧、不在这个 npm 包里」，免得用户把文档/CI 改动读成产品改动。

## pin 链

`scripts/sync-pinned-versions.sh <pkg> <ver> --apply`，三包各跑一次（先 dry-run 看 diff 再 apply），**没有手改**：

- `package.json` ×3、`package-lock.json` 顶层 `version` + `packages[""].version` ×3
- `PINNED_SERVER_VERSION` → `0.9.0-preview.42`
- `PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.52`、`PAIRED_AGENT_NETWORK_VERSION` → `2.3.0-preview.67`
- `tests/test766-bunx-preflight/run.sh` 里的字面量

**脚本不碰的三处，手改**：

1. `deploy/hub/hub-daemon.sh` 的 `RUNTIME_DIR`：`preview41` → `preview42`，按该文件惯例补一行历史（内容 + 回滚目标）；
2. `docs-site/docs/{,en/}guide/getting-started.md` 的版本戳：机器读的 `<!-- version-claim -->` **和**人读的那张表，中英**四处**；
3. `docs/tests/release-v{0.9.0-preview.42,2.5.0-preview.52,2.3.0-preview.67}.md` 三份 release notes。

## 本地按 CI 口径跑过的门

| 门 | 结果 |
|---|---|
| `check-hub-launcher-pin.py` | rc=0（launcher `preview42` == `PINNED_SERVER_VERSION` `preview.42`） |
| `check-doc-version-claims.py --package agent-network --version 2.3.0-preview.67 --verify-latest-from-npm` | rc=0（CI 的 gate-4 就是这条） |
| release.yml gate-3 的三条判据（`^## Install` / `^## Upgrade` / Install 块内含 `@<ver>`） | 三份 notes 逐个跑过，全过 |
| `package-version-consistency.test.ts` ×2 + `opencode-agent-node-pair.test.ts` | 10 pass / 0 fail |
| `check-doc-symbol-pins.py`（两个 doc-root）、`check-doc-source-pins.py` | 0 漂移 / rc=0 |

**顺带核了发版时最容易变假的那句**：getting-started 里「生成密码的 `server/src/auth.ts` 自 `.49` 发布起零提交」——`git log --since=2026-08-27T02:25Z -- server/src/auth.ts` 重数是 **0**，在 `.67` 上仍然成立，所以只改版本号、结论不动。

## 没做的事

**没有 trigger `release.yml`、没有实发 npm、没有碰生产。** 发布顺序（server → agent-node → agent-network）与 `-f publish=true` 由 @通信龙 编排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)