### PR TITLE
fix(ci-gate): #1466 check-release-channel-assertions structural table-row match (drops whole-file substring)

### DIFF
--- a/.github/scripts/check-release-channel-assertions.py
+++ b/.github/scripts/check-release-channel-assertions.py
@@ -20,6 +20,29 @@ SOP 自己写着「加新断言时同时加进这张表」,而那条纪律靠人
 `latest`/`preview` 字样与一个具体版本号的行 —— 那就是信道断言的形状。
 每一个这样的文件都必须在 SOP 表里登记。**没登记 = 红。**
 
+## 🔴 判「已登记」用**结构化行**判,不用**全文子串**判(#1466)
+
+判据(判什么)是对的,取集(怎么算「已登记」)从头就写歪了 —— 早期用
+`f in sop`(整份文件 substring),于是**任何在 SOP 别处顺带提到那个路径的位置**
+(正文的例子、别的段落的引用、甚至同一个路径出现在 `### B. Frozen snapshots`
+下的「未 register」列表里)全都会让它算成已登记。
+
+这是 CLAUDE.md ⑤「判据 vs 取集」同族的洞。真实案例:2026-08-29 修 #1462
+之后仍有 `docs-site/docs/changelog.md` + `en/changelog.md` 两份被算成已登记 ——
+它们**不在**逐次发版重核表里,只是在 SOP 别处被提到。差额从「4」降到「2」
+只是巧合,不是取集变严了。
+
+现在改成:扫 SOP 里的 markdown 表格行,拿**第一格 backtick 里的路径**当已登记。
+一条路径被算「已登记」的前提是**它作为表格首格出现**,不再是「文本里出现过」。
+
+## 显式豁免(有意不追踪,不是漏了)
+
+`docs-site/docs/changelog.md` + 英文对应版是**版本钉死的历史记录** —— 那些「latest
+2.2.21 上……」的句子说的是当时发版那一刻的事,发新版**不会**让它们变假,反而登记进
+逐次发版重核表会让每次发版都要重核一堆早已冻结的历史记录 —— 变弱的清单下次就没
+人逐条核了。跟 docstring 里「不扫只出现版本号的行」同样的推理:**有意不追踪就显式
+写出来,别指望「因为漏配所以放行」这种巧合。**
+
 ## 🔴 刻意不做的两件事
 
 1. **不扫「只出现版本号」的行。** 那样会把带日期的实测记录也算进来
@@ -38,6 +61,47 @@ SOP = Path("docs/RELEASE-SOP.md")
 VERSION = re.compile(r"\b\d+\.\d+\.\d+(?:-preview\.\d+)?\b")
 CHANNEL = re.compile(r"\blatest\b|\bpreview\b", re.IGNORECASE)
 
+# #1466 — a table row's first cell is `| \`<path>\` |`. We accept an
+# optional leading `>` because RELEASE-SOP.md's registration table lives
+# inside a `>` blockquote (rendering choice, not semantics). The path
+# must match the docs-site tree exactly — no globs, no partial paths.
+#
+# 🔴 We require the ENTIRE first cell to be just a backtick-wrapped path.
+# A row like `| \`docs-site/docs/x.md\` （英文对应）| … | … |` would still
+# match, but a prose line that HAPPENS to start with `| \`…\`` (e.g. a code
+# example inside a paragraph) still gets picked up — that's very rare in
+# practice, and requiring the exact three-cell markdown table shape is
+# what turns this from "structural" into "brittle-to-prose-formatting".
+# The `.split("|")` shape check below asserts the row has at least the
+# three cells the table is documented to have — that's tight enough.
+REG_ROW = re.compile(r"^\s*>?\s*\|\s*`(docs-site/docs/[^`]+)`\s*\|")
+
+# #1466 — deliberately-untracked (see docstring "显式豁免" section).
+# Adding a path here is a decision, not a workaround: prove it's
+# frozen/historical and the sentence won't go false on release.
+EXEMPT: frozenset[str] = frozenset({
+    "docs-site/docs/changelog.md",
+    "docs-site/docs/en/changelog.md",
+})
+
+
+def parse_registered_paths(sop_text: str) -> set[str]:
+    """Return the set of docs-site paths that appear as the FIRST cell of a
+    markdown table row in `sop_text`. Structural match — a prose mention
+    of the path anywhere else in the SOP does NOT qualify."""
+    out: set[str] = set()
+    for line in sop_text.splitlines():
+        # Cheap shape filter first: a real table row has at least three
+        # cells (`|` shows up ≥ 3 times per row: opening + between cells +
+        # closing). Prose lines with a single backtick-wrapped path don't.
+        if line.count("|") < 3:
+            continue
+        m = REG_ROW.match(line)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
 def assertion_files() -> dict[str, list[int]]:
     found: dict[str, list[int]] = {}
     for p in sorted(DOCS.rglob("*.md")):
