### PR TITLE
chore(release): bump —— server .43 / agent-node .53 / agent-network .68

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1763,7 +1763,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.42";
+const PINNED_SERVER_VERSION = "0.9.0-preview.43";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.67",
+  "version": "2.3.0-preview.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.67",
+      "version": "2.3.0-preview.68",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.67",
+  "version": "2.3.0-preview.68",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.67";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.52";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.68";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.53";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.52",
+  "version": "2.5.0-preview.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.52",
+      "version": "2.5.0-preview.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.52",
+  "version": "2.5.0-preview.53",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -66,6 +66,15 @@ set -uo pipefail
 #   内容 = #1448 f1 门铃补偿(#1450) + #1451 opencode 回复解析(#1452) + #1286 对称收敛(#1453)
 #          + start_node stale-starting reaper(#1456) + send_desktop_message 诚实投递态(#1460)
 #   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
+# 2026-08-30: preview42 → preview43（跟随 PINNED_SERVER_VERSION；daemon 建节点门 + inbox 硬化）
+#   内容 = #1510 create_node 派发按 daemon 自报的 can_create_nodes 设闸(#1353 Fix①)
+#          + #1511 /api/host-supervisors 透出 can_create_nodes/blocked_reason(#1353 Fix②)
+#          + #1516 user_inbox.network_id 升 schema 级 NOT NULL(#1493)
+#   🔴 #1516 带一条 boot 期迁移：遇存量 network_id IS NULL 行会 **warn+skip**（列保持可空、
+#      hub 照常启动），不 abort boot。升级前可在旁路副本上跑
+#      `SELECT COUNT(*) FROM user_inbox WHERE network_id IS NULL`（预期 0；user_inbox 自
+#      preview41 才建表）。详见 deploy/hub/README.md 的 step 4。
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 # 2026-08-30: preview41 → preview42（跟随 PINNED_SERVER_VERSION；host.ip P bug）
 #   内容 = #1498 report_status 接受 host.ip=null —— 此前没有非回环 IPv4 的机器上
 #          agent-node 一启动就被 MCP -32602 打死（与 runtime 无关）
