### PR TITLE
fix(hub): #1353 Fix ① gate create_node dispatch on daemon-reported can_create_nodes

### DIFF
--- a/server/src/create-node-blocked-gate.test.ts
+++ b/server/src/create-node-blocked-gate.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { db } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+// #1353 Fix ① — hub gates create_node dispatch on the daemon's
+// self-reported can_create_nodes bit. Before this, daemon reported
+// can_create_nodes=false (via #1371 + #1377) → hub stored it → nothing
+// read it → dispatch returned {ok:true, request_id} and pushed a
+// doorbell to a daemon that had already told hub it couldn't create
+// nodes. That's the exact "在线但静默失败" case the issue title reports.
+//
+// Vincent 2026-08-28 comment on #1353:
+//   "daemon 侧确知不可用时,hub 应当**拒绝派发**并返回可操作的错误,
+//    而不是发一个注定失败的 doorbell"
+//
+// 🔴 Pre-#1371 daemons (preview.55 and earlier) don't report the field
+// at all. That must NOT fail-closed — the guard is "known-blocked",
+// not "unknown-treated-as-blocked". Tested explicitly below.
+
+const NET = "net_1353_gate";
+const USER_ID = "u_1353_admin";
+const DAEMON_ID = "node_1353_daemon";
+const DAEMON_ALIAS = "gate-daemon";
+const DAEMON_TOK = "tok_1353_daemon";
+
+interface ToolHandler { (args: any, extra?: any): Promise<{ content: Array<{ type: "text"; text: string }> }>; }
+interface Reply { ok?: boolean; error?: string; blocked_reason?: string; request_id?: string; [k: string]: unknown; }
+
+function cleanup() {
+  try { db.run("DELETE FROM node_create_requests WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM audit_log WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM api_tokens WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER_ID]); } catch {}
+}
+beforeEach(cleanup);
+afterAll(cleanup);
+
+function seed(snapshot: object | string | null) {
+  db.run(
+    `INSERT INTO users (user_id, username, password_hash, role, created_at)
+     VALUES (?1, ?2, 'x', 'user', datetime('now'))`,
+    [USER_ID, USER_ID],
+  );
+  db.run(
+    `INSERT OR REPLACE INTO networks (network_id, network_name, owner_id, created_at)
+     VALUES (?1, ?1, ?2, datetime('now'))`,
+    [NET, USER_ID],
+  );
+  db.run(
+    `INSERT INTO network_members (user_id, network_id, role, joined_at)
+     VALUES (?1, ?2, 'admin', datetime('now'))`,
+    [USER_ID, NET],
+  );
+  const snap = snapshot === null
+    ? null
+    : (typeof snapshot === "string" ? snapshot : JSON.stringify(snapshot));
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, config_snapshot, hostname, created_at, updated_at, lifecycle_state)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'), datetime('now'), 'active')`,
+    [DAEMON_ID, DAEMON_ALIAS, DAEMON_ALIAS, NET, snap, `host-${DAEMON_ALIAS}`],
+  );
+  db.run(
+    `INSERT INTO api_tokens (token_id, user_id, network_id, scope, name, token_hash, expires_at, revoked_at)
+     VALUES (?1, ?2, ?3, 'network', ?4, ?5, NULL, NULL)`,
+    [DAEMON_TOK, USER_ID, NET, `node:${DAEMON_ALIAS}`, `hash_${DAEMON_TOK}`],
+  );
+}
+
+function tools(): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const out: Record<string, ToolHandler> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, _schema: any, handler: ToolHandler) => {
+    out[name] = handler;
+    return origTool(name, _desc, _schema, handler);
+  };
+  const origRegisterTool = server.registerTool?.bind(server);
+  if (origRegisterTool) {
+    server.registerTool = (name: string, _cfg: any, handler: ToolHandler) => {
+      out[name] = handler;
+      return origRegisterTool(name, _cfg, handler);
+    };
+  }
+  registerTools(
+    server, undefined,
+    /* enforceNetworkId */ NET,
+    /* enforceUserId */ USER_ID,
+    /* callerAlias */ null,
+    /* callerTokenIsNetwork */ true,
+    /* callerTokenId */ null,
+  );
+  return out;
+}
+
+async function call(handler: ToolHandler, args: any): Promise<Reply> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0].text) as Reply;
+}
+
+const spec = {
+  name: "child-1353",
+  runtime: "claude-agent-sdk",
+  model: "claude-sonnet-4-5",
+  flags: {},
+};
+
+describe("#1353 Fix ① — hub gates create_node on daemon-reported can_create_nodes", () => {
+  test("🔴 witnessed-red: blocked daemon (can_create_nodes=false + reason) → refuse with reason, NO dispatch", async () => {
+    seed({
+      role: "host_supervisor",
+      daemon_capabilities: {
+        runtimes_supported: ["claude-agent-sdk"],
+        can_create_nodes: false,
+        create_nodes_blocked_reason: "anet_bin_permission",
+      },
+    });
+    const t = tools();
+    const r = await call(t.create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_cannot_create_nodes");
+    expect(r.blocked_reason).toBe("anet_bin_permission");
+    // No request row inserted — hub must refuse BEFORE dispatch.
+    const rows = db.get<{ n: number }>(
+      "SELECT COUNT(*) AS n FROM node_create_requests WHERE daemon_node_id = ?1",
+      DAEMON_ID,
+    );
+    expect(rows?.n).toBe(0);
+  });
+
+  test("blocked daemon with each of the 4 reason codes surfaces that specific code", async () => {
+    const codes = ["anet_bin_identity", "anet_bin_source", "anet_bin_shape", "anet_bin_permission"];
+    for (const code of codes) {
+      cleanup();
+      seed({
+        role: "host_supervisor",
+        daemon_capabilities: {
+          runtimes_supported: ["claude-agent-sdk"],
+          can_create_nodes: false,
+          create_nodes_blocked_reason: code,
+        },
+      });
+      const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+      expect(r.error).toBe("daemon_cannot_create_nodes");
+      expect(r.blocked_reason).toBe(code);
+    }
+  });
+
+  test("blocked with .40-shape 'anet_bin_pin_unresolved' reason surfaces that literal (backcompat)", async () => {
+    // The Zod enum in tools.ts still accepts this coarse pre-#1377 code
+    // because agent-node@2.5.0-preview.40 daemons in the wild still emit
+    // it. If we ever swallow it into "unknown", those daemons' user
+    // messages get worse than they already are.
+    seed({
+      role: "host_supervisor",
+      daemon_capabilities: {
+        runtimes_supported: ["claude-agent-sdk"],
+        can_create_nodes: false,
+        create_nodes_blocked_reason: "anet_bin_pin_unresolved",
+      },
+    });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.blocked_reason).toBe("anet_bin_pin_unresolved");
+  });
+
+  test("blocked with NO reason field → fallback 'anet_bin_unknown' (defensive)", async () => {
+    seed({
+      role: "host_supervisor",
+      daemon_capabilities: {
+        runtimes_supported: ["claude-agent-sdk"],
+        can_create_nodes: false,
+        // no create_nodes_blocked_reason
+      },
+    });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.error).toBe("daemon_cannot_create_nodes");
+    expect(r.blocked_reason).toBe("anet_bin_unknown");
+  });
+
+  test("can_create_nodes=true daemon dispatches normally (gate must not false-positive on healthy daemon)", async () => {
+    seed({
+      role: "host_supervisor",
+      daemon_capabilities: {
+        runtimes_supported: ["claude-agent-sdk"],
+        can_create_nodes: true,
+      },
+    });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    // Doesn't matter whether downstream dispatch succeeds — the point
+    // is that THIS gate did not reject. If reject, r.error would be
+    // "daemon_cannot_create_nodes".
+    expect(r.error).not.toBe("daemon_cannot_create_nodes");
+  });
+
+  test("🔴 pre-#1371 compat: snapshot with NO can_create_nodes field passes through (must NOT fail-closed)", async () => {
+    // preview.10 through preview.55 daemons never report this field.
+    // If we fail-closed on undefined we silently break every in-flight
+    // daemon that hasn't upgraded. Guard is "known-blocked", not
+    // "unknown-treated-as-blocked".
+    seed({
+      role: "host_supervisor",
+      daemon_capabilities: {
+        runtimes_supported: ["claude-agent-sdk"],
+        // no can_create_nodes at all
+      },
+    });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.error).not.toBe("daemon_cannot_create_nodes");
+  });
+
+  test("pre-#1371 compat: snapshot with no daemon_capabilities at all → passes through", async () => {
+    seed({ role: "host_supervisor" });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.error).not.toBe("daemon_cannot_create_nodes");
+  });
+
+  test("pre-#1371 compat: NULL config_snapshot passes through (very old daemon shape)", async () => {
+    seed(null);
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.error).not.toBe("daemon_cannot_create_nodes");
+  });
+
+  test("malformed config_snapshot: permissive fallthrough (mirrors runtimes_supported catch), no crash", async () => {
+    seed("{not json");
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.error).not.toBe("daemon_cannot_create_nodes");
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3207,6 +3207,41 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "cross_network_node" }) }] };
       }
 
