### PR TITLE
fix(test225): 诊断在 grep 不命中时把整个套件打死 —— 修回归并给它判别力 (#1422)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -462,6 +462,34 @@ jobs:
       - name: Run complete agent-node unit domain
         run: docker run --rm anet-test725-agent-node-unit
 
+  test-lib-meta:
+    # tests/lib/ 下的共享 helper 各自带一份元测试。它们此前**一个都没被 CI 跑过** ——
+    # mutation-guard.test.sh(#1454)和 delivery-discrimination.test.sh(#1467)
+    # 全仓零引用:文件在、能过、CI 从不执行。「存在 / 挂上 / 会被触发」是三件事,
+    # 这一格补的是第三件。
+    name: tests/lib 元测试 (host)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run every tests/lib/*.test.sh
+        run: |
+          set -uo pipefail
+          # 🔴 分母从「**存在什么**」算,不从「打算跑什么」算;而且 0 个必须红 ——
+          #    一次「一个元测试都没找到」的运行,打印出来和「全部通过」逐字相同。
+          mapfile -t METAS < <(find tests/lib -maxdepth 1 -name '*.test.sh' | sort)
+          if [ "${#METAS[@]}" -eq 0 ]; then
+            echo "::error::tests/lib 下没找到任何 *.test.sh —— 这是取集坏了,不是没有测试"
+            exit 1
+          fi
+          echo "发现 ${#METAS[@]} 个元测试"
+          rc=0
+          for m in "${METAS[@]}"; do
+            echo "──────── $m"
+            bash "$m" || { rc=1; echo "::error::$m 红了"; }
+          done
+          exit $rc
+
   recovered-suites:
     name: recovered suites (Docker)
     runs-on: ubuntu-latest

--- a/tests/lib/anet-failure-code.sh
+++ b/tests/lib/anet-failure-code.sh
@@ -1,0 +1,29 @@
+# anet 失败码提取器 —— 从一份 `anet` 命令的原始输出里取出第一条失败文案的白名单标识。
+#
+# 为什么是白名单:原始输出是 600 私有的(可能含凭据),CI 上看不到。这里只把**匹配到的
+# 那一段**打出来,而所有候选项都是 cli.ts 里**不含插值的字面句**,或全大写错误码形状
+# ——凭据不是这两种形状(utok_/ntok_ 是小写前缀,base64/hex 带混合大小写或 /+=)。
+#
+# 🔴 这个函数**永远 return 0**,这是它最重要的性质,不是随手写的。
+#    调用它的套件跑在 `set -euo pipefail` 下。#1437 里这段逻辑是内联的:
+#        code=$(grep -oE '^\[anet\] [A-Z][A-Z0-9_]+' "$path" | head -1)
+#    grep 不命中时退 1 → pipefail 传给整条管道 → 赋值语句退出码=1 → **set -e 当场打死
+#    脚本**。于是紧跟其后的 fail() 一行都没跑到,报告里连 "FAIL: ..." 都没有,
+#    只剩前一条 bytes 行。#1422 的本地复现就是这么死的:整份报告在 L2 断掉,
+#    没有失败原因、没有早停行、没有 Summary。
+#    **一条"失败时告诉你是哪一种"的诊断,恰恰在不命中时把失败信息本身销毁了**,
+#    而不命中正是它被写出来要应付的那种情况(实测 7 条真实文案里 5 条不命中)。
+#
+# 🔴 候选项按「cli.ts 里逐条复核过的字面句」维护,不要换成通用占位符或笛卡尔积
+#    (与 failure-diagnostic.mjs 里 FAILURE_CODES 的维护方式一致)。
+#    末位那条通用全大写形状**必须保留**:它的价值正在于打出**意料之外**的码。
+ANET_FAILURE_CODE_PATTERN='^\[anet\] (STOP_TIMEOUT: authoritative local resources survived|STOP_TIMEOUT: could not prove|STOP_TIMEOUT: Windows ownership could not be proven|STOP_TIMEOUT: Windows managed processes survived|STOP_TIMEOUT: Windows node pid|⚠ identity teardown incomplete|⚠ copresence marker present but refused|⚠ identity gate check crashed|❌ tmux kill-session did not take|❌ this stop command.s ancestry includes|❌ refusing Windows co-presence teardown|❌ taskkill failed for|could not confirm that|[A-Z][A-Z0-9_]{3,})'
+
+# anet_first_failure_code <path> —— 打印标识;文件不存在打 <no-log>,没命中打 <none matched>。
+anet_first_failure_code() {
+  local path=${1:-} code=''
+  if [ ! -e "$path" ]; then printf '%s' '<no-log>'; return 0; fi
+  code=$(grep -oE "$ANET_FAILURE_CODE_PATTERN" "$path" 2>/dev/null | head -1) || code=''
+  printf '%s' "${code:-<none matched>}"
+  return 0
+}

--- a/tests/lib/anet-failure-code.test.sh
+++ b/tests/lib/anet-failure-code.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tests/lib/anet-failure-code.sh 的元测试。
+#
+# 两件事必须各自被证明:
+#   A 判别力 —— 每条真实失败文案给出**互不相同**的标识(#1437 那版把两条 STOP_TIMEOUT
+#     塌成同一个字符串 "[anet] STOP_TIMEOUT",红了也分不清是哪一种)。
+#   B 不杀调用方 —— 不命中时调用方在 `set -euo pipefail` 下必须活着走完。
+#     这是 #1422 的真回归:诊断自己把 FAIL 行弄没了。
+set -uo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$HERE/anet-failure-code.sh"
+WORK=$(mktemp -d /tmp/anet-failure-code-meta.XXXXXX)
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'PASS: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL: %s\n' "$1"; }
+
+# —— A. 每条真实文案(逐字取自 agent-network/bin/cli.ts 的 stopCommand)——
+declare -a SAMPLES=(
+  '[anet] STOP_TIMEOUT: authoritative local resources survived for "n" after 10000ms; hub was not notified offline.'
+  '[anet] STOP_TIMEOUT: could not prove "n" stopped; hub was not notified offline.'
+  '[anet] ⚠ identity teardown incomplete: detail here'
+  '[anet] ❌ tmux kill-session did not take for: sess-a'
+  '[anet] could not confirm that "n" exited (pid 1234); pidfile retained and PID was not signalled.'
+  '[anet] ⚠ copresence marker present but refused (STALE): detail'
+  "[anet] ❌ this stop command's ancestry includes a marker-carrying process"
+)
+declare -a CODES=()
+i=0
+for s in "${SAMPLES[@]}"; do
+  i=$((i+1)); f="$WORK/sample$i.log"; printf '%s\n' "$s" > "$f"
+  c=$(anet_first_failure_code "$f")
+  CODES+=("$c")
+  if [ "$c" = "<none matched>" ]; then bad "第 $i 条真实文案没被认出:${s:0:52}"
+  else ok "第 $i 条认出 → $c"; fi
+done
+
+# 判别力:七条必须两两不同(#1437 那版这里是 6 个不同值,两条 STOP_TIMEOUT 撞了)
+uniq_n=$(printf '%s\n' "${CODES[@]}" | sort -u | wc -l)
+if [ "$uniq_n" -eq "${#CODES[@]}" ]; then ok "七条文案给出七个互不相同的标识(判别力=满)"
+else bad "判别力不足:${#CODES[@]} 条文案只给出 $uniq_n 个不同标识 —— 有两条塌成同一个"; fi
+
+# —— B. 不命中 → 调用方必须活着(本条就是 #1422 的回归测试)——
+noise="$WORK/noise.log"
+printf 'some log line\nanother line without any anet marker\n' > "$noise"
+# 🔴 探针有两种形状,必须都测 —— 这一格是量出来的,不是补全性写的:
+#    ② 函数体内赋值 + 函数当**普通语句**调用 …… set -e 打死整个脚本(rc=1)
+#    ③ 函数体内赋值 + 函数在**命令替换**里调用 …… 活着(rc=0)
+#    run.sh 里 fail_with_private_log 是形状 ②。我第一版元测试只写了 ③,
+#    于是把 helper 里的 `|| code=''` 拿掉,测试**照样全绿** ——
+#    一个结构上不可能观察到该缺陷的探针。两向见证才把它逼出来。
+probe="$WORK/probe.sh"
+cat > "$probe" <<'PROBE'
+set -euo pipefail
+source "$1"
+code=$(anet_first_failure_code "$2")
+printf 'reached-end code=%s\n' "$code"
+PROBE
+probe2="$WORK/probe2.sh"
+cat > "$probe2" <<'PROBE2'
+set -euo pipefail
+source "$1"
+anet_first_failure_code "$2" >/dev/null
+printf 'reached-end-stmt\n'
+PROBE2
+out=$(bash "$probe" "$HERE/anet-failure-code.sh" "$noise" 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -Fq 'reached-end'; then
+  ok "不命中时调用方在 set -euo pipefail 下活着走完(rc=0)"
+else
+  bad "不命中把调用方打死了:rc=$rc out='$out' —— 这正是 #1437 的回归"
+fi
+if printf '%s' "$out" | grep -Fq 'code=<none matched>'; then ok "不命中报 <none matched>"
+else bad "不命中没有报 <none matched>:$out"; fi
+
+# 形状 ②:当普通语句调用 —— 这才是 run.sh 里的真实写法,也是唯一能看见 #1437 那个缺陷的形状
+out_s=$(bash "$probe2" "$HERE/anet-failure-code.sh" "$noise" 2>&1); rc_s=$?
+if [ "$rc_s" -eq 0 ] && printf '%s' "$out_s" | grep -Fq 'reached-end-stmt'; then
+  ok "不命中时【当普通语句调用】也活着走完(run.sh 的真形状)"
+else
+  bad "不命中把调用方打死了(普通语句形状):rc=$rc_s out='$out_s' —— #1437 的真回归"
+fi
+
+# 文件不存在 —— 也不能杀调用方,且要说得出是「没日志」而不是「没命中」
+out2=$(bash "$probe" "$HERE/anet-failure-code.sh" "$WORK/does-not-exist.log" 2>&1); rc2=$?
+if [ "$rc2" -eq 0 ] && printf '%s' "$out2" | grep -Fq 'code=<no-log>'; then
+  ok "日志不存在报 <no-log> 且不杀调用方"
+else bad "日志不存在这一格不对:rc=$rc2 out='$out2'"; fi
+
+# 意料之外的码仍要打得出来(这一格丢了,白名单就变成了藏东西的清单)
+printf '[anet] NODE_SOMETHING_BRAND_NEW: x\n' > "$WORK/unexpected.log"
+c=$(anet_first_failure_code "$WORK/unexpected.log")
+if [ "$c" != "<none matched>" ] && printf '%s' "$c" | grep -Fq 'NODE_SOMETHING_BRAND_NEW'; then
+  ok "没预料到的全大写码照样打得出来 → $c"
+else bad "通用兜底失效,意料之外的码被吞了:'$c'"; fi
+
+rm -f "$WORK"/*.log "$WORK"/*.sh 2>/dev/null || true
+rmdir "$WORK" 2>/dev/null || true
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test225-grok-preview-package-live/Dockerfile
+++ b/tests/test225-grok-preview-package-live/Dockerfile
@@ -80,6 +80,7 @@ RUN npm install -g /candidate/sleep2agi-agent-network-*.tgz \
 
 COPY tests/test225-grok-preview-package-live /test225
 COPY tests/lib/safe-rm.sh /test225/lib/safe-rm.sh
+COPY tests/lib/anet-failure-code.sh /test225/lib/anet-failure-code.sh
 RUN chmod 755 /test225/run.sh /test225/fake-grok.mjs /test225/local-registry.mjs /test225/npx-env-wrapper.mjs /test225/old-v1-agent-node.mjs /test225/tui-tool-inventory-probe.mjs
 
 RUN mkdir -p /test225-work && chown node:node /test225-work

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 umask 077
 source /test225/lib/safe-rm.sh
+source /test225/lib/anet-failure-code.sh
 
 # test225 runs in the *runtime* stage of its Dockerfile.  That image contains
 # only the globally installed anet candidate, the unpublished agent-node
@@ -170,10 +171,19 @@ fail_with_private_log() {
   #
   # ⚠️ pattern 故意保持通用,不收窄到几个已知码:**这一格的价值正在于它能打出
   # 「意料之外的码」**。如果真凶根本不在我们猜的那一族里,只有通用 pattern 会说出来。
-  if [ -e "$path" ]; then
-    code=$(grep -oE '^\[anet\] [A-Z][A-Z0-9_]+' "$path" 2>/dev/null | head -1)
-    log "diagnostic: private log first anet error code: ${code:-<none matched>}"
-  fi
+  # 🔴 #1422 —— 这里曾经是一段内联的 `code=$(grep … | head -1)`。它有两个缺陷,
+  #    第二个比第一个严重得多:
+  #    ① 判别力:pattern `^\[anet\] [A-Z][A-Z0-9_]+` 只认全大写开头的码。实测
+  #       stopCommand 的 7 条真实失败文案里 **5 条不命中**(以 `⚠`/`❌`/小写开头),
+  #       认出的那 2 条还塌成同一个字符串(regex 停在冒号)。
+  #    ② 致命:套件是 `set -euo pipefail`,grep 不命中时退 1、pipefail 传出去、
+  #       赋值语句退出码=1 → **set -e 当场打死脚本**,下面的 fail() 一行都跑不到。
+  #       于是报告里连 "FAIL: …" 都没有,只剩上面那条 bytes 行。#1422 本地复现
+  #       就是这么死的:整份报告在 L2 断掉,没有原因、没有早停行、没有 Summary。
+  #       **一条"失败时告诉你是哪一种"的诊断,恰恰在不命中时把失败信息本身销毁了。**
+  #    判据与用例见 tests/lib/anet-failure-code.test.sh(两向见证:退回窄 pattern
+  #    → 判别力那条红;去掉 helper 里的 `|| code=''` → 普通语句形状那条红)。
+  log "diagnostic: private log first anet error code: $(anet_first_failure_code "$path")"
   fail "$message"
 }
 


### PR DESCRIPTION
## Author & Helpers

**Author (Primary)**: 通信测试马

**Helpers**:
- 通信龙: 派工 / 独立复现了本 PR 修的那个 set -e 缺陷(他自己搭最小用例跑形状 ②,没只信我的表)

**Tier review gate**: 通信龙

## Why

Refs #1422

#1422 是「test225 known-failure ratchet 偶红卡合并」。查它的第一步是**看清那次红到底是哪一种 stop 失败** —— 而我在 #1437 给 `fail_with_private_log` 加的那条"打印首个 anet 错误码"的诊断,**恰恰在这件事上是坏的,而且坏的方式是销毁证据**。

```bash
# tests/test225-grok-preview-package-live/run.sh —— #1437 加的
code=$(grep -oE '^\[anet\] [A-Z][A-Z0-9_]+' "$path" 2>/dev/null | head -1)
```

套件跑在 `set -euo pipefail`。grep **不命中**时退 1 → pipefail 传给整条管道 → 赋值语句退出码=1 → **set -e 当场打死脚本**,紧跟其后的 `fail()` 一行都跑不到。

于是 main 上现在 test225 的任何一次红长这样:

```
[L2] deterministic package-only TUI co-presence
PASS: auth evidence scanner emits only closed target-role diagnostics
diagnostic: private raw log retained until cleanup (bytes=941 mode=600)
                                          ← 到此为止,全文完
```

没有 `FAIL:`、没有早停行、没有 Summary。对照 #1437 **之前**的同一位置(2026-08-29 CI 真红):

```
diagnostic: private raw log retained until cleanup (bytes=371 mode=600)
FAIL: node stop failed for fallback           ← 这一行现在没有了
diagnostic: 早停于 run.sh:163 / 共 2582 行
```

**一条"失败时告诉你是哪一种"的诊断,在 pattern 不命中时把失败信息本身销毁了** —— 而不命中正是它被写出来要应付的那种情况(实测 7 条真实文案里 5 条不命中)。

第二个缺陷是**判别力**:把 `stopCommand` 里 7 条真实失败文案喂给那条 grep,只认出 2 条(其余以 `⚠` / `❌` / 小写开头),而认出的 2 条还**塌成同一个字符串** `[anet] STOP_TIMEOUT`(regex 停在冒号)—— 红了也分不清是"socket 残留超窗"还是"证不出已停"。

## What

把错误码提取做成 `tests/lib/anet-failure-code.sh`(**永远 return 0** 的结构性修法),pattern 扩到认全 7 条真实文案且两两可分,并把 `tests/lib/*.test.sh` 真正接进 CI。

## How to verify

```bash
# 1. 元测试(13 条)
bash tests/lib/anet-failure-code.test.sh          # PASS=13 FAIL=0

# 2. 见红 A —— 退回 #1437 那条窄 pattern
sed -i "s#^ANET_FAILURE_CODE_PATTERN=.*#ANET_FAILURE_CODE_PATTERN='^\\\\[anet\\\\] [A-Z][A-Z0-9_]+'#" tests/lib/anet-failure-code.sh
bash tests/lib/anet-failure-code.test.sh          # rc=1, PASS=7 FAIL=6
                                                  # "判别力不足:7 条文案只给出 2 个不同标识"

# 3. 见红 B —— 去掉 helper 里的 || code=''
sed -i "s#) || code=''#)#" tests/lib/anet-failure-code.sh
bash tests/lib/anet-failure-code.test.sh          # rc=1
                                                  # "不命中把调用方打死了(普通语句形状)"

# 4. 还原后复跑 → PASS=13 FAIL=0
```

三种 shell 形状的实测(**这是量出来的,不是推理**):

| 形状 | 结果 |
|---|---|
| ① 顶层赋值 | rc=1 死 |
| ② 函数体内赋值 + 函数当**普通语句**调用 —— **run.sh 的真形状** | **rc=1 死** |
| ③ 函数体内赋值 + 函数在**命令替换**里调用 | rc=0 活 |

**投递语义自答**:n/a —— 本 PR 不改动任何带投递含义的返回值。唯一新增的返回值是 `anet_first_failure_code` 的退出码,它**恒为 0 且刻意如此**(这正是本 PR 要修的东西),它的"成功/失败"信息走 stdout 的 `<no-log>` / `<none matched>` / 具体码三态,元测试逐条断言这三态互不相同。

## Test evidence

- `bash tests/lib/anet-failure-code.test.sh` → **PASS=13 FAIL=0**
- 见红 A → `rc=1  PASS=7 FAIL=6`,红话逐字:`判别力不足:7 条文案只给出 2 个不同标识 —— 有两条塌成同一个`
- 见红 B → `rc=1`,红话逐字:`不命中把调用方打死了(普通语句形状):rc=1 out='' —— #1437 的真回归`
- 三个元测试在本分支全绿:`anet-failure-code 13` / `delivery-discrimination 7` / `mutation-guard 8`
- `bash tests/scripts/lint-no-bare-rm-rf.sh` → rc=0

## 两件我自己踩了、值得写进正文的事

**1. 我的第一版回归测试是假的。** 探针写成了形状 ③,而 ③ **结构上不可能**观察到这个缺陷 —— 把 `|| code=''` 拿掉,测试**照样 13/13 全绿**。是两向见证把它逼出来的;只做"补上之后变绿"那一向的话,我会交付一个守不住任何东西的绿测试。现在探针**两种形状都测**,形状 ② 那条才是真闸。

**2. `mutation-guard.test.sh`(#1454)和 `delivery-discrimination.test.sh`(#1467)全仓零引用 —— CI 一次都没跑过。** 文件在、本地能过、从不执行。`tests/lib/**` 在 qa.yml 里只是个 path filter(触发别的 job),不跑它们。这就是「存在 / 挂上 / 会被触发是三件事」,而我踩的是自己在别处引用过的那条注释。新增的 `test-lib-meta` job 补的是第三件,并且对"找到 0 个"判红 —— 一次"一个元测试都没找到"的运行,打印出来和"全部通过"逐字相同。

## 合并注意

`qa.yml` 上另有 3 个 open PR(#1200 / #1196 / #1180)。本 PR 对它是**纯新增一个 job**(插在 `recovered-suites:` 之前),但纯新增也可能撞键,建议按合并顺序先合先跑。

## 本 PR **不**做什么

不修 #1422 的 flake 本身。这是 通信龙 拍的拆分:仪器是 main 上的活回归,且**后续所有 #1422 取证都依赖它** —— 不修的话,下一轮复现拿到的还是空日志。根因另出 PR。

用 `Refs` 不用 `Closes`:#1422 要的是"stop 为什么偶发失败",本 diff 一个字都没回答。

## Checklist

- [x] Relevant tests pass locally (`bash tests/lib/anet-failure-code.test.sh`)
- [ ] `docs-site/docs/changelog.md` updated — n/a(测试基建,非用户可见)
- [ ] Docs synced — n/a
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`fix:`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] Issue 链接用对了关键字:`Refs #1422`
- [x] **投递语义自答**:见 How to verify 末段
