### PR TITLE
fix(side-thread): reconcile 出 turnId 后也绑定已存在的 live execution（#1449 f3，最后一条）

### DIFF
--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -234,6 +234,62 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
   });
 
+  // #1449 f3 —— reconcile 出 turnId 之后，**已存在的 live** 也必须被绑上。
+  // 原来只有 `!live` 分支绑定，于是这条路上终态既不触发、也不计入 dropped：
+  // 订阅方无声地永远等下去。两个到达顺序都要覆盖。
+  test("🔴 reconcile 之后到达的终态必须触发（live 已存在时也要绑 byTurn）", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "f3a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const dropped: string[] = []; const terminal: any[] = [];
+    adapter.subscribeDropped((reason) => dropped.push(reason)); adapter.subscribe((event) => terminal.push(event));
+    client.holdTurnStart = true;
+    const input = { sideThreadId: "f3a", attemptId: "att", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    await expect(adapter.start(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    client.threads.get(fork.derivedThreadId).turns.push({ id: "turn-recovered", items: [{ type: "userMessage", clientId: "anet-side:f3a:att" }] });
+    await expect(adapter.start(input)).resolves.toEqual({ turnId: "turn-recovered" });
+
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: "turn-recovered", status: "completed" } });
+    await Bun.sleep(10);
+    expect(terminal).toHaveLength(1);
+    // 🔴 顺带钉住那个**最难发现**的性质：修复前它既不触发终态、
+    //    也不进 dropped —— 连一个可观测的信号都没有。
+    expect(dropped).not.toContain("unowned-terminal");
+  });
+
+  test("🔴 reconcile **之前**就到的终态被缓冲，绑定之后必须冲出来", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "f3b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const terminal: any[] = [];
+    adapter.subscribe((event) => terminal.push(event));
+    client.holdTurnStart = true;
+    const input = { sideThreadId: "f3b", attemptId: "att", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    await expect(adapter.start(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    client.threads.get(fork.derivedThreadId).turns.push({ id: "turn-early", items: [{ type: "userMessage", clientId: "anet-side:f3b:att" }] });
+
+    // 终态先到（此时还没 reconcile，byTurn 里没有它）
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: "turn-early", status: "completed" } });
+    await Bun.sleep(5);
+    expect(terminal).toHaveLength(0);
+
+    await expect(adapter.start(input)).resolves.toEqual({ turnId: "turn-early" });
+    await Bun.sleep(10);
+    expect(terminal).toHaveLength(1);   // 绑定把缓冲的那条冲了出来
+  });
+
+  test("reconcile 不认领别人的 turn（归属判据与 restoreExecution 一致）", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "f3c", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    // 另一个 attempt 先把这个 turn 占了
+    const other = { sideThreadId: "f3c", attemptId: "other", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    const otherStarted = await adapter.start(other);
+    client.holdTurnStart = true;
+    const mine = { sideThreadId: "f3c", attemptId: "mine", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    await expect(adapter.start(mine)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    // 把**别人那条 turn** 伪装成我的 clientId 写进历史
+    client.threads.get(fork.derivedThreadId).turns.push({ id: otherStarted.turnId, items: [{ type: "userMessage", clientId: "anet-side:f3c:mine" }] });
+    await expect(adapter.start(mine)).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+  });
+
   test("accepted and ambiguous start/interrupt/archive/delete operations never repeat their RPC", async () => {
     const { client, adapter } = make({ identityTimeoutMs: 5 });
     const fork = await adapter.fork({ sideThreadId: "ops", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -551,9 +551,56 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     if (current.state === "accepted" || current.state === "reconciling") {
       this.put({ ...current, state: "reconciled", result: { ...current.result, turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
     }
+    // #1449 f3 —— `live` 存在时也必须把 turn 绑上去。
+    // 原来只有 `!live` 分支调 restoreExecution，于是「有一个陈旧的 live、但它
+    // 从没回显过身份（live.turnId === undefined）」这条路上：turnId 从持久历史
+    // reconcile 出来了、却没人写进 byTurn，live.turnId 也仍是 undefined。
+    // 之后那条 turn/completed 在 byTurn 里 miss，被当成「身份还没回显」缓冲起来
+    // —— **既不触发终态，也不计入 dropped**，订阅方就这么无声地等下去。
+    // 实测（本文件的 witnessed-red）：byClientId=1 / byTurn=0 / live.turnId=undefined
+    // / terminal=0 / dropped=[]。
     if (!live) this.restoreExecution(input, clientUserMessageId, turnId, matchedTurn);
+    else this.adoptReconciledTurn(live, input, turnId);
     return { turnId };
   }
+  /**
+   * 把 reconcile 出来的 turnId 绑到**已存在的** live execution 上（#1449 f3）。
+   *
+   * 与 restoreExecution 保持同一套归属判据：别人的 turn 不认领；live 自己已经
+   * 有一个不同的身份时也不认领 —— 那说明 reconcile 与回显对不上，宁可失败也
+   * 不要静默改写一个已绑定的身份。
+   */
+  private adoptReconciledTurn(live: Execution, input: { sideThreadId: string; attemptId: string; derivedThreadId: string }, turnId: string): void {
+    const key = turnKey(input.derivedThreadId, turnId);
+    const owned = this.byTurn.get(key);
+    if (owned && owned !== live && (owned.sideThreadId !== input.sideThreadId || owned.attemptId !== input.attemptId)) {
+      throw new SideThreadConflictError("reconciled Codex turn is already owned by another attempt");
+    }
+    if (live.turnId && live.turnId !== turnId) {
+      throw new SideThreadConflictError("reconciled Codex turn contradicts the live execution identity");
+    }
+    live.turnId = turnId;
+    clearTimeout(live.identityTimer);
+    live.resolveIdentity(turnId);
+    this.byTurn.set(key, live);
+    live.readyForTerminal = true;
+    // 终态可能**已经先到**。它会落在两个地方之一，两个都要冲：
+    //   • execution.pendingTerminal —— 已绑定但 readyForTerminal 还是 false 时；
+    //   • earlyTerminals —— byTurn 还没有这个 key 时（本条修复之前，reconcile
+    //     路径上**永远**是这一个；而 earlyTerminals 此前只有 onStarted(:366)
+    //     的身份回显路径会去取，reconcile 路径从不取，于是它就烂在那里）。
+    // 只冲前者的话，这条修复只覆盖「终态后到」那一半。
+    const early = this.earlyTerminals.get(key);
+    if (early !== undefined) {
+      this.earlyTerminals.delete(key);
+      setTimeout(() => this.onCompleted(early), 0);
+    } else if (live.pendingTerminal) {
+      const pending = live.pendingTerminal;
+      live.pendingTerminal = undefined;
+      setTimeout(() => this.onCompleted(pending), 0);
+    }
+  }
+
   private restoreExecution(input: { sideThreadId: string; attemptId: string; derivedThreadId: string },
     clientUserMessageId: string, turnId: string, turn?: RuntimeTurn): void {
     const key = turnKey(input.derivedThreadId, turnId);


### PR DESCRIPTION
## 功能确认：#1449 三条里两条已在 main 上，f3 还在

按老规矩先确认不重造（`main` @ `f9a2f1ac`）：

| 发现 | 状态 | 坐标 |
|---|---|---|
| **f1** 一个 turn 多条 `agentMessage` 只发最后一条 → 回复截断 | ✅ **已修** | `codex-app-server-adapter.ts:377-392` —— 用 **phase 过滤**（只有 `final_answer` 能覆盖缓冲区），对齐主 bridge 的既有做法；而且刻意**朝安全方向宽**：`phase` 为 null/缺失时仍然覆盖，因为严格要求 `=== "final_answer"` 会让终态变空串、被上层读成"失败" |
| **f2** open/bootstrap 抛异常孤儿化自己 spawn 的子进程 | ✅ **已修** | `codex-app-server/runtime.ts:167-168` 的 `#1449` 注释 + `:241-243` 的 `catch { proc.kill() }`（只在 owned-child 分支） |
| **f3** `reconcileStart` 留下未绑定的 turn → 终态丢弃、任务卡死 | 🔴 **仍在**，本 PR 修 | 见下 |

## f3 比 issue 描述的更难发现

原来 `reconcileStart` 只有 `!live` 分支调 `restoreExecution` 去绑 `byTurn`。「有一个陈旧 `live`、但它从没回显过身份（`live.turnId === undefined`）」这条路上：`turnId` 从持久历史 reconcile 出来了，却没人写进 `byTurn`，`live.turnId` 也仍是 `undefined`。之后那条 `turn/completed` 在 `byTurn` miss ——

🔴 **它既不触发终态，也不计入 `dropped`。** issue 猜的是「被 buffer 或 `dropped("unowned-terminal")`」，实际是前者：`onCompleted` 看到该 thread 上有 live execution，就把事件塞进 `earlyTerminals` 等身份回显；而 `earlyTerminals` **只有 `onStarted:366` 会去取**，reconcile 路径从不取。于是订阅方无声地永远等下去，**连一个可观测的计数都没有**。

**探针实测**（不是读代码推的）：

| | `byClientId` | `byTurn` | `live.turnId` | terminal | dropped |
|---|---|---|---|---|---|
| 改前 | 1 | **0** | **undefined** | **0** | `[]` |
| 改后 | 1 | 1 | `turn-recovered` | **1** | `[]` |

## 修法

新增 `adoptReconciledTurn()`，与 `restoreExecution` 用**同一套归属判据**：

- 别人的 turn 不认领（`SideThreadConflictError`）；
- `live` 已有一个**不同**身份时也不认领 —— 那说明 reconcile 与回显对不上，宁可失败也不静默改写一个已绑定的身份。

绑定之后冲**两个**可能的缓冲位置：`earlyTerminals`（`byTurn` 还没这个 key 时终态落这里，也就是本条路径的实际情况）和 `execution.pendingTerminal`。只冲后者的话，这条修复只覆盖「终态后到」那一半 —— 见下面的变异 B。

## 测试与 witnessed-red

3 条，两个到达顺序都覆盖：

1. 🔴 reconcile **之后**到达的终态必须触发（并断言它没有退化成 `unowned-terminal` —— 钉住"连信号都没有"这个最难发现的性质）
2. 🔴 reconcile **之前**就到的终态被缓冲，绑定之后必须冲出来
3. reconcile 不认领别人的 turn

**两个方向的变异**（变异前 `cmp` 证明非 no-op，跑完逐字还原）：

| 变异 | 结果 |
|---|---|
| 拿掉 `adoptReconciledTurn` 调用 | **3 条全红** |
| 只冲 `pendingTerminal`、不冲 `earlyTerminals` | 「终态先到」那条红 |

`agent-node/src/runtime/side-thread/` 全目录 **63 pass / 0 fail**。推之前也跑了 doc 门（两个 doc-root 0 漂移、`check-doc-source-pins` rc=0、test-file-coverage 334/0 漏网）。

## 关于 #1449 的关闭

f1/f2/f3 三条这下齐了，本 PR 合入后我认为可以关。但 issue 里 f1 留了一句「**影响置信度**：实际是否触发取决于 codex 当前 pin 版本一个 turn 是否真发 >1 条 `agentMessage`，建议一次性探针确认」—— 那条探针**我没做**，它要起一个真 codex app-server。f1 的修复本身不依赖这个答案（phase 过滤在任何条数下都正确），所以不阻塞；只是"这个 bug 在生产上到底触发了多少次"仍是未知。

🤖 Generated with [Claude Code](https://claude.com/claude-code)