@@ -77,7 +86,7 @@ set -uo pipefail
 #   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
 #      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
 #      在这里标出来，免得下一个人把这份历史当完整的读。
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview42"
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview43"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.67 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.68 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.67` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.68` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.67 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.68 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.67`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.68`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.43.md
+++ b/docs/tests/release-v0.9.0-preview.43.md
@@ -1,0 +1,66 @@
+# @sleep2agi/commhub-server 0.9.0-preview.43 — release notes
+
+三条 hub 侧改动：两条把 daemon「能不能建节点」这件事变成**可判定的**，一条给
+`user_inbox` 加 schema 级保险带。
+
+- **`create_node` 派发按 daemon 自报的能力设闸**（PR #1510，#1353 Fix ①）。
+  此前 hub 会把 `create_node` 派给一个**其实建不了节点**的 daemon（例如它丢了
+  `ANET_BIN_ABS`），daemon 侧失败，而调用方看到的是一个泛泛的错误 —— daemon
+  仍然显示在线。现在闸设在**副作用之前**：daemon 上报 `can_create_nodes=false`
+  时直接拒绝派发，并带上 `blocked_reason`。
+
+- **`/api/host-supervisors` 透出 `can_create_nodes` / `create_nodes_blocked_reason`**
+  （PR #1511，#1353 Fix ②）。Dashboard 的「建节点向导」据此决定某台服务器能不能选、
+  不能选时给出原因。
+  🔴 **`undefined ≠ false`**：只有 daemon 真的上报了 `daemon_capabilities` 才带这两个键；
+  较旧的 agent-node 不上报时两个键**整个缺席**（不是 `false`）。消费方必须把「键缺席」
+  当作「未知、按可建处理」，**不能**把缺席当成 blocked 而误灰掉一台健康的旧 daemon。
+  文档见 `docs-site/docs/api/rest.md` 的 `GET /api/host-supervisors`（PR #1515）。
+
+- **`user_inbox.network_id` 升到 schema 级 `NOT NULL`**（PR #1516，#1493）。
+  「不产生 `network_id = NULL` 孤儿行」原本只是**代码级**保证（`send_desktop_message`
+  INSERT 之前的三道闸，#1492 有测试钉着）；这一版把它也写进 schema，belt-and-suspenders。
+
+🔴 **本版带一条 boot 期迁移，但它不会挡住启动**：SQLite 不能 `ALTER COLUMN ADD NOT NULL`，
+所以走「建新表 → copy → rename」，并按 `sqlite_master` 幂等跳过。迁移前会数一次存量
+`network_id IS NULL` 的行 —— **数到非 0 时是 `warn` + 跳过迁移（列保持可空），hub 照常启动**，
+不是 abort boot。理由：这条约束是冗余保险带，代码级三闸已经在挡；为它拒绝启动等于用
+整个舰队的 hub 停摆去换一个尚未发生的回归。孤儿行仍有明确的运维信号，人工清干净之后
+下次启动迁移会自动完成。
+
+**升级前的可选预检**（在旁路副本上，不碰生产库）：
+
+```bash
+sqlite3 <db-copy> "SELECT COUNT(*) FROM user_inbox WHERE network_id IS NULL"
+```
+
+预期 `0` —— `user_inbox` 自 `0.9.0-preview.41` 才建表，且代码级三闸从建表起就在。
+详细步骤见 `deploy/hub/README.md` 的 step 4（旁路验证）。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.68 @sleep2agi/agent-node@2.5.0-preview.53
+anet hub start
+```
+
+hub 自己由 `anet` 按 `PINNED_SERVER_VERSION` 拉起（本版 `0.9.0-preview.43`），
+通常不需要单独装 `@sleep2agi/commhub-server@0.9.0-preview.43`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.68
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1510 | #1353 Fix ① | `create_node` 派发按 daemon 自报 `can_create_nodes` 设闸（副作用之前） |
+| #1511 | #1353 Fix ② | `/api/host-supervisors` 透出 `can_create_nodes` / `create_nodes_blocked_reason`（undefined ≠ false） |
+| #1516 | #1493 | `user_inbox.network_id` schema 级 `NOT NULL` + boot 期 warn+skip 迁移 |

--- a/docs/tests/release-v2.3.0-preview.68.md
+++ b/docs/tests/release-v2.3.0-preview.68.md
@@ -1,0 +1,48 @@
+# @sleep2agi/agent-network 2.3.0-preview.68 — release notes
+
+一条 CLI 侧改动，直接对着「grok 共存开箱即用」：**detach 之后不再留下一屏死掉的 TUI**。
+
+- **`anet grok attach` 的会话跑在备用屏幕（alt-screen）**（PR #1514，#1412 残留半）。
+  症状：attach 成功、用 `Ctrl-]` 断开后，终端**定格在断开前的 grok 画面**，
+  用户以为还连着、在里面打字没反应（输入没到 runtime、节点日志无新记录）。
+  修法：整个 attach 会话进备用屏缓冲，detach 时离开 —— 终端把 attach 之前的画面
+  **原样还回来**（连用户自己的 scrollback 一起，vim / less / tmux 的标准做法），
+  比粗暴 clear 干净。回到主屏后再打一行「已断开 + 怎么重连」，
+  否则用户只看到画面变了、不知道是断开还是崩了。
+  🔴 附带一条断言**钉住客户端不自己做重绘抖动**：那一半在服务端（#1414），
+  两套重绘叠在一起不仅冗余，还会**掩盖服务端那条坏掉** —— 黑屏回归了测试还是绿的。
+
+配合 `agent-node 2.5.0-preview.53` 的 #1518，grok 共存这一轮的四个坑
+（attach 黑屏 #1414 / detach 残留 #1514 / 换模型崩溃 #1416+#1509 / 失败不可见 #1518）
+到此全部清掉。
+
+🔴 **只有 #1514 进了这个 tarball**。同期合入的 #1515（rest.md 的
+`can_create_nodes` 文档）、#1517（Codex TUI 安全重启 runbook）分别在 `docs-site/`，
+而 `agent-network` 的 `files` 是 `["dist"]` —— **它们不进这个包**，
+在这里列出来只是免得被读成产品改动。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.68 @sleep2agi/agent-node@2.5.0-preview.53
+anet hub start
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.68
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1514 | #1412 残留半 | attach 会话跑备用屏，detach 原样还原断开前画面 + 断开提示；断言钉住客户端不自重绘 |
+
+pin 链：`PINNED_SERVER_VERSION` → `0.9.0-preview.43`、
+`PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.53`。

--- a/docs/tests/release-v2.5.0-preview.53.md
+++ b/docs/tests/release-v2.5.0-preview.53.md
@@ -1,0 +1,51 @@
+# @sleep2agi/agent-node 2.5.0-preview.53 — release notes
+
+三条 grok / BTW 共存的可靠性与**可诊断性**修复。前两条直接对着「共存节点开箱即用」
+这个目标：失败要么不再发生，要么**说得出为什么**。
+
+- **recovery TUI 退出时透出 grok 的真实输出**（PR #1518，#1400）。
+  症状：把既有 grok 会话 pin 进共存节点后启动，节点循环打
+  `resume attempt N/3 failed: Grok recovery TUI exited before recovery drain`，
+  **日志里没有任何一行说明 TUI 为什么退**，三次重试三次同句、任务全部失败。
+  根因**不是没抓到 grok 的 stderr，而是抓到又扔掉**：PTY 把 stdout/stderr 合成一路，
+  `tuiReadinessBuffer` 在 composer 就绪之前一直累积着这些字节（那句
+  `error: cannot resume this session under sandbox profile ...` 就在里面），
+  而 `pty.onExit` 的第一件事就是清空这个缓冲。
+  修法：onExit **先抓再清**，错误里挂上 `; grok said: <最后几行>`；
+  🔴 抓不到任何可见输出时改打 `(grok printed nothing before exiting)` ——
+  **空白不该被读成「没异常」**。取尾按**行**不按字节（grok 崩前可能刚画过一整屏 ANSI，
+  按字节取会拿到那一行的中段乱码、真错反而被挤掉）。
+  只用**就绪前**的缓冲：它在就绪那一刻即被清空，所以装的只有启动期输出，
+  **不含人类后来打进 TUI 的内容**。
+
+- **换模型的观察窗口改成「观察到轮转就关」**（PR #1509，#1413 残留）。
+  #1416 的正确性原本押在「轮转发生在 ack 之后 3000ms 内」这条**从未实测过**的假设上：
+  大会话 / 忙碌 session / grok 慢的时候轮转迟到，窗口已被定时器关掉，
+  boundary error 走回 `failFatal` —— #1413 的原始现象照旧复现。现在窗口的**关闭条件**
+  是「观察到轮转」，硬上限同时放宽。
+
+- **BTW 侧线程：reconcile 出 turnId 后也绑定已存在的 live execution**（PR #1512，#1449 f3）。
+  reconcile 拿到 turnId 时若该 execution 已经在跑，此前不会绑定，
+  早期 terminal 事件与 pendingTerminal 会滞留；现在一并 flush。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.68 @sleep2agi/agent-node@2.5.0-preview.53
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.53
+# 共存节点需要重启才会用上新 runtime
+anet node restart <节点名>
+```
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1518 | #1400 | recovery TUI 退出时透出 grok 真实输出（先抓再清 / 按行取尾 / 空输出明确说明） |
+| #1509 | #1413 残留 | 换模型窗口改为「观察到轮转即关」，去掉「轮转必在 3000ms 内」这条未实测假设 |
+| #1512 | #1449 f3 | reconcile 出 turnId 后绑定已存在的 live execution，flush 早期 terminal |

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.42",
+  "version": "0.9.0-preview.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.42",
+      "version": "0.9.0-preview.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.42",
+  "version": "0.9.0-preview.43",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.42' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.43' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## 为什么现在发

