### PR TITLE
docs(rest): 记 /api/host-supervisors 的 can_create_nodes / create_nodes_blocked_reason

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -794,7 +794,8 @@ curl "http://localhost:9200/api/host-supervisors" \
         "cpu_cores": 8,
         "mem_gb": 16,
         "ip_internal": "10.x.x.x"
-      }
+      },
+      "can_create_nodes": true
     }
   ],
   "count": 1
@@ -802,6 +803,9 @@ curl "http://localhost:9200/api/host-supervisors" \
 ```
 
 🔴 **`host_telemetry` 按角色遮蔽**：所有人都能看到 `alert_level`（`green` = 在线 / `gray` = 不在线）；**只有该网络的 `admin` / `owner`（或用 network token 调用）**才拿得到 `cpu_cores` / `mem_gb` / `ip_internal`。普通成员看到的 `host_telemetry` 里**只有 `alert_level`**，不是这些字段为 null。
+
+🔴 **`can_create_nodes` / `create_nodes_blocked_reason`（daemon 建节点能力）**：daemon 通过 `report_status.host.daemon_capabilities` 上报，hub 原样镜像进这里 —— Dashboard「建节点向导」据此决定某台服务器能不能选、不能选时给出原因（`create_nodes_blocked_reason` 仅在 `can_create_nodes===false` 时出现）。
+🔴 **只有 daemon 真的上报了才带这两个键**：agent-node 版本较旧、尚未上报 `daemon_capabilities` 的 daemon，响应里这两个键**整个缺席**（不是 `false`）。消费方必须把「键缺席」当作「未知、按可建处理」，**不能**把缺席当成 blocked 而误灰掉一台健康的老 daemon（`undefined ≠ false`）。
 
 🔴 **`online` 的窗口是 5 分钟**，不是心跳周期本身。agent-node 的 `report_status` 每 **3 分钟**一次，窗口必须大于它 —— 否则每次心跳之后的 60~180 秒必然抖成 `offline`。
 

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -805,7 +805,8 @@ curl "http://localhost:9200/api/host-supervisors" \
         "cpu_cores": 8,
         "mem_gb": 16,
         "ip_internal": "10.x.x.x"
-      }
+      },
+      "can_create_nodes": true
     }
   ],
   "count": 1
@@ -813,6 +814,9 @@ curl "http://localhost:9200/api/host-supervisors" \
 ```
 
 🔴 **`host_telemetry` is masked by role.** Everyone sees `alert_level` (`green` = online, `gray` = not). Only a network `admin` / `owner` — or a network-token caller — receives `cpu_cores` / `mem_gb` / `ip_internal`. For an ordinary member those keys are **absent**, not null.
+
+🔴 **`can_create_nodes` / `create_nodes_blocked_reason` (daemon node-creation capability).** The daemon reports it via `report_status.host.daemon_capabilities`; the hub mirrors it here verbatim so the Dashboard "create-node wizard" can decide whether a host is selectable and, if not, why (`create_nodes_blocked_reason` appears **only** when `can_create_nodes === false`).
+🔴 **Both keys are present only if the daemon actually reported them.** A daemon running an older agent-node that does not yet send `daemon_capabilities` omits both keys **entirely** from the response — they are absent, not `false`. Consumers must treat an absent key as "unknown, assume creatable" and must **not** grey out a healthy older daemon by mistaking absence for blocked (`undefined ≠ false`).
 
 🔴 **The `online` window is 5 minutes**, not the heartbeat period. agent-node's `report_status` fires every **3 minutes**, and the window must exceed it — otherwise a daemon would flap to `offline` for the 60–180 s after every heartbeat.
 


### PR DESCRIPTION
## 补一个已发布 API 的文档缺口（前6 文档 · directive 4）

#1510/#1511 给 `GET /api/host-supervisors` 响应加了 **`can_create_nodes`** + **`create_nodes_blocked_reason`**（Dashboard「建节点向导」读它判断某台 daemon 能不能选、不能选给原因），但 `docs-site/docs/api/rest.md` 的响应示例和说明**一直没记这两个键**。

## 改动（zh + en 对称）

- JSON 示例的 daemon 对象加 `can_create_nodes: true`
- 新增 🔴 说明：
  - 两个键从 `report_status.host.daemon_capabilities` 镜像而来；`create_nodes_blocked_reason` 仅在 `can_create_nodes === false` 时出现
  - **`undefined ≠ false` 语义**（对齐 `server.ts:3150` Fix② 的立场）：只有 daemon 真上报了才带这两个键；旧 agent-node 未上报时**整个缺席**，消费方必须当「未知、按可建处理」，**不能**把缺席误当 blocked 而灰掉一台健康的旧 daemon

## 验证

- `check-doc-symbol-anchors.py`：83/83 resolved，rc=0
- `check-docs-integrity.py`：rc=0
- 版本声明纪律：初稿写了 `preview.55` 阈值，核查发现该版本**未发布**（当前 preview=.52），已改成版本无关表述，避免把未发布版本当成已发布来引用

🤖 Generated with [Claude Code](https://claude.com/claude-code)