### PR TITLE
fix(grok-copresence): 换模型窗口改成「观察到轮转就关」+ 放宽上限（#1413 残留）

### DIFF
--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -928,6 +928,88 @@ describe("Grok copresence runtime integration", () => {
     }
   }, 15_000);
 
+  // #1413 残留：窗口的**关闭条件**。issue 报告人审计时点出，#1416 的正确性押在
+  // 「轮转发生在 ack 之后 3000ms 内」这条没实测过的假设上；轮转迟到就照旧崩。
+  // 下面三条钉的是改动后的两条性质：①观察到轮转就立刻关窗（防篡改**更早**恢复）
+  // ②窗口外的截断仍然 fatal（防篡改语义一字未改）。
+  test("🔴 窗口内观察到轮转后，窗口立刻关闭 —— 紧接着的第二次截断必须仍然 fatal (#1413 残留)", async () => {
+    const fixture = new RuntimeFixture();
+    let runtime: GrokCopresenceRuntimeSession | undefined;
+    try {
+      runtime = await openGrokCopresenceRuntime({ ...fixture.options(), model: "grok-4.5" });
+      await waitFor(() => runtime!.tuiReady);
+      await runtime.submit({ taskId: "warm", from: "reviewer", text: "hi", timeoutMs: 4_000 });
+      const chatPath = join(
+        grokSessionDirectory(fixture.grokHome, fixture.cwd, SESSION),
+        "chat_history.jsonl",
+      );
+      await waitFor(() => existsSync(chatPath) && readFileSync(chatPath).length > 0);
+      await Bun.sleep(150);
+
+      const decision = await runtime.switchModel("grok-4.6");
+      expect(decision).toMatchObject({ ok: true, route: "hot" });
+
+      // 第一次轮转：窗口内，应当 re-arm 并存活。
+      truncateSync(chatPath, 0);
+      await Bun.sleep(300);
+      expect(runtime.isRunning).toBe(true);
+
+      // 🔴 承重：窗口此刻应该**已经关了**（轮转已被观察到），
+      //    所以再来一次截断就是**篡改**，必须 fatal。
+      //    改动前窗口会一直开到 grace 到期，这一条会红。
+      await runtime.submit({ taskId: "second", from: "reviewer", text: "hi again", timeoutMs: 4_000 });
+      await waitFor(() => readFileSync(chatPath).length > 0, 4_000);
+      await Bun.sleep(100);
+      truncateSync(chatPath, 0);
+      await waitFor(() => !runtime!.isRunning, 5_000);
+      expect(runtime.isRunning).toBe(false);
+    } finally {
+      await runtime?.close();
+      await fixture.close();
+    }
+  }, 20_000);
+
+  test("🔴 从未开过窗口时截断 chat_history 仍然 fatal —— 防篡改语义没有被放宽", async () => {
+    const fixture = new RuntimeFixture();
+    let runtime: GrokCopresenceRuntimeSession | undefined;
+    try {
+      runtime = await openGrokCopresenceRuntime({ ...fixture.options(), model: "grok-4.5" });
+      await waitFor(() => runtime!.tuiReady);
+      await runtime.submit({ taskId: "warm", from: "reviewer", text: "hi", timeoutMs: 4_000 });
+      const chatPath = join(
+        grokSessionDirectory(fixture.grokHome, fixture.cwd, SESSION),
+        "chat_history.jsonl",
+      );
+      await waitFor(() => existsSync(chatPath) && readFileSync(chatPath).length > 0);
+      await Bun.sleep(150);
+      truncateSync(chatPath, 0);              // 没有任何换模型窗口
+      await waitFor(() => !runtime!.isRunning, 5_000);
+      expect(runtime.isRunning).toBe(false);  // 仍然 fatal
+    } finally {
+      await runtime?.close();
+      await fixture.close();
+    }
+  }, 20_000);
+
+  test("switchModel 的每条提前返回路径都不会留下开着的窗口（防泄漏）", async () => {
+    const fixture = new RuntimeFixture();
+    let runtime: GrokCopresenceRuntimeSession | undefined;
+    try {
+      runtime = await openGrokCopresenceRuntime({ ...fixture.options(), model: "grok-4.5" });
+      await waitFor(() => runtime!.tuiReady);
+      const internals = runtime as unknown as { modelSwitchInFlight: string | null };
+
+      expect(await runtime.switchModel("grok-4.5")).toMatchObject({ ok: false, code: "unchanged" });
+      expect(internals.modelSwitchInFlight).toBeNull();
+
+      expect(await runtime.switchModel("")).toMatchObject({ ok: false });
+      expect(internals.modelSwitchInFlight).toBeNull();
+    } finally {
+      await runtime?.close();
+      await fixture.close();
+    }
+  }, 15_000);
+
   test("continues exactly once across prefix-preserving atomic chat rewrites", async () => {
     const fixture = new RuntimeFixture();
     let runtime: GrokCopresenceRuntimeSession | undefined;

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -93,10 +93,25 @@ const MAX_TAIL_READ_BYTES = 4 * 1024 * 1024;
 const MAX_LIFECYCLE_LINE_BYTES = 256 * 1024;
 const MAX_PENDING_AUTOMATIC_PERMISSIONS = 64;
 const MAX_RESUME_AUDIT_BYTES = 64 * 1024 * 1024;
-// #1416 review — bounded grace after a hot model-switch ack before the tail-
-// tamper window closes, so a rotation grok emits a few ms AFTER the ACP
-// set_model ack is still recovered-by-rearm instead of hitting failFatal.
-const MODEL_SWITCH_HOT_GRACE_MS = 3000;
+// 换模型窗口的**硬上限**（#1413 残留）。
+//
+// #1416 用一个固定 3000ms 的 grace 覆盖「grok ack 了 set_model、几毫秒后才轮转
+// chat_history」。但 issue 报告人自己在审计里点出：整条正确性押在
+// **「轮转发生在 ack 之后 3000ms 内」**这条**没有实测过**的假设上 ——
+// 大会话 / 忙碌 session / grok 慢的时候轮转迟到，窗口已关，boundary error
+// 走回原来的 failFatal，**#1413 的原始现象照旧复现**。
+//
+// 这里改的是窗口的**关闭条件**，不只是它的长度：
+//   • 观察到轮转就**立刻关**（见 pollLogs 的 boundary 分支）——
+//     典型窗口从"固定 3s"变成"毫秒级"，防篡改检查恢复得**更早**，
+//     这是安全性上的**收紧**，不是放松；
+//   • 只有在**始终没观察到轮转**时才走到这个上限。
+//
+// 🔴 上限仍然是个猜的数（真机 ack→轮转时延我拿不到：需要一台真 grok 节点，
+//    而生产节点和别人在用的 grok 测试节点都不能碰）。所以这里只做两件能确定
+//    的事：把典型暴露时间**缩短**，把尾部风险窗口**拉长**。要把这个数变成
+//    实测值，仍需 issue 里写的那条真机时延测量。
+const MODEL_SWITCH_ROTATION_WINDOW_CAP_MS = 30_000;
 const UNIX_SOCKET_PATH_MAX_BYTES = 100;
 const GROK_TUI_READY_TEXT = "Shift+Tab:mode";
 const GROK_TUI_SHORTCUTS_TEXT = "Ctrl+x:shortcuts";
@@ -1189,9 +1204,21 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     const timer = setTimeout(() => {
       this.modelSwitchWindowTimer = null;
       if (this.modelSwitchInFlight === token) this.modelSwitchInFlight = null;
-    }, MODEL_SWITCH_HOT_GRACE_MS);
+    }, MODEL_SWITCH_ROTATION_WINDOW_CAP_MS);
     timer.unref?.();
     this.modelSwitchWindowTimer = timer;