上一次 bump 是 #1508（server .42 / node .52 / network .67），**之后又合了 7 个 PR** —— 今天上午所有面向用户的修复目前**只在 main，不在任何已发布的包里**，用户拿不到。本 PR 把它们推上 preview 通道。

## 内容（逐包 `git log 12799587..origin/main -- <pkg>/` 数出来，不是照清单抄）

| 包 | 版本 | 内容 |
|---|---|---|
| commhub-server | .42 → **.43** | #1510（create_node 派发按 daemon 自报能力设闸，#1353 Fix①）· #1511（/api/host-supervisors 透出 can_create_nodes/blocked_reason，Fix②）· #1516（user_inbox.network_id schema 级 NOT NULL，#1493） |
| agent-node | .52 → **.53** | #1518（recovery TUI 退出透出 grok 真实输出，#1400）· #1509（换模型窗口改「观察到轮转即关」，#1413 残留）· #1512（reconcile turnId 绑定已存在 live execution，#1449 f3） |
| agent-network | .67 → **.68** | #1514（attach 跑备用屏、detach 原样还原，#1412 残留半） |

🔴 同期合入的 #1515 / #1517 在 `docs-site/`，而 agent-network 的 `files` 是 `["dist"]` —— **它们不进这个 tarball**，release notes 里单列说明，免得被读成产品改动。

基线三个 from 用 `npm view <pkg> dist-tags.preview` 现取（.42/.52/.67，与树里对上）。

## 改了什么

**脚本（`scripts/sync-pinned-versions.sh --apply`，三包各跑、先 dry-run 看 diff）**：package.json ×3 + lock 各两处 ×3 + `PINNED_SERVER_VERSION`→.43 + `PAIRED_AGENT_NODE_VERSION`→.53 + test766 字面量。

**脚本不碰、手改三处**：
1. `deploy/hub/hub-daemon.sh` RUNTIME_DIR preview42→43，按该文件惯例补历史行（内容 + 回滚目标），并写明 **#1516 那条 boot 期迁移是 warn+skip 不 abort boot**，附旁路副本预检命令。
2. getting-started 版本戳 .67→.68（机器注释 + 人读表，中英四处）。**改之前核过**那句「`auth.ts` 自 .49 起零提交」在 .68 上仍成立：`git log --since=2026-08-27T02:25:00Z -- server/src/auth.ts` = **0 条**。
3. `docs/tests/release-v{0.9.0-preview.43,2.5.0-preview.53,2.3.0-preview.68}.md` ×3。

## 本地按 CI 口径跑过

- `check-doc-version-claims.py` rc=0
- `check-release-channel-assertions.py` rc=0
- `check-hub-launcher-pin.py` rc=0（launcher preview43 == PINNED .43）
- `check-doc-symbol-anchors.py` rc=0（83/83）
- gate-3 三条判据对三份 notes 逐个数过（各 1×`## Install` / 1×`## Upgrade` / 3 处版本号）

## 已知：版本号 bump PR 的 e2e 天然过不了

`PINNED_SERVER_VERSION` 指着一个**尚未发布**的版本（#194 记录的先有鸡还是先有蛋）。release.yml 的 install-smoke 才是权威判据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)