@@ -47,19 +111,89 @@ def assertion_files() -> dict[str, list[int]]:
                 found.setdefault(rel, []).append(i)
     return found
 
-def main() -> int:
+
+def selftest() -> int:
+    """Prove the parser + exemption logic works before the real scan runs.
+    Any change to `parse_registered_paths` or EXEMPT that breaks a real
+    case must trip a selftest first — otherwise the real scan below will
+    just print a number and exit 0 (a green byte-identical to a real one).
+    """
+    fixture = (
+        "# some SOP\n"
+        "\n"
+        "prose paragraph that mentions `docs-site/docs/prose-only.md`\n"
+        "in the flow of a sentence — this line has only 0 pipes\n"
+        "\n"
+        "> | 文件 | 行 | 断言 |\n"
+        "> |---|---|---|\n"
+        "> | `docs-site/docs/table-listed.md` | 42 | latest x.y.z 断言 |\n"
+        "> | `docs-site/docs/en/table-listed.md` | 42 | 同上(英文) |\n"
+        "\n"
+        "### B. Frozen snapshots\n"
+        "\n"
+        "- `docs-site/docs/frozen-listed.md` (bullet mention, NOT a table row)\n"
+        "- `docs-site/docs/changelog.md` / `docs-site/docs/en/changelog.md`\n"
+    )
+    reg = parse_registered_paths(fixture)
+    failures: list[str] = []
+    # Positive: table rows are counted.
+    for p in ("docs-site/docs/table-listed.md", "docs-site/docs/en/table-listed.md"):
+        if p not in reg:
+            failures.append(f"selftest: {p} should be counted (real table row) — parser missed it")
+    # Negative: prose / bullet mentions must NOT be counted (this is
+    # the exact class of false-positive #1466 reports).
+    for p in ("docs-site/docs/prose-only.md",
+              "docs-site/docs/frozen-listed.md",
+              "docs-site/docs/changelog.md",
+              "docs-site/docs/en/changelog.md"):
+        if p in reg:
+            failures.append(f"selftest: {p} should NOT be counted (prose mention) — parser false-positived")
+    # Exemption: changelog paths must be in EXEMPT even though prose
+    # mentions them (belt-and-braces: parser drops them via structural
+    # match, EXEMPT is the second line of defense in case someone later
+    # ALSO adds a changelog row to the SOP table by mistake).
+    for p in ("docs-site/docs/changelog.md", "docs-site/docs/en/changelog.md"):
+        if p not in EXEMPT:
+            failures.append(f"selftest: {p} should be in EXEMPT")
+    if failures:
+        for f in failures:
+            print(f"::error::{f}", file=sys.stderr)
+        return 1
+    print(f"selftest ok: parsed {len(reg)} row(s), {len(EXEMPT)} exempted")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--selftest":
+        return selftest()
+
     if not DOCS.is_dir() or not SOP.is_file():
         print("::error::取集塌了:找不到 docs-site/docs 或 RELEASE-SOP.md —— 拒绝通过", file=sys.stderr)
         return 2                                  # 说不清楚就不说「没问题」
     sop = SOP.read_text(encoding="utf-8")
