### PR TITLE
docs: 12 个代码块标着 ```bash 其实不是 shell

### DIFF
--- a/docs-site/docs/concepts/security.md
+++ b/docs-site/docs/concepts/security.md
@@ -312,7 +312,7 @@ chmod 600 ~/.commhub/commhub.db
 
 ### 建议配置
 
-```bash
+```nginx
 # 1. 使用 TLS（反向代理）
 # nginx.conf
 server {

--- a/docs-site/docs/concepts/task-lifecycle.md
+++ b/docs-site/docs/concepts/task-lifecycle.md
@@ -131,7 +131,7 @@ INSERT INTO tasks (task_id, from_name, to_name, status, content, ...) VALUES (..
 
 每个任务有 TTL（Time To Live），默认 1 小时：
 
-```bash
+```text
 # 设置 TTL
 commhub_send_task(alias="代码1号", task="...", ttl_seconds=7200)  # 2 小时
 ```
@@ -163,7 +163,7 @@ expires_at = datetime('now', '+3600 seconds')
 下面的管理调用走 REST `POST /mcp`。Claude Code channel wrapper 只暴露通信与状态工具，不提供 `cancel_task` / `retry_task` / `reassign_task` / `get_inbox`。
 :::
 
-```bash
+```text
 # 重试任务（POST /mcp，tool=retry_task）
 retry_task(task_id="t_xxx")
 ```
@@ -191,7 +191,7 @@ flowchart LR
 
 可以取消尚未完成的任务：
 
-```bash
+```text
 # POST /mcp，tool=cancel_task
 cancel_task(task_id="t_xxx", reason="不再需要")
 ```
@@ -209,7 +209,7 @@ cancel_task(task_id="t_xxx", reason="不再需要")
 
 将任务从一个 Agent 转给另一个：
 
-```bash
+```text
 # POST /mcp，tool=reassign_task
 reassign_task(task_id="t_xxx", new_alias="代码2号")
 ```
@@ -300,7 +300,7 @@ Task t_a1b2c3d4 events:
 | `normal` | 普通任务 | 默认 |
 | `low` | 低优先级 | 排在最后 |
 
-```bash
+```text
 # 发高优先级任务
 commhub_send_task(alias="代码1号", task="紧急修复", priority="high")
 ```

--- a/docs-site/docs/en/concepts/security.md
+++ b/docs-site/docs/en/concepts/security.md
@@ -311,7 +311,7 @@ chmod 600 ~/.commhub/commhub.db
 
 ### Recommended Configuration
 
-```bash
+```nginx
 # 1. Use TLS (reverse proxy)
 # nginx.conf
 server {

--- a/docs-site/docs/en/concepts/task-lifecycle.md
+++ b/docs-site/docs/en/concepts/task-lifecycle.md
@@ -131,7 +131,7 @@ INSERT INTO tasks (task_id, from_name, to_name, status, content, ...) VALUES (..
 
 Each task has a TTL (Time To Live), defaulting to 1 hour:
 
-```bash
+```text
 # Set TTL
 commhub_send_task(alias="coder-1", task="...", ttl_seconds=7200)  # 2 hours
 ```
@@ -163,7 +163,7 @@ Failed, cancelled, and expired tasks can all be retried:
 The management calls below go through REST `POST /mcp`. The Claude Code channel wrapper exposes communication and status tools, not `cancel_task`, `retry_task`, `reassign_task`, or `get_inbox`.
 :::
 
-```bash
+```text
 # Retry a task (POST /mcp, tool=retry_task)
 retry_task(task_id="t_xxx")
 ```
@@ -191,7 +191,7 @@ flowchart LR
 
 You can cancel tasks that haven't completed yet:
 
-```bash
+```text
 # POST /mcp, tool=cancel_task
 cancel_task(task_id="t_xxx", reason="No longer needed")
 ```
@@ -209,7 +209,7 @@ Cancellable statuses are `created`, `delivered`, `acked`, and `running`. Termina
 
 Transfer a task from one agent to another:
 
-```bash
+```text
 # POST /mcp, tool=reassign_task
 reassign_task(task_id="t_xxx", new_alias="coder-2")
 ```
@@ -300,7 +300,7 @@ Tasks support three priority levels:
 | `normal` | Standard task | Default |
 | `low` | Low priority | Sorted last |
 
-```bash
+```text
 # Send a high-priority task
 commhub_send_task(alias="coder-1", task="Critical fix needed", priority="high")
 ```


### PR DESCRIPTION
## 起因：扫「用户会照着粘的那些命令」

用 `bash -n` 扫了 docs-site 全部 **478** 个 ```bash / ```sh 代码块，13 个解析失败。逐个看过后是三类：

| 类别 | 数量 | 处理 |
|---|---|---|
| MCP 工具调用（`retry_task(task_id="t_xxx")`、`commhub_send_task(alias=…)`）+ 1 个 SQL 式 TTL 表达式，却标 ```bash | 10 | → ```text（**仓里其它地方写 MCP 调用就是用 ```text，按既有惯例统一，不新造**） |
| nginx 配置（`server { listen 443 ssl; … }`）标 ```bash | 2 | → ```nginx |
| 有意的占位符（`--password <横幅里那串>`、`@<已验证版本>`） | 3 | **不动** —— bash 把 `<…>` 读成重定向才失败，它们本来就不是拿来直接跑的 |

## 为什么值得改

一个标着 ```bash 的块，读者的默认动作就是**复制进终端**。而这些块粘进去只会得到 `syntax error near unexpected token '('` —— 用户会以为是自己的环境有问题。语言标错还让语法高亮跟着错。

中英两侧对称，各 6 处。

## 验证

- 改完重扫 **468** 个块：解析失败 **13 → 3**，剩下 3 个全是上面那类有意占位符；
- `check-doc-symbol-anchors.py` rc=0（83/83）；
- `check-docs-integrity.py` rc=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)