### PR TITLE
fix(daemon): anet_bin_source 给的修复命令根本跑不通 —— 两处都坏 (#1353)

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -236,6 +236,44 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     })).toThrow(/anet_bin_unsafe_path.*no ANET_BIN_ABS/);
   });
 
+  // #1353 —— anet_bin_source 的 `Fix:` 那半是用户唯一拿到的修法。它在 2026-08-30 之前
+  // **两处都坏**：shell 语法就不成立（`$( )` 里的 `\"`），以及 `install -d /etc/...` 少了
+  // sudo 导致 `&&` 断链、后面的 `sudo tee` 永不执行。两个坏法的共同点是
+  // **照敲一遍不会报"你没权限"，而是留下一个仍然没修好的系统** —— 用户以为修过了。
+  //
+  // 所以这里断言的不是"文案里有 sudo"这种字面，而是**这条命令的结构性质**：
+  //   ① 创建目录那一步必须带 sudo（否则断链）
+  //   ② 不出现 `$( … \" … )` 这种在命令替换里反斜杠转义引号的形状（bash 直接语法错误）
+  // 平台分支只测 POSIX —— Windows 那条是 PowerShell，不适用本判据。
+  test("anet_bin_source 的修复命令必须可执行：sudo 盖住建目录 + 无 $( \" ) 语法错误 (#1353)", () => {
+    const posixFix = (): string => {
+      try {
+        loadAndVerifyAnetBin({ ANET_DAEMON_PATH_CONF: "/nonexistent" }, "linux");
+      } catch (e: any) {
+        return String(e?.message ?? "");
+      }
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    };
+    const msg = posixFix();
+    expect(msg).toMatch(/anet_bin_unsafe_path/);
+
+    // ① 建目录必须在 sudo 之下。裸 `install -d /etc/anet-daemon` 普通用户 exit 1。
+    expect(msg).toContain("sudo install -d -m 0755 /etc/anet-daemon");
+    expect(msg).not.toMatch(/(^|[^o] )install -d -m 0755 \/etc\/anet-daemon/);
+
+    // ② node 的内联脚本必须用**单引号**包。坏掉的那一版写成
+    //    `node -e \"console.log(require('fs')…)\"`，而它整个又处在 `$( )` 里、
+    //    外层还有双引号 —— bash 看到的是 `$(node -e \"…`，直接
+    //    `syntax error near unexpected token '('`（实测 `bash -n` rc=2）。
+    //    单引号包脚本、脚本内部用 "fs"，两层引号才不打架。
+    //    🔴 这条断言的第一版写成「命令替换里不出现 \\" 」，看着更"直指语法"，
+    //       但**变异后仍然全绿** —— 因为运行时字符串里根本没有反斜杠，
+    //       那个形状只存在于 TS 源码里。断言要钉运行时真有的性质。
+    const cmd = msg.slice(msg.indexOf("Fix: ") + 5);
+    expect(cmd).toContain("node -e 'console.log(require(");
+    expect(cmd).not.toContain('node -e "console.log');
+  });
+
   test("REJECT: ANET_BIN_ABS env fallback without explicit opt-in", () => {
     cleanup();
     const p = setup("env-fallback-disabled");

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -223,7 +223,18 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
       `ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is ${trustRoot})`,
       platform === "win32"
         ? `New-Item -ItemType Directory -Force -Path "${win32.dirname(trustRoot)}" | Out-Null; "ANET_BIN_ABS=<absolute path to anet.cjs>" | Set-Content -Path "${trustRoot}" -Encoding ascii`
-        : "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+        // 🔴 这条命令在 2026-08-30 之前**两处都坏**，而它是 anet_bin_source 唯一给出的修法：
+        //   ① **语法就不成立**：`"$(node -e \\"…\\" …)"` 里的 `\\"` 在 `$( )` 内不是转义、是语法错误，
+        //      `bash -n` 直接 rc=2 —— 用户粘贴进去只会看到 `syntax error near unexpected token '('`。
+        //      改用单引号包 node 脚本，脚本内部才用 `"fs"`，两层引号不再打架。
+        //   ② **sudo 盖错了半边**：`install -d /etc/anet-daemon` 没有 sudo，普通用户下 exit 1
+        //      （实测 `install: cannot change permissions of '/etc/anet-daemon'`），`&&` 当场断链，
+        //      后面的 `sudo tee` **根本不执行**。用户照敲之后 path.conf 依旧不存在。
+        //   一条跑不通的修复建议比没有建议更糟：它让人以为自己已经修过了。
+        //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
+        //   可能解析到另一个（或找不到）二进制。
+        //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
+        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   if (!pin) {
@@ -231,7 +242,18 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
       `no ANET_BIN_ABS resolved from ${trustRoot}; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1`,
       platform === "win32"
         ? `New-Item -ItemType Directory -Force -Path "${win32.dirname(trustRoot)}" | Out-Null; "ANET_BIN_ABS=<absolute path to anet.cjs>" | Set-Content -Path "${trustRoot}" -Encoding ascii`
-        : "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+        // 🔴 这条命令在 2026-08-30 之前**两处都坏**，而它是 anet_bin_source 唯一给出的修法：
+        //   ① **语法就不成立**：`"$(node -e \\"…\\" …)"` 里的 `\\"` 在 `$( )` 内不是转义、是语法错误，
+        //      `bash -n` 直接 rc=2 —— 用户粘贴进去只会看到 `syntax error near unexpected token '('`。
+        //      改用单引号包 node 脚本，脚本内部才用 `"fs"`，两层引号不再打架。
+        //   ② **sudo 盖错了半边**：`install -d /etc/anet-daemon` 没有 sudo，普通用户下 exit 1
+        //      （实测 `install: cannot change permissions of '/etc/anet-daemon'`），`&&` 当场断链，
+        //      后面的 `sudo tee` **根本不执行**。用户照敲之后 path.conf 依旧不存在。
+        //   一条跑不通的修复建议比没有建议更糟：它让人以为自己已经修过了。
+        //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
+        //   可能解析到另一个（或找不到）二进制。
+        //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
+        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   // ① absolute — cross-platform. Was `startsWith("/")` which returned


### PR DESCRIPTION
## 一条**跑不通**的修复建议，正好躺在 #1353 的核心路径上

daemon 丢了 `ANET_BIN` pin 之后，`anet_bin_source` 的 `Fix:` 那半是用户拿到的**唯一**修法。它有两个独立缺陷，**都不会报「你没权限」**，只会留下一个仍然没修好的系统 —— 用户照敲一遍，症状（daemon 在线 / hub 返回 `ok:true` / 节点永远不出现）原样复现。

### ① shell 语法就不成立（实测 `bash -n` rc=2）
```
install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\n' "$(node -e \"console.log(...)\" $(command -v anet))" | sudo tee …
                                                                          ^^ $( ) 内部的 \" 不是转义，是语法错误
$ bash -n /tmp/orig_cmd.sh
syntax error near unexpected token '('     rc=2
```
粘贴进终端**一步都不会执行**。

### ② sudo 盖错了半边（实测 exit 1 → `&&` 断链）
```
$ install -d -m 0755 /etc/anet-daemon        # 没有 sudo
install: cannot change permissions of '/etc/anet-daemon': No such file or directory
rc=1     ⇒ && 断链 ⇒ 后面的  根本不执行 ⇒ path.conf 没写成
```

## 改动

两个 `anet_bin_source` throw 站点的 **POSIX 分支**（Windows 那条是 PowerShell、不受影响）：

```bash
ANET_BIN_REAL="$(node -e 'console.log(require("fs").realpathSync(process.argv[1]))' "$(command -v anet)")" \
  && sudo install -d -m 0755 /etc/anet-daemon \
  && printf 'ANET_BIN_ABS=%s\n' "$ANET_BIN_REAL" | sudo tee /etc/anet-daemon/path.conf >/dev/null
```
- node 内联脚本改用**单引号**包，内部才用 `"fs"` —— 两层引号不再打架；
- `sudo` 盖住建目录那一步；
- realpath 在 sudo **之前**算好存进变量：root 环境里 `command -v anet` 可能解析到另一个（或找不到）二进制。

**验证**：`bash -n` **rc=0**；非 sudo 段实跑，解析出 `…/@sleep2agi/agent-network/dist/bin/cli.js`；`printf` 段输出正确的 `ANET_BIN_ABS=` 行。

## 测试：两向见红（每向都验过非 NO-OP、跑完逐字还原）

| 变异 | 结果 |
|---|---|
| `sudo install -d` → `install -d` | **65 pass / 1 fail** |
| node 脚本改回双引号包 | **65 pass / 1 fail** |

🔴 **断言 ② 的第一版不承重**：写成「命令替换里不出现 `\"`」，变异后**仍然全绿** —— 那个反斜杠只存在于 TS 源码里，运行时字符串里没有。改成钉运行时真有的性质（`node -e '` 单引号形态）才见红。这段经过写进了测试注释，免得下一个人再写一遍不承重的版本。

全模块 **67 pass / 0 fail**。

Refs #1353（本 PR 只修这条命令；#1353 的持久化方向见我在 issue 上的分析 —— 不要用「用户可写的 path.conf」来解，那会拆掉 trust root）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)