+    registered = parse_registered_paths(sop)
+    if not registered:
+        print("::error::SOP 里一条表格行都没解析出来 —— 更可能是表格 shape 改了、判据没跟上", file=sys.stderr)
+        return 2
     found = assertion_files()
     if not found:
         print("::error::零命中。信道断言不可能一条都没有 —— 更可能是扫描范围错了", file=sys.stderr)
         return 2
-    missing = [f for f in found if f not in sop]
-    print(f"扫到带信道断言的文件 {len(found)} 个;RELEASE-SOP 已登记 {len(found) - len(missing)} 个")
+    missing = [f for f in found if f not in registered and f not in EXEMPT]
+    exempted_hits = [f for f in found if f in EXEMPT]
+    print(
+        f"扫到带信道断言的文件 {len(found)} 个;"
+        f"表格行登记 {len(found) - len(missing) - len(exempted_hits)} 个;"
+        f"显式豁免 {len(exempted_hits)} 个;"
+        f"未登记 {len(missing)} 个"
+    )
     for f in sorted(found):
-        mark = "MISS" if f in missing else "ok  "
+        if f in missing:
+            mark = "MISS"
+        elif f in EXEMPT:
+            mark = "SKIP"
+        else:
+            mark = "ok  "
         print(f"  {mark} {f}  行 {found[f][:6]}")
     if missing:
         print(f"\n::error::{len(missing)} 个文件带信道断言但没登记进 docs/RELEASE-SOP.md。", file=sys.stderr)
@@ -67,5 +201,6 @@ def main() -> int:
         return 1
     return 0
 
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -56,5 +56,10 @@ jobs:
       # targets were invisible, and both broken links in scope were among them.
       - run: python3 .github/scripts/check-docs-integrity.py --selftest
       - run: python3 .github/scripts/check-docs-integrity.py
+      # #1466 — selftest first. Real scan can be structurally green even
+      # when the parser is wrong: all real SOP paths appear SOMEWHERE in
+      # the file, so a substring-based parser rc=0 either way. The
+      # selftest fixture is the canary that catches parser regression.
+      - run: python3 .github/scripts/check-release-channel-assertions.py --selftest
       - name: 信道断言清单未登记即红
         run: python3 .github/scripts/check-release-channel-assertions.py