+      // #1353 Fix ① — daemon self-declared "I can't create nodes right now"
+      // is now a dispatch-time gate, not just a stored fact. Before this,
+      // daemon reported `daemon_capabilities.can_create_nodes=false` (via
+      // #1371 + #1377), hub stored it in config_snapshot, and then no
+      // consumer read it — dispatch still returned `{ok:true, request_id}`
+      // and pushed an SSE doorbell to the broken daemon. That's the exact
+      // "在线但静默失败" case the issue title reports.
+      //
+      // Vincent's own 2026-08-28 comment on #1353 authorizes this shape:
+      // "daemon 侧确知不可用时,hub 应当**拒绝派发**并返回可操作的错误,
+      //  而不是发一个注定失败的 doorbell".
+      //
+      // 🔴 Pre-#1371 compat: a daemon that has NOT reported
+      // `can_create_nodes` at all leaves the field UNDEFINED in the
+      // snapshot. Do NOT fail-closed on undefined — that would silently
+      // start rejecting every daemon on the old (preview.10 through .55
+      // roughly) shape. Only `=== false` gates; `=== true` and `undefined`
+      // both pass through (new-guard-matches-existing-stance).
+      try {
+        const snap = daemon.config_snapshot ? JSON.parse(daemon.config_snapshot) : null;
+        const caps = snap?.daemon_capabilities;
+        if (caps && caps.can_create_nodes === false) {
+          const reason: string = (typeof caps.create_nodes_blocked_reason === "string"
+            && caps.create_nodes_blocked_reason.length > 0)
+            ? caps.create_nodes_blocked_reason
+            : "anet_bin_unknown";
+          return { content: [{ type: "text" as const, text: JSON.stringify({
+            ok: false,
+            error: "daemon_cannot_create_nodes",
+            blocked_reason: reason,
+            daemon_node_id,
+          }) }] };
+        }
+      } catch { /* malformed snapshot: permissive, mirrors L3230 fallthrough */ }
+
       // Read daemon's host_supervisor capability + allowlist from its
       // last reported config_snapshot. PR3 (#338) canonical path is
       // `daemon_capabilities.runtimes_supported` (RFC-026 §9.3).


