### PR TITLE
fix(grok): attach 会话跑在备用屏幕，detach 不再留下死掉的 TUI（#1412 残留半）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5919,6 +5919,20 @@ async function grokCommand() {
   }
 
   printGrokCopresenceWarning(undefined, profile.tools, "resume");
+  // #1412 —— 用**备用屏幕**（alternate screen）承载整个 attach 会话。
+  //
+  // 症状：detach 之后屏幕定格在断开前那一帧，用户以为还连着、继续打字，
+  // 而输入根本没到 runtime（节点日志里没有新记录）。这是"以为还连着"这类
+  // 误解里最贵的一种 —— 它看起来完全像一个活着的会话。
+  //
+  // 进备用屏幕之后，终端会在 detach 时**把 attach 之前的画面原样还回来**，
+  // 而不是留下一屏死掉的 TUI；也不需要粗暴 clear 掉用户自己的 scrollback。
+  // 这是所有全屏 TUI（vim / less / tmux）的标准做法。
+  // 上面已强制要求 stdin/stdout 都是 TTY，所以这里不必再判。
+  //
+  // 与 #1414 的黑屏修复正交：那一条在**服务端**（attach 后首次 resize 做一次
+  // 一行抖动，强制 grok 全量重画）；这一条只管**客户端终端**在断开后的恢复。
+  process.stdout.write("\u001b[?1049h");
   const relay = new PassThrough({ highWaterMark: 64 * 1024 });
   const stdin = process.stdin;
   const wasRaw = stdin.isRaw === true;
@@ -5935,6 +5949,11 @@ async function grokCommand() {
     try { stdin.setRawMode(wasRaw); } catch {}
     if (wasPaused) stdin.pause();
     else stdin.resume();
+    // 回到主屏幕：attach 之前的画面被终端还原，断开前那一帧不会留下。
+    // 然后在**主屏幕**上明确说一句已断开 —— 否则用户只看到画面变了，
+    // 不知道是断开了还是崩了。
+    process.stdout.write("\u001b[?1049l");
+    process.stdout.write(`[anet] detached from Grok TUI "${nodeDisplayName(nodeId, profile)}" — reattach: anet grok attach ${shellQuote(nodeId)}\n`);
   };
   const requestDetach = () => {
     if (detaching) return;

--- a/agent-network/src/copresence-cli-wiring.test.ts
+++ b/agent-network/src/copresence-cli-wiring.test.ts
@@ -99,3 +99,42 @@ describe("cli.ts copresence stop wiring (structural gate)", () => {
     expect(removal).toBeLessThan(elseBranch);
   });
 });
+
+describe("grok attach 的备用屏幕（#1412 detach 残留半）", () => {
+  // 只能做源码顺序断言：attach 这条路要 TTY、要 raw mode、结尾 process.exit，
+  // 没法 import 进单测。
+  //
+  // 搜的是 cli.ts 的**源码文本**：那里的 ESC 是字面的 \\u001b（没被解码）。
+  // 测试里若写同样的转义串，TS 会把它解码成真正的 ESC 字符 —— 那个字符在源码
+  // 文本里根本不存在，断言会红得莫名其妙。所以只搜 `[?1049h` 这一段。
+  const body = (() => {
+    const start = CLI.indexOf("async function grokCommand");
+    expect(start).toBeGreaterThan(-1);
+    const rest = CLI.slice(start + 1);
+    const end = rest.search(/\n(?:export )?(?:async )?function /);
+    return end < 0 ? rest : rest.slice(0, end);
+  })();
+
+  test("🔴 进备用屏幕在建立会话之前，离开在 restoreTerminal 里", () => {
+    const enter = body.indexOf("[?1049h");
+    const connect = body.indexOf("connectGrokAttach(");
+    expect(enter).toBeGreaterThan(-1);
+    expect(connect).toBeGreaterThan(enter);   // 先进备用屏，再连
+    expect(body).toContain("[?1049l");
+  });
+
+  test("🔴 离开备用屏幕之后要在主屏幕上说一句已断开", () => {
+    const leave = body.indexOf("[?1049l");
+    const banner = body.indexOf("detached from Grok TUI");
+    expect(leave).toBeGreaterThan(-1);
+    expect(banner).toBeGreaterThan(leave);    // 横幅打在主屏幕上，不是备用屏
+  });
+
+  test("不碰 #1414 的服务端重绘：客户端仍然只发一帧初始 resize", () => {
+    // #1414 的一次性抖动在服务端（attach 后首次 resize 时做）。客户端要是
+    // 自己也抖一次，就是两套重绘叠在一起 —— 冗余，而且会掩盖服务端那条坏掉。
+    const activate = CLI.indexOf("connectGrokAttach(");
+    expect(activate).toBeGreaterThan(-1);
+    expect(CLI).not.toContain("redrawOnAttach");
+  });
+});


