### PR TITLE
fix(grok-copresence): recovery TUI 退出时透出 grok 的真实输出（#1400）

### DIFF
--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -17,7 +17,7 @@ import {
 } from "fs";
 import { PassThrough } from "stream";
 import { createConnection, type Socket } from "net";
-import { mkdtempSync } from "fs";
+import { mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join, resolve } from "path";
 import { describe, expect, test } from "bun:test";
@@ -66,6 +66,7 @@ import {
   type GrokCopresenceRuntimeSession,
   type GrokPtyLike,
   type GrokPtySpawn,
+  describeTuiStartupOutput,
 } from "./runtime";
 import { renderGrokCopresenceAgentProfile } from "./policy";
 
@@ -3814,3 +3815,48 @@ async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<voi
   }
   throw new Error(`condition not met within ${timeoutMs}ms`);
 }
+
+// #1400 —— recovery TUI 退出时把 grok 的真实输出透出来，而不是只报一句 opaque 的
+// "exited before recovery drain"。实测那次真因是
+// `error: cannot resume this session under sandbox profile ...`，
+// 而节点日志里没有任何一行说明为什么退，用户看着它空转重试三次。
+describe("#1400 recovery TUI 退出时透出 grok 的真实输出", () => {
+  const SANDBOX_ERROR = "error: cannot resume this session under sandbox profile 'read-only'";
+
+  test("🔴 剥掉 ANSI、保留行结构，取最后几行", () => {
+    const raw = `\u001b[2J\u001b[H${"noise line\r\n".repeat(20)}${SANDBOX_ERROR}\r\n`;
+    const out = describeTuiStartupOutput(raw);
+    expect(out).toContain(SANDBOX_ERROR);
+    expect(out).not.toContain("\u001b");
+    // 只留最后 5 行 ⇒ 前面那 20 行噪音不会把真错挤掉，也不会灌满一屏
+    expect(out.split(" | ")).toHaveLength(5);
+  });
+
+  test("🔴 一整屏 ANSI 也不会把真错挤掉（按行取尾，不按字节）", () => {
+    // grok 崩之前可能刚画过一整屏。按字节取尾会拿到那一行的中段乱码。
+    const wall = `\u001b[38;5;42m${"x".repeat(50_000)}\u001b[0m\r\n`;
+    const out = describeTuiStartupOutput(`${wall}${SANDBOX_ERROR}\r\n`);
+    expect(out).toContain(SANDBOX_ERROR);
+    expect(out.length).toBeLessThan(600);
+  });
+
+  test("超长单行被截断并标记", () => {
+    const out = describeTuiStartupOutput(`${"y".repeat(500)}\r\n`);
+    expect(out.length).toBeLessThanOrEqual(201);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  test("没有可见输出时返回空串（调用方据此换一句话，而不是打一个空的 grok said:）", () => {
+    expect(describeTuiStartupOutput(undefined)).toBe("");
+    expect(describeTuiStartupOutput("")).toBe("");
+    expect(describeTuiStartupOutput("\u001b[2J\u001b[H   \r\n  \r\n")).toBe("");
+  });
+
+  test("🔴 捕获发生在缓冲被清空**之前**（顺序错了就永远抓到空串）", () => {
+    const src = readFileSync(join(import.meta.dir, "runtime.ts"), "utf8");
+    const capture = src.indexOf("tui.startupOutput = this.tuiReadinessBuffer");
+    const clear = src.indexOf('this.tuiReadinessBuffer = "";', capture);
+    expect(capture).toBeGreaterThan(-1);
+    expect(clear).toBeGreaterThan(capture);   // 先抓，后清
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -89,6 +89,11 @@ import { GrokAcpClient } from "../grok-build-acp/client";
 const MAX_NETWORK_PROMPT_BYTES = 384 * 1024;
 const MAX_DEFERRED_HUMAN_BYTES = 128 * 1024;
 const MAX_TUI_READINESS_BUFFER = 128 * 1024;
+// #1400 —— TUI 在就绪前退出时，错误里带上它最后几行可见输出。
+// 取「行」不取字节：grok 崩前打的可能是一整屏 ANSI，按字节取尾会拿到一段
+// 中间的乱码，真正的 `error: …` 反而被挤掉（#1225 那次踩过同款）。
+const TUI_EXIT_OUTPUT_LINES = 5;
+const TUI_EXIT_OUTPUT_LINE_CHARS = 200;
 const MAX_TAIL_READ_BYTES = 4 * 1024 * 1024;
 const MAX_LIFECYCLE_LINE_BYTES = 256 * 1024;
 const MAX_PENDING_AUTOMATIC_PERMISSIONS = 64;
@@ -124,6 +129,20 @@ const GROK_TUI_SHORTCUTS_TEXT = "Ctrl+x:shortcuts";
  * cannot hide a marker that spans multiple PTY chunks.
  */
 export function hasGrokTuiReadyMarker(raw: string): boolean {
+  const visible = stripTerminalControl(raw, false);
+  return visible.includes(GROK_TUI_READY_TEXT)
+    && visible.includes(GROK_TUI_SHORTCUTS_TEXT);
+}
+
+/**
+ * 剥掉终端控制序列，只留可见文本（#1400 起从 hasGrokTuiReadyMarker 里抽出来复用）。
+ *
+ * `keepNewlines=false` 是就绪判据原来的行为，**逐字不变**：换行也被丢掉，
+ * 于是一个跨 PTY chunk 被 ANSI 打断的 marker 仍能匹配。
+ * `keepNewlines=true` 给的是**给人读**的那种输出（#1400 把 grok 真 stderr
+ * 透出来时用），行结构必须留着，否则最后 N 行取不出来。
+ */
+function stripTerminalControl(raw: string, keepNewlines: boolean): string {
   let visible = "";
   let state: "text" | "escape" | "csi" | "osc" | "control-string" = "text";
   for (let index = 0; index < raw.length; index += 1) {
@@ -137,6 +156,8 @@ export function hasGrokTuiReadyMarker(raw: string): boolean {
         state = "control-string";
       } else if (code >= 0x20 && code !== 0x7f && !(code >= 0x80 && code <= 0x9f)) {
         visible += char;
+      } else if (keepNewlines && (code === 0x0a || code === 0x0d)) {
+        visible += "\n";
       }
       continue;
     }
@@ -161,8 +182,30 @@ export function hasGrokTuiReadyMarker(raw: string): boolean {
       state = "text";
     }
   }
-  return visible.includes(GROK_TUI_READY_TEXT)
-    && visible.includes(GROK_TUI_SHORTCUTS_TEXT);
+  return visible;
+}
+
+/**
+ * 一个 TUI 世代在**就绪之前**就退出时，把它留下的最后几行可见输出整理成
+ * 一句能贴进错误里的话（#1400）。
+ *
+ * 为什么只用就绪前的缓冲：`tuiReadinessBuffer` 只在 composer 就绪之前累积、
+ * 就绪那一刻就被清空。所以它装的正好是**启动期的那点输出** —— 不含人类
+ * 后来打进 TUI 的任何内容。这既是我们要的东西，也顺带把「把用户输入写进
+ * 节点日志」这条风险排除在外。
+ */
+export function describeTuiStartupOutput(raw: string | undefined): string {
+  if (!raw) return "";
+  const lines = stripTerminalControl(raw, true)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return "";
+  return lines.slice(-TUI_EXIT_OUTPUT_LINES)
+    .map((line) => (line.length > TUI_EXIT_OUTPUT_LINE_CHARS
+      ? `${line.slice(0, TUI_EXIT_OUTPUT_LINE_CHARS)}…`
+      : line))
+    .join(" | ");
 }
 const COMPLETION_CHAT_SETTLE_MS = 500;
 
@@ -180,6 +223,8 @@ interface GrokTuiGeneration {
   readonly pty: GrokPtyLike;
   readonly exit: Promise<void>;
   exited: boolean;
+  /** 就绪前的 PTY 可见输出，退出那一刻抓下来（#1400）。 */
+  startupOutput?: string;
 }
 
 export type GrokPtySpawn = (
@@ -1666,6 +1711,12 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     });
     pty.onExit((event) => {
       tui.exited = true;
+      // 🔴 在下面把 tuiReadinessBuffer 清掉**之前**抓走它（#1400）。
+      //    grok 真正的失败原因（实测那次是 `error: cannot resume this session
+      //    under sandbox profile ...`）就在这段里；原来它在这里被丢掉，recovery
+      //    只抛得出一句 opaque 的 "exited before recovery drain"，节点日志里
+      //    没有任何一行说明为什么退 —— 用户看着它空转重试三次。
+      if (!tui.startupOutput) tui.startupOutput = this.tuiReadinessBuffer;
       resolveExit();
       if (this.activeTui !== tui || generation !== this.ptyGeneration || this.closing) return;
       this.tuiComposerReady = false;
@@ -1944,7 +1995,12 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
 
   private assertLiveTuiGeneration(tui: GrokTuiGeneration, boundary: string): void {
     this.assertOwnedTuiGeneration(tui, boundary);
-    if (tui.exited) throw new Error(`Grok recovery TUI exited before ${boundary}`);
+    if (tui.exited) {
+      const output = describeTuiStartupOutput(tui.startupOutput);
+      throw new Error(output
+        ? `Grok recovery TUI exited before ${boundary}; grok said: ${output}`
+        : `Grok recovery TUI exited before ${boundary} (grok printed nothing before exiting)`);
+    }
   }
 
   private detachTuiGeneration(tui: GrokTuiGeneration | null): void {


### PR DESCRIPTION
## 现象

把既有 grok 会话 pin 进共存节点后启动，节点循环报：

```
[grok-copresence] TUI exited code=1 signal=0; resuming same session
resume attempt 1/3 failed: Grok recovery TUI exited before recovery drain
```

三次重试三句一样，**日志里没有任何一行说明 TUI 为什么退**。手工 pty 跑同一条 argv 才看到真因：`error: cannot resume this session under sandbox profile ...`（沙箱档不匹配的 resume 拒绝）。用户完全不知道发生了什么、只能看着它空转重试。

## 根因不是「没抓到」，是**抓到了又扔掉**

PTY 把 grok 的 stdout/stderr 合成一路，`tuiReadinessBuffer` 在 composer 就绪之前一直累积着这些字节 —— **那句 sandbox 错误就在里面**。而 `pty.onExit` 的第一件事就是把这个缓冲清空，`assertLiveTuiGeneration` 再抛出一句不带任何输出的 `Grok recovery TUI exited before <boundary>`。

## 改动

| # | 改了什么 |
|---|---|
| ① | `onExit` 里**先把缓冲抓进这一代**（`tui.startupOutput`）**再清空** |
| ② | `assertLiveTuiGeneration` 把它挂在错误后面：`… exited before recovery drain; grok said: error: cannot resume this session …`。抓不到任何可见输出时换一句明确的 `(grok printed nothing before exiting)` —— **空白不该被读成「没异常」** |
| ③ | 从 `hasGrokTuiReadyMarker` 抽出 `stripTerminalControl(raw, keepNewlines)` 复用。`keepNewlines=false` 是就绪判据原来的行为、**逐字不变**（该文件既有测试全绿）；`keepNewlines=true` 保留行结构，因为要取最后 N 行 |

🔴 **按行取尾，不按字节。** grok 崩之前可能刚画过一整屏 ANSI；按字节取尾会拿到那一行的中段乱码，真正的 `error:` 反而被挤掉 —— #1225 那次我就是这么踩的。这里有一条 50000 字符的 ANSI 墙测试专门钉住它。

🔴 **只用就绪前的缓冲，不新开采集通道。** `tuiReadinessBuffer` 在就绪那一刻就被清空，所以它装的只有**启动期**输出，不含人类后来打进 TUI 的任何东西。这既是我们要的那段，也顺带把「把用户输入写进节点日志」这条风险排除在外。

## 测试

5 条，外加**三个方向**的变异（变异前 `cmp` 证明非 no-op，跑完逐字还原）：

| 变异 | 红的是哪条 |
|---|---|
| 拿掉 `onExit` 里的捕获 | 「捕获发生在清空之前」 |
| 不剥 ANSI | 「无可见输出返回空串」 |
| 改成按字节取尾 | 「ANSI 墙不挤掉真错」+「超长单行截断」 |

`grok-copresence/runtime.test.ts` 全套 **76 pass / 0 fail**。推之前跑了 doc 门（两个 doc-root 0 漂移、`check-doc-source-pins` rc=0、`check-doc-symbol-anchors` rc=0、test-file-coverage 334/0 漏网）。

## 未做的，写清楚

- **真机 end-to-end 没做**：复现那条沙箱 resume 拒绝需要一台真 grok 节点，生产的和别人正在用的测试节点都不能碰。所以本 PR 的证据是**单测 + 代码路径**，不含真机验证。
- **#1409 的 `auto_update` → 1.0.13 残留没顺带动** —— 那是另一条，值不值得并进来由 @通信龙 判断。