+  }
+
+  /**
+   * 立刻关闭换模型窗口（轮转已被观察到，窗口的目的达成）。
+   * 定时器和 flag 一起清 —— 只清 flag 会留下一个稍后把**新**窗口关掉的定时器。
+   */
+  private closeModelSwitchWindow(): void {
+    if (this.modelSwitchWindowTimer) {
+      clearTimeout(this.modelSwitchWindowTimer);
+      this.modelSwitchWindowTimer = null;
+    }
+    this.modelSwitchInFlight = null;
   }
 
   private rearmJsonlTailsAfterModelSwitch(): void {
@@ -2508,7 +2535,12 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
       // === null) the original fatal path is unchanged: the tamper check holds.
       if (this.modelSwitchInFlight !== null && error instanceof GrokJsonlTailBoundaryError) {
         this.rearmJsonlTailsAfterModelSwitch();
-        this.log("[grok-copresence] re-armed JSONL tail after model-switch rotation (#1413)");
+        // 🔴 观察到轮转 = 这个窗口存在的理由已经兑现，**立刻关掉它**，
+        //    不要把它开满上限。窗口开着的每一毫秒,防篡改检查都是关掉的;
+        //    #1416 那版会一直开到 grace 到期,即便轮转早就发生过了。
+        //    早关是安全性上的收紧 —— 也正因为有它,上限才敢放宽到覆盖慢轮转。
+        this.closeModelSwitchWindow();
+        this.log("[grok-copresence] re-armed JSONL tail after model-switch rotation; window closed (#1413)");
         return;
       }
       const failureSubcode = error instanceof GrokJsonlTailBoundaryError


### PR DESCRIPTION
## 先说结论

**#1413 的核心修复早就在 main 上**（#1416 `5a2578df`，随 agent-node `preview.48` 发版）：换模型时主动 re-arm JSONL tail，并留一个 3000ms grace 兜住「ack 之后几毫秒才轮转」。本 PR **不动那一半**。

要收的是报告人自己在质量审计里留下的**残留**（也正是这条 issue 至今没关的原因）:

> 整条正确性押在**「轮转发生在 ack 之后 3000ms 内」**这条**从没实测过**的假设上。大会话 / 忙碌 session / grok 慢的时候轮转迟到，窗口已被定时器关掉，boundary error 走回原来的 `failFatal` —— #1413 的原始现象照旧复现。

## 改动：换掉窗口的**关闭条件**，不只是它的长度

**① 观察到轮转就立刻关窗。** `pollLogs` 的 boundary 分支在 re-arm 之后调 `closeModelSwitchWindow()`。

窗口开着的每一毫秒，防篡改检查都是关掉的 —— 而 #1416 那版会一直开到 grace 到期，**哪怕轮转早就发生过**。所以这一条是安全性上的**收紧**，不是放松。

**② 正因为有 ①，上限才敢放宽**：`MODEL_SWITCH_ROTATION_WINDOW_CAP_MS` 3000ms → 30s，覆盖迟到的轮转。

净效果：

| | 典型窗口（轮转按时到） | 尾部（轮转迟到） |
|---|---|---|
| 改前 | 固定 **3s** | > 3s 就崩 |
| 改后 | **毫秒级**（观察到即关） | 30s 内不崩 |

🔴 **上限仍然是个猜的数，常量注释里写明了**：真机 ack→轮转时延我拿不到 —— 需要一台真 grok 节点，而生产节点和别人正在用的 grok 测试节点都不能碰。所以这里只做两件**能确定**的事：把典型暴露时间缩短、把尾部风险窗口拉长。要把 30s 换成实测值，仍需 issue 里写的那条真机时延测量。

## 测试（照 issue 自己列的安全边界清单）

| 测试 | 钉的是什么 |
|---|---|
| 🔴 窗口内观察到轮转后**窗口立刻关闭** —— 紧接着的第二次截断必须仍然 fatal | 本 PR 的核心性质 |
| 🔴 从未开过窗口时截断 `chat_history` 仍然 fatal | 防篡改语义**一字未改** |
| `switchModel` 每条提前返回路径都不留下开着的窗口 | 防泄漏 —— 窗口泄漏 = 防篡改永久关闭，issue 里点名的**最大风险**（比崩节点严重） |

**witnessed-red**：把 `closeModelSwitchWindow()` 那一行拿掉 → 第一条红（变异前 `cmp` 证明非 no-op，跑完逐字还原）。

`grok-copresence/runtime.test.ts` 全套 **71 pass / 0 fail**。

## 🔴 一条我自己走过的弯路，写出来

我最初怀疑 **restart 分支**还会崩（#1413 的原始复现走的就是 restart），写了个探针在「新一代 TUI 起来时」轮转 —— 得到 `isRunning: false`，看起来坐实了。

**但对照组（不轮转）也是 `isRunning: false`。** fixture 在 restart 路由上本来就留不下一个活着的运行时。两边同红 ⇒「轮转」这个变量完全隐身，那个探针**零分辨力**。

先跑对照组，才没把一个 fixture artifact 报成产品缺陷。**所以本 PR 不含任何关于 restart 分支的结论** —— 那条既未被证实也未被证伪，需要一个能在 restart 后维持活运行时的 fixture（或真机）才谈得上。

## 建议：#1413 先别关

本 PR 把「窗口长度是个猜的数」从**唯一防线**降级成**兜底**（正常路径已不依赖它），但 issue 要的那条真机时延证据仍然缺。等有人能在可牺牲的隔离 grok 节点上测出 ack→轮转的时延分布，再带证据关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)