### PR DESCRIPTION
> 只收 **#1412 的第二半**。黑屏那半已经由 **#1414 修好并在 `main` 上**（服务端：terminal 客户端 `hello` 后 arm 一次性重绘，首次 resize 做一行抖动强制 grok 全量重画）。两者正交，本 PR 不碰它。

## 症状

`anet grok attach` 之后按 Ctrl-] detach，终端**定格在断开前那一帧 grok 画面**。用户以为还连着、继续打字，而输入根本没到 runtime（节点日志里没有新记录）。

这是「以为还连着」这类误解里最贵的一种 —— **它看起来完全像一个活着的会话**，没有任何东西告诉用户那是一张遗照。

## 改法：整个 attach 会话跑在备用屏幕

进入时写 alt-screen 进入序列、`restoreTerminal()` 里写离开序列。终端会在 detach 时**把 attach 之前的画面原样还回来**，而不是留下一屏死掉的 TUI；也不需要粗暴 `clear` 掉用户自己的 scrollback。vim / less / tmux 都是这么做的。

回到主屏幕之后再打一行：

```
[anet] detached from Grok TUI "<node>" — reattach: anet grok attach <node>
```

否则用户只看到画面变了，不知道是断开了还是崩了。

上游已经强制要求 stdin/stdout 都是 TTY，所以不必再判一次。

## 一条专门防「两套重绘叠在一起」的断言

有一条测试钉住**客户端不要自己也做重绘抖动**。#1414 的一次性抖动在服务端；客户端要是自己也抖一次，是冗余，而且会**掩盖服务端那条坏掉** —— 到时候黑屏回归了，测试还是绿的。

（这条断言不是凭空加的：我做这个 PR 时第一版就是在客户端实现了同样的抖动 —— 因为我把 `grep … | head -8` 的截断读成了「main 上没有这个修复」。见下。）

## 测试

`copresence-cli-wiring.test.ts` 新增三条源码顺序断言：

1. 🔴 进备用屏幕在建立会话**之前**；
2. 🔴 横幅打在**离开**备用屏幕之后（打在主屏幕上，不是备用屏 —— 打在备用屏里等于没打）；
3. 客户端不含自己的重绘（见上）。

前两条各自 **witnessed-red**：删掉对应那一行 → 对应断言红（变异前 `cmp` 证明非 no-op，跑完逐字还原）。

`agent-network/src` 全套 **759 pass / 0 fail**。推之前也跑了 doc 门（两个 doc-root 0 漂移、`check-doc-source-pins` rc=0、test-file-coverage 334/0 漏网）。

🔴 **一个转义坑写进测试注释了**：断言搜的是 `cli.ts` 的**源码文本**，那里的 ESC 是字面的 `\u001b`（没被解码）。测试里若写同样的转义串，TS 会把它解码成**真正的 ESC 字符** —— 那个字符在源码文本里根本不存在，断言会红得莫名其妙。所以只搜 `[?1049h` 这一段。

## 🔴 我自己在这条上翻过一次，记下来

我最初以为黑屏那半也没修：查了 issue 里点名的 `onTerminalAttached`、也查了客户端的初始 resize，都「没找到」，于是在客户端实现了一遍抖动。

**实际是我把搜索结果截断了。** 那条命令是 `grep -rn "onTerminalAttached|jitter" … | head -8`，前 8 行全是 `supervise-child.ts` 里无关的 "jitter" —— `attach.ts` 和 `runtime.ts` 的真命中在第 8 行以下，被 `head` 切掉了。**一个被截断的搜索结果，和一个真的没有命中的搜索结果，打印出来一模一样。**

坐实的方式是问一个 `head` 骗不了的问题：`git show origin/main:<file> | grep -c <symbol>` —— 得到 3 和 4，而不是 0。另外 `git log --oneline origin/main` 里看不到 #1414 的提交（squash 合并，commit id 变了），所以「main 的 log 里没有」也不能当证据。