### PR DESCRIPTION
Fixes the "hub 侧不读" half of [#1353](https://github.com/sleep2agi/agent-network/issues/1353). Pinned to `origin/main = 12799587`.

## What was already done vs. what wasn't

The **报**-side (daemon computes + reports capability) closed in main via #1371 + #1377 since 2026-08-28:
- `daemonCreateCapability()` in `agent-node/src/cli.ts:192` computes `{ok, reason: <4 codes | anet_bin_unknown>}` at startup by running `loadAndVerifyAnetBin()`
- Threaded through `buildConfigSnapshot()` → `daemon_capabilities.can_create_nodes / create_nodes_blocked_reason`
- Reported via `report_status` with masked reason (only enum code, never full path)
- Hub Zod schema at `server/src/tools.ts:614/631` accepts + stores in `config_snapshot`

The **读**-side had **zero consumers**:
- `create_node` tool at `server/src/tools.ts:3187+` grepped for `can_create_nodes` → 0 hits. Still dispatched to blocked daemons and returned `{ok:true, request_id}`.
- `/api/host-supervisors` REST endpoint didn't surface the field. Dashboard picker still showed blocked daemons as online.
- No dashboard consumer anywhere in the repo.

Canonical "gate exists → wired → **actually triggers**" split — the first two were true, the third wasn't.

Vincent's own 2026-08-28 comment on #1353 authorizes this exact shape:
> \"daemon 侧确知不可用时,hub 应当**拒绝派发**并返回可操作的错误,而不是发一个注定失败的 doorbell\"

## Scope (per 通信龙 2026-08-29 decision)

**In this PR:** Fix ① only — hub `create_node` refuses dispatch when daemon reports `can_create_nodes === false`.

**Not in this PR (explicit follow-ups):**
- **Fix ②** — `/api/host-supervisors` REST surfacing so dashboard picker can filter. Couples with dashboard client; belongs on that PR line.
- **Fix ③** — pin persistence across daemon restart on rootless machines. Vincent explicitly deferred (\"等 @vansin 定方向再开工\") — 3 candidates in his final scope comment.

## Fix

`server/src/tools.ts:3209` (after daemon-exists + sec1Ok, before runtimes/max-children reads):

\`\`\`ts
try {
  const snap = daemon.config_snapshot ? JSON.parse(daemon.config_snapshot) : null;
  const caps = snap?.daemon_capabilities;
  if (caps && caps.can_create_nodes === false) {
    const reason: string = (typeof caps.create_nodes_blocked_reason === \"string\"
      && caps.create_nodes_blocked_reason.length > 0)
      ? caps.create_nodes_blocked_reason
      : \"anet_bin_unknown\";
    return { content: [{ type: \"text\" as const, text: JSON.stringify({
      ok: false,
      error: \"daemon_cannot_create_nodes\",
      blocked_reason: reason,
      daemon_node_id,
    }) }] };
  }
} catch { /* malformed snapshot: permissive, mirrors L3230 fallthrough */ }
\`\`\`

No downstream side-effect fires: no INSERT into `node_create_requests`, no SSE push, no audit row.

## 🔴 Pre-#1371 compatibility — the guard is \"known-blocked\", NOT \"unknown-treated-as-blocked\"

`preview.10` through ~`preview.55` daemons never report `can_create_nodes` at all. Failing closed on `undefined` would silently start rejecting every daemon that hasn't upgraded — exactly the *\"a new guard must match the product's existing stance, not tighten it\"* trap ([team memory](https://github.com/sleep2agi/agent-network) `feedback_a_new_guard_must_match_the_products_existing_stance_not_tighten_it`).

Only `caps.can_create_nodes === false` triggers. Explicit passthrough paths (all tested):
- Snapshot has `daemon_capabilities` but no `can_create_nodes` key
- Snapshot has no `daemon_capabilities` at all
- `config_snapshot` column is `NULL`
- `config_snapshot` is malformed JSON (permissive catch, mirrors the existing L3230 fallthrough for `runtimes_supported` parse)

## Tests — 9 new cases in `server/src/create-node-blocked-gate.test.ts`

1. **🔴 witnessed-red**: blocked daemon → refuse with reason, `count(node_create_requests) = 0` after the call (proves gate fires BEFORE any side-effect).
2. All 4 categorized reason codes surface correctly (identity / source / shape / permission).
3. `.40`-shape `anet_bin_pin_unresolved` (coarse pre-#1377) still surfaces as-is — matches the compat comment in the Zod enum.
4. Blocked with NO reason field → fallback `anet_bin_unknown`.
5. `can_create_nodes=true` daemon dispatches normally (gate must not false-positive on healthy daemon).
6. **🔴 pre-#1371 compat**: snapshot with no `can_create_nodes` key → passes.
7. Pre-#1371 compat: no `daemon_capabilities` at all → passes.
8. Pre-#1371 compat: NULL `config_snapshot` → passes.
9. Malformed `config_snapshot` → permissive fallthrough, no crash.

Test infra follows the same `registerTools` + `McpServer.tool = capturing shim` pattern as `stop-delete-node.test.ts` — real handlers, real auth context, real DB.

## Witnessed-red — body-only revert of the gate block

\`\`\`
Fixed body:     9 pass / 0 fail / 20 expect() calls
Reverted body:  5 pass / 4 fail /  9 expect() calls
\`\`\`

The 4 failures are exactly the tests that positive-assert refusal (🔴 witnessed-red + code-sweep + backcompat literal + fallback code). The 5 passes on revert are the 5 pass-through tests — which **should** still pass under the reverted body, because reverting the gate means \"everything passes through\", which is what the passthrough tests assert independently. Signal isolated to precisely what the gate does.

## Adjacent test regression check

`create-node-tool-schema.test.ts` + `stop-delete-node.test.ts` (surrounding create_node flow + node lifecycle handlers):

\`\`\`
38 pass / 0 fail / 134 expect() calls — unchanged in both directions
\`\`\`

## Deploy risk

Additive-only:
- Adds one new error shape (`error: \"daemon_cannot_create_nodes\"`) that previously never came out of this handler
- Callers doing `if (r.ok) { … }` continue to work — the new refusal has `ok:false`
- Callers reading `r.error` need to know the new value; the value is descriptive
- No schema change (uses fields daemons have been reporting since #1371 preview.56+)
- No DB migration
- No SSE / event stream change

Pre-#1371 daemons' behavior is byte-identical to before this PR (they don't report the field, so the gate branch is never entered).

## Related

- #1353 (this issue) — daemon 重启即丢 ANET_BIN_ABS ⇒ create_node 静默失败
- #1371 (PR #1371) — the 报-side (daemon reports capability)
- #1377 — four-code taxonomy that this fix's `blocked_reason` surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)