### PR TITLE
fix(drift-gate): 指纹比对前两边都要归一化 —— 带引号的行永远匹配不上

### DIFF
--- a/.github/scripts/check-docs-site-drift.py
+++ b/.github/scripts/check-docs-site-drift.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 import re
+from html import unescape as html_unescape
 import subprocess
 import sys
 import html as _html
@@ -273,7 +274,19 @@ def run() -> int:
         # 「已经部署好的页」报成 behind main(2026-08-29 两个英文页实测假阳性)。
         text = _html.unescape(text)
         text = re.sub(r"\s+", " ", text)
-        if re.sub(r"\s+", " ", fp) in text:
+        # 🔴 渲染会改写指纹里的字符，比对前两边都要过同一次归一化，否则会报假红：
+        #   ① VitePress 把 `'` 渲染成 `&#39;`（`"` → `&quot;`，`&` → `&amp;`…），
+        #      所以任何**带引号**的源码行（SQL/JSON/命令行里到处都是）永远匹配不上；
+        #   ② 语法高亮把 token 拆进各自的 <span>，去标签后会多出空格
+        #      （`'system',` → `'system' ,`），所以标点前后也要归一。
+        #   实测：`actor TEXT NOT NULL DEFAULT 'system', -- …` 这一行，
+        #   **刚构建出来的本地产物**里也匹配不上 —— 也就是说这条红与线上新旧无关，
+        #   是判据自身的洞。会让人以为"站点没部署"，然后去重复部署（而那不会有任何效果）。
+        text = html_unescape(text)
+        text = re.sub(r"\s*([,;:])\s*", r"\1", text)
+        fp_norm = re.sub(r"\s+", " ", html_unescape(fp))
+        fp_norm = re.sub(r"\s*([,;:])\s*", r"\1", fp_norm)
+        if fp_norm in text:
             print(f"  ok   {rel}  →  {md_to_url(rel)}   [{source}]")
         else:
             print(f"  MISS {rel}  →  {md_to_url(rel)}   [{source}]")


### PR DESCRIPTION
## 症状：一道会把「已经部署好」报成「没部署」的门

`check-docs-site-drift.py` 拿**源码原文**当指纹，去匹配**渲染后的 HTML**。渲染会改写指纹里的字符：

- VitePress 把 `'` 渲染成 `&#39;`（`"` → `&quot;`、`&` → `&amp;`…）
- 语法高亮把 token 拆进各自的 `<span>`，去标签后标点前后多出空格（`'system',` → `'system' ,`）

⇒ **任何带引号的源码行**（SQL / JSON / 命令行里到处都是）都匹配不上。

## 🔴 决定性证据：本地产物也匹配不上

今天实测：anet.sh 部署成功（日志 `Using prebuilt build artifacts` + `Aliased https://www.anet.sh`），门仍报 **2 页落后**，指纹是

```
actor         TEXT NOT NULL DEFAULT 'system',          -- NOT NULL + 默认 'system'
```

拿这条指纹去搜**刚 `vitepress build` 出来的本地 dist** —— **同样搜不到**。本地产物的渲染结果是 `actor TEXT NOT NULL DEFAULT &#39;system&#39; , -- …`。

**所以这条红与线上新旧无关，是判据自身的洞。** 后果不只是多一条红：它会让人以为站点没部署，然后**重复部署**，而那不会有任何效果 —— 一道指向错误动作的门。

## 改动

比对前两边过同一次归一化：`html.unescape()` + 收掉标点前后的空白。

## 见证红（比改动本身更重要）

改完必须证明门**还抓得住真漂移**，否则就是把门改绿（缩小扫描面那一类）。

| 步骤 | 结果 |
|---|---|
| 往 `concepts/task-lifecycle.md` 提交一行线上不可能有的句子 | **rc=1**，`MISS concepts/task-lifecycle.md`，报错里原样打出那句 |
| 撤掉该提交 | rc=0，文件 `cmp` 逐字还原 |
| 修复后对真实线上 | rc=0，`every sampled page on the live site matches main` |

### 🔴 第一次见证红失败 —— 而错在我的探针，不在门

第一版 sentinel 写成 `… DRIFT_PROBE_SENTINEL_9f3a2b。`，含 `_`；而 `fingerprint()` **明确跳过含 `*_\`` 的行**（渲染后 markdown 强调符号会消失）。于是它根本没被选成指纹，门当然不红。

我一度据此以为门还有第二层缺陷（40 提交窗口 + first-match 会钉住陈旧行）——**那个判断是错的，在此撤回**。换成不含 `_` 的句子后一次见红。

**探针没打到判据上，和判据失灵，打印出来一模一样。** 这条写进了提交信息，免得下一个人重走。

🤖 Generated with [Claude Code](https://claude.com/claude-code)