### PR DESCRIPTION
Fixes [#1466](https://github.com/sleep2agi/agent-network/issues/1466) — the gate decides \"file is registered in the release-recheck table\" via `f not in sop` (whole-file substring). Any prose mention of the path anywhere in the SOP counts — even in a bullet under a completely different section about a different sync mechanism.

Pinned to `origin/main = f9a2f1ac`.

## The bug on origin/main today

\`\`\`
$ python3 .github/scripts/check-release-channel-assertions.py
扫到带信道断言的文件 44 个;RELEASE-SOP 已登记 44 个
  ok   docs-site/docs/changelog.md  行 [5, 19, 25, 40, 51, 52]
  ok   docs-site/docs/en/changelog.md  行 [5, 19, 25, 45, 46, 62]
  ...
$ echo $?
0
\`\`\`

The table in `docs/RELEASE-SOP.md` has **42 rows** (verified by grep). The gate says **44 registered**. The excess 2 are `docs-site/docs/changelog.md` + `en/changelog.md`, which show up under `### B. Frozen snapshots` at SOP L193 — a section about the `sync-pinned-versions.sh` mechanism, unrelated to this gate:

\`\`\`markdown
下列路径当前未被 register:
- `docs-site/docs/changelog.md` / `docs-site/docs/en/changelog.md`
- `docs-site/docs/v0.8.0/**`（整套历史归档版本的 docs）
...
\`\`\`

Substring match happily counts these as registered. Same class as CLAUDE.md rule ⑤「判据 vs 取集」— the 判据 (what qualifies as a channel assertion) is correct; the 取集 (how \"registered\" is decided) is loose.

## Fix ① — structural table-row parse

New `parse_registered_paths(sop_text)` extracts paths from markdown table rows only:

\`\`\`python
REG_ROW = re.compile(r\"^\\s*>?\\s*\\|\\s*`(docs-site/docs/[^`]+)`\\s*\\|\")
\`\`\`

`>` optional (SOP puts the table inside a `>` blockquote). Cheap `line.count(\"|\") < 3` shape filter first so prose lines with a single backtick-wrapped path don't even hit the regex. A path only counts as registered if it appears as the first cell of a markdown table row.

## Fix ② — explicit exemption for changelog

Post-Fix ①, `changelog.md` × 2 would show as MISS (real red — genuine \"not tracked\"). Adding them to the recheck table would force every release to walk a growing pile of frozen historical records — a longer list is a weaker signal, and a weaker signal is the one people stop checking.

Same reasoning as the docstring's existing \"不扫只出现版本号的行\" exemption: 有意不追踪就显式写出来,别指望「因为漏配所以放行」这种巧合. Documented in the new \"显式豁免\" docstring section + gated by an `EXEMPT` frozenset.

## Selftest

New `--selftest` flag runs an embedded SOP fixture through `parse_registered_paths` and asserts:
- **Positive**: two paths in a `| \`path\` | col | col |` table are counted
- **Negative** (the exact bug): a prose sentence mention, a bullet list mention, and a \"different section header\" mention all NOT counted
- **Exemption**: changelog paths in `EXEMPT`

Failures print `::error::` + rc=1 so CI stops before the real scan.

## 🔴 Selftest is the canary the real scan can't be

Every real SOP path appears SOMEWHERE in the SOP text (they're all in the table). So the OLD substring-based `f not in sop` returns 0 missing on real SOP either way, whether the parser is correct or bugged. The fixture is what distinguishes — it constructs the \"in prose but NOT in table\" case that real SOP happens not to have for the exact 42 table-row paths.

## Workflow — selftest first, real scan after

`.github/workflows/docs-integrity.yml` gains a selftest step BEFORE the real scan (same shape as `check-docs-integrity`). Any regression to the parser or `EXEMPT` trips the selftest first, before the real scan produces its structurally-green output.

## Witnessed-red — body-only revert of `parse_registered_paths` to substring semantics

**Fixed body (parser structural + EXEMPT):**
\`\`\`
selftest ok: parsed 2 row(s), 2 exempted (rc=0)
real scan: 44 total; 42 table-row registered; 2 EXEMPT; 0 missing (rc=0)
\`\`\`

**Reverted body (parser reverts to substring — the bug):**
\`\`\`
selftest rc=1 with 4 explicit ::error:: lines naming exactly the 4
prose-mention paths the substring parser wrongly counts as registered.
Real scan STILL rc=0 (all real paths are substring-mentioned; that's
exactly why the fixture is needed and why the real scan alone can't
detect the class).
\`\`\`

Signal isolated to the parser body — `EXEMPT` + selftest fixture + `main()` wire-up all preserved across the revert.

## Post-fix output labels

New: `MISS` / `SKIP` (explicit exemption) / `ok` (table row). Old output was just `MISS` / `ok` — the `SKIP` row surfaces which paths are `EXEMPT` so the operator can see which \"greens\" are actually \"deliberately not tracked.\"

## Deploy risk

Zero at runtime — CI gate script only, no product code. The gate now correctly rejects prose-mention false-positives; a real PR that adds a new channel assertion in a file not in the SOP table will red where it previously false-greened. That's the intended behavior.

## Not in this PR

The table-row shape currently accepts `| \`path\` | ... | ... |` — a rare prose line starting with `| \`docs-site/docs/…\`` (a code example inside a paragraph) would still match. Tightening to require a table-header-defined 3-column shape is bigger scope than the reported bug and adds a table-header parser step; left as a follow-up if it ever becomes real.

## Related

- #1466 (this issue) — gate uses substring, prose mentions false-positive
- #1462 — 文档马's fix that revealed the residual `changelog.md × 2` gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)