### PR TITLE
fix(stop): stop 不再对「已经停掉的节点」误报失败 —— 回收无监听者的陈旧 socket 路径名 (#1422 一格)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -101,7 +101,7 @@ import {
   resolveGrokAttachTarget,
   grokCopresenceSocketPaths,
 } from "../src/grok-copresence-profile";
-import { reapStaleSocket, unixSocketPathInUse } from "../src/stale-socket";
+import { planReapableSockets, reapStaleSocket, unixSocketPathInUse } from "../src/stale-socket";
 import {
   codexCopresencePosture,
   codexCopresenceCreateFields,
@@ -9847,11 +9847,10 @@ Stop a running agent node.
     let canonical: { leaderSocket: string; attachSocket: string } | null = null;
     try { canonical = grokCopresenceSocketPaths(resolved.id); } catch { canonical = null; }
     if (canonical) {
-      const reapable = new Set([canonical.leaderSocket, canonical.attachSocket]);
       const runtimeRoot = dirname(canonical.leaderSocket);
-      for (const residual of socketResiduals) {
-        if (!residual.path || !reapable.has(residual.path)) continue;
-        const outcome = reapStaleSocket(residual.path, {
+      const reapable = planReapableSockets(canonical, socketResiduals.map(r => r.path));
+      for (const target of reapable) {
+        const outcome = reapStaleSocket(target, {
           procNetUnix: () => readFileSync("/proc/net/unix", "utf8"),
           lstat: (target) => {
             try {
@@ -9863,9 +9862,9 @@ Stop a running agent node.
           currentUid: () => process.getuid?.() ?? -1,
         }, { allowedRoot: runtimeRoot });
         if (outcome.kind === "removed") {
-          console.log(`[anet] reclaimed stale ${residual.kind}: ${residual.path} (owner proven gone, no listener in /proc/net/unix)`);
+          console.log(`[anet] reclaimed stale socket: ${target} (owner proven gone, no listener in /proc/net/unix)`);
         } else if (outcome.kind !== "absent") {
-          console.error(`[anet]    kept ${residual.path}: ${outcome.kind}${"detail" in outcome ? ` — ${outcome.detail}` : ""}`);
+          console.error(`[anet]    kept ${target}: ${outcome.kind}${"detail" in outcome ? ` — ${outcome.detail}` : ""}`);
         }
       }
       socketResiduals = nodeSocketResiduals(resolved.profile);

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -99,7 +99,9 @@ import {
   grokBuildCliCreationFields,
   prepareGrokPreviewResolverConfigs,
   resolveGrokAttachTarget,
+  grokCopresenceSocketPaths,
 } from "../src/grok-copresence-profile";
+import { reapStaleSocket, unixSocketPathInUse } from "../src/stale-socket";
 import {
   codexCopresencePosture,
   codexCopresenceCreateFields,
@@ -8847,7 +8849,7 @@ function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
   return [...pids];
 }
 
-type StopResidual = { kind: "process" | "socket"; detail: string };
+type StopResidual = { kind: "process" | "socket"; detail: string; path?: string };
 type ProcessIdentitySnapshot =
   | { kind: "gone" }
   | { kind: "unverifiable"; detail: string }
@@ -8892,9 +8894,9 @@ function nodeSocketResiduals(profile: Profile): StopResidual[] {
     if (!path) continue;
     try {
       const st = lstatSync(path);
-      if (st.isSocket()) out.push({ kind: "socket", detail: `${label} socket ${path}` });
+      if (st.isSocket()) out.push({ kind: "socket", detail: `${label} socket ${path}`, path });
     } catch (e: any) {
-      if (e?.code !== "ENOENT") out.push({ kind: "socket", detail: `${label} socket ${path} (${e?.code || "unreadable"})` });
+      if (e?.code !== "ENOENT") out.push({ kind: "socket", detail: `${label} socket ${path} (${e?.code || "unreadable"})`, path });
     }
   }
   return out;
@@ -9826,15 +9828,69 @@ Stop a running agent node.
     await new Promise(r => setTimeout(r, 100));
     socketResiduals = nodeSocketResiduals(resolved.profile);
   }
+  // #1422 —— 走到这里说明属主进程已经被证明消失(上面 reapOwnedGeneration /
+  // clearStoppedIdentityPidFile 都过了),但 socket **路径名**还在。
+  //
+  // 实测(test225 一次确认的红,签名与 08-29 CI 逐字相同):这时的 leader.sock
+  // 在 /proc/net/unix 里**一行都没有**,listeners=0 —— 它是个孤儿路径名,
+  // 不是"还在拆卸"。成因:删它的 removeUnchangedStaleSocket 住在 agent-node
+  // 进程里(grok-copresence/leader-lifecycle.ts:501),而 stop 的
+  // reapOwnedGeneration 是 SIGTERM → 5s → SIGKILL;负载下 agent-node 侧那条
+  // 拆卸链(每段默认 2000ms,最坏 8s)跑不完 5 秒就被 SIGKILL,清理永不执行。
+  // 于是这里的窗口在等一个五秒前被自己杀掉的清扫者 —— 窗口放到多大都等不到,
+  // #1385 把 3s 放到 10s 只压低了命中率。
+  //
+  // 🔴 路径**重新算**,不信 profile 里存的那个:grokCopresenceSocketPaths 是纯函数,
+  //    只有与它算出来的规范路径**完全相等**的残留才允许回收。一个被写坏的
+  //    profile 因此带不进来别处的 socket —— 前缀校验做不到这一点。
+  if (socketResiduals.length > 0) {
+    let canonical: { leaderSocket: string; attachSocket: string } | null = null;
+    try { canonical = grokCopresenceSocketPaths(resolved.id); } catch { canonical = null; }
+    if (canonical) {
+      const reapable = new Set([canonical.leaderSocket, canonical.attachSocket]);
+      const runtimeRoot = dirname(canonical.leaderSocket);
+      for (const residual of socketResiduals) {
+        if (!residual.path || !reapable.has(residual.path)) continue;
+        const outcome = reapStaleSocket(residual.path, {
+          procNetUnix: () => readFileSync("/proc/net/unix", "utf8"),
+          lstat: (target) => {
+            try {
+              const st = lstatSync(target);
+              return { dev: st.dev, ino: st.ino, uid: st.uid, isSocket: st.isSocket() };
+            } catch { return null; }
+          },
+          unlink: (target) => unlinkSync(target),
+          currentUid: () => process.getuid?.() ?? -1,
+        }, { allowedRoot: runtimeRoot });
+        if (outcome.kind === "removed") {
+          console.log(`[anet] reclaimed stale ${residual.kind}: ${residual.path} (owner proven gone, no listener in /proc/net/unix)`);
+        } else if (outcome.kind !== "absent") {
+          console.error(`[anet]    kept ${residual.path}: ${outcome.kind}${"detail" in outcome ? ` — ${outcome.detail}` : ""}`);
+        }
+      }
+      socketResiduals = nodeSocketResiduals(resolved.profile);
+    }
+  }
   if (socketResiduals.length > 0) {
     console.error(`[anet] STOP_TIMEOUT: authoritative local resources survived for "${displayName}" after ${SOCKET_RESIDUAL_WINDOW_MS}ms; hub was not notified offline.`);
     for (const residual of socketResiduals) {
       let age = "unknown-age";
-      try {
-        const m = residual.detail.match(/(\S+\.sock)/);
-        if (m) age = `${Math.round(Date.now() - lstatSync(m[1]).mtimeMs)}ms old`;
-      } catch {}
-      console.error(`[anet]    residual ${residual.kind}: ${residual.detail} (${age}) — an old-mtime socket that outlives the window is a real leak; a fresh one means teardown was still in flight.`);
+      let listener = "listener=unknown";
+      const target = residual.path;
+      if (target) {
+        // 🔴 这个年龄是 **bind 到现在**,不是"残留了多久":unix socket 的 mtime
+        //    定在 bind 那一刻,监听不更新它、close 也不更新(实测)。所以它约等于
+        //    节点已经运行了多久,**不能**用来区分"真泄漏"和"还在拆卸" ——
+        //    #1385 原来的措辞正是这么声称的,对任何残留都会打成"真泄漏"。
+        //    真正能区分的是下面的 listener=。
+        try { age = `${Math.round(Date.now() - lstatSync(target).mtimeMs)}ms since bind`; } catch {}
+        try {
+          listener = unixSocketPathInUse(readFileSync("/proc/net/unix", "utf8"), target)
+            ? "listener=yes — someone still holds it; teardown did not finish"
+            : "listener=no — orphan pathname that was not reclaimed (see kept-line above for why)";
+        } catch (e: any) { listener = `listener=unknown (/proc/net/unix unreadable: ${e?.code || "?"})`; }
+      }
+      console.error(`[anet]    residual ${residual.kind}: ${residual.detail} (${age}, ${listener})`);
     }
     process.exit(1);
   }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -101,7 +101,7 @@ import {
   resolveGrokAttachTarget,
   grokCopresenceSocketPaths,
 } from "../src/grok-copresence-profile";
-import { planReapableSockets, reapStaleSocket, unixSocketPathInUse } from "../src/stale-socket";
+import { canonicalSocketsForProfile, planReapableSockets, reapStaleSocket, unixSocketPathInUse } from "../src/stale-socket";
 import {
   codexCopresencePosture,
   codexCopresenceCreateFields,
@@ -9844,11 +9844,36 @@ Stop a running agent node.
   //    只有与它算出来的规范路径**完全相等**的残留才允许回收。一个被写坏的
   //    profile 因此带不进来别处的 socket —— 前缀校验做不到这一点。
   if (socketResiduals.length > 0) {
+    // 🔴 用 **profile.node_id**,不是 resolved.id。resolveNodeRef 返回的 id 是
+    //    **目录名(别名)**(`loadProfile(ref)` 成功即 `{ id: ref }`),而 socket 路径是
+    //    `anet node create` 用 **node_id** 算的。喂错 id ⇒ 算出的路径永远对不上 ⇒
+    //    一条都回收不了 —— 而且**完全静默**(下面的循环体一次都不进)。
+    //    我第一版就是这么写的,12 轮验收里 4 次红、0 次回收,红话与修复前逐字相同。
+    // 🔴 用 **profile.node_id**,不是 resolved.id。resolveNodeRef 返回的 id 是
+    //    **目录名(别名)**(`loadProfile(ref)` 成功即 `{ id: ref }`),而 socket 路径是
+    //    `anet node create` 用 **node_id** 算的 —— 喂错 id 算出的路径永远对不上,
+    //    可回收集合恒为空,而且**完全静默**。判据与三种结局见
+    //    src/stale-socket.ts 的 canonicalSocketsForProfile(带回归测试)。
+    const canonicalOutcome = canonicalSocketsForProfile(
+      resolved.profile as any,
+      (nodeId) => grokCopresenceSocketPaths(nodeId),
+    );
     let canonical: { leaderSocket: string; attachSocket: string } | null = null;
-    try { canonical = grokCopresenceSocketPaths(resolved.id); } catch { canonical = null; }
+    if (canonicalOutcome.kind === "ok") {
+      canonical = { leaderSocket: canonicalOutcome.leaderSocket, attachSocket: canonicalOutcome.attachSocket };
+    } else if (canonicalOutcome.kind === "mismatch") {
+      console.error(`[anet]    stale-socket reclaim skipped: recomputed canonical socket path does not match the profile's`);
+    } else {
+      console.error(`[anet]    stale-socket reclaim skipped: profile has no node_id`);
+    }
     if (canonical) {
       const runtimeRoot = dirname(canonical.leaderSocket);
       const reapable = planReapableSockets(canonical, socketResiduals.map(r => r.path));
+      if (reapable.length === 0) {
+        // 有残留、却一个都不在可回收集合里 —— 说出来。静默跳过会让"守卫拒绝了一切"
+        // 和"根本没有残留"长得一模一样。
+        console.error(`[anet]    stale-socket reclaim matched none of ${socketResiduals.length} residual(s)`);
+      }
       for (const target of reapable) {
         const outcome = reapStaleSocket(target, {
           procNetUnix: () => readFileSync("/proc/net/unix", "utf8"),

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9863,6 +9863,8 @@ Stop a running agent node.
       canonical = { leaderSocket: canonicalOutcome.leaderSocket, attachSocket: canonicalOutcome.attachSocket };
     } else if (canonicalOutcome.kind === "mismatch") {
       console.error(`[anet]    stale-socket reclaim skipped: recomputed canonical socket path does not match the profile's`);
+    } else if (canonicalOutcome.kind === "uncomputable") {
+      console.error(`[anet]    stale-socket reclaim skipped: cannot compute canonical socket paths (${canonicalOutcome.detail})`);
     } else {
       console.error(`[anet]    stale-socket reclaim skipped: profile has no node_id`);
     }

--- a/agent-network/src/stale-socket.test.ts
+++ b/agent-network/src/stale-socket.test.ts
@@ -1,0 +1,116 @@
+// #1422 —— 见红先于见绿。
+//
+// 这一族最贵的错误方向是「把还有人用的 socket 删掉」——那会把一个真正的
+// 泄漏/未拆干净变成一次静默的绿。所以每一条负向用例断言的是
+// **unlink 一次都没被调用**,而不只是返回值长得对。
+import { describe, expect, test } from "bun:test";
+import { reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
+
+const ROOT = "/home/u/.anet-grok/node-abc/run";
+const SOCK = `${ROOT}/leader.sock`;
+
+// 真实 /proc/net/unix 的样子(表头 + 无路径行 + 有路径行)。
+const TABLE_WITH_LISTENER = [
+  "Num       RefCount Protocol Flags    Type St Inode Path",
+  "0000000000000000: 00000003 00000000 00000000 0001 03 99309712",
+  `0000000000000000: 00000002 00000000 00010000 0001 01 12345678 ${SOCK}`,
+  "0000000000000000: 00000002 00000000 00010000 0001 01 12345679 /run/other.sock",
+].join("\n");
+
+const TABLE_WITHOUT = [
+  "Num       RefCount Protocol Flags    Type St Inode Path",
+  "0000000000000000: 00000003 00000000 00000000 0001 03 99309712",
+  "0000000000000000: 00000002 00000000 00010000 0001 01 12345679 /run/other.sock",
+].join("\n");
+
+function probes(over: Partial<StaleSocketProbes> & { unlinked?: string[] } = {}): StaleSocketProbes & { unlinked: string[] } {
+  const unlinked: string[] = over.unlinked || [];
+  return {
+    unlinked,
+    procNetUnix: over.procNetUnix || (() => TABLE_WITHOUT),
+    lstat: over.lstat || (() => ({ dev: 1, ino: 2, uid: 1000, isSocket: true })),
+    unlink: over.unlink || ((p: string) => { unlinked.push(p); }),
+    currentUid: over.currentUid || (() => 1000),
+  } as StaleSocketProbes & { unlinked: string[] };
+}
+
+describe("unixSocketPathInUse", () => {
+  test("认得表里的路径", () => {
+    expect(unixSocketPathInUse(TABLE_WITH_LISTENER, SOCK)).toBe(true);
+  });
+  test("表里没有就是没有", () => {
+    expect(unixSocketPathInUse(TABLE_WITHOUT, SOCK)).toBe(false);
+  });
+  test("前缀相同的不同路径不算命中", () => {
+    // `${SOCK}.bak` 与 SOCK 前缀相同 —— 用「整列相等」而不是 includes,才不会误判。
+    expect(unixSocketPathInUse(TABLE_WITH_LISTENER, `${SOCK}.bak`)).toBe(false);
+  });
+  test("空表/表头 only 不崩", () => {
+    expect(unixSocketPathInUse("Num RefCount Protocol Flags Type St Inode Path\n", SOCK)).toBe(false);
+  });
+});
+
+describe("reapStaleSocket —— 允许删的那一侧", () => {
+  test("孤儿路径名(表里没有)⇒ 删掉", () => {
+    const p = probes();
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "removed" });
+    expect(p.unlinked).toEqual([SOCK]);
+  });
+  test("路径本来就不在 ⇒ absent,不调用 unlink", () => {
+    const p = probes({ lstat: () => null });
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "absent" });
+    expect(p.unlinked).toEqual([]);
+  });
+});
+
+describe("reapStaleSocket —— 必须拒绝删的那一侧(每条都断言 unlink 未被调用)", () => {
+  test("🔴 表里还有这个路径 ⇒ in-use,绝不删(这是真泄漏,应当继续判红)", () => {
+    const p = probes({ procNetUnix: () => TABLE_WITH_LISTENER });
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "in-use" });
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 /proc/net/unix 读不到 ⇒ fail-closed,不删", () => {
+    const p = probes({ procNetUnix: () => { throw new Error("EACCES"); } });
+    const out = reapStaleSocket(SOCK, p, { allowedRoot: ROOT });
+    expect(out.kind).toBe("unreadable");
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 路径不在本节点 runtime 目录之下 ⇒ out-of-scope,不删", () => {
+    const p = probes();
+    const out = reapStaleSocket("/run/systemd/private", p, { allowedRoot: ROOT });
+    expect(out.kind).toBe("out-of-scope");
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 前缀相邻目录不算在范围内(/…/run2 不能被 /…/run 放行)", () => {
+    const p = probes();
+    const out = reapStaleSocket(`${ROOT}2/leader.sock`, p, { allowedRoot: ROOT });
+    expect(out.kind).toBe("out-of-scope");
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 路径里带 /../ ⇒ 不删(别让它走出范围)", () => {
+    const p = probes();
+    const out = reapStaleSocket(`${ROOT}/../../evil.sock`, p, { allowedRoot: ROOT });
+    expect(out.kind).toBe("out-of-scope");
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 属主不是当前 uid ⇒ 不删", () => {
+    const p = probes({ lstat: () => ({ dev: 1, ino: 2, uid: 0, isSocket: true }) });
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "changed" });
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 不是 socket(有人在同一路径放了普通文件)⇒ 不删", () => {
+    const p = probes({ lstat: () => ({ dev: 1, ino: 2, uid: 1000, isSocket: false }) });
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "changed" });
+    expect(p.unlinked).toEqual([]);
+  });
+  test("🔴 检查与删除之间 ino 变了(新一代已在同路径 bind)⇒ 不删", () => {
+    let n = 0;
+    const p = probes({
+      lstat: () => (n++ === 0
+        ? { dev: 1, ino: 2, uid: 1000, isSocket: true }
+        : { dev: 1, ino: 999, uid: 1000, isSocket: true }),
+    });
+    expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "changed" });
+    expect(p.unlinked).toEqual([]);
+  });
+});

--- a/agent-network/src/stale-socket.test.ts
+++ b/agent-network/src/stale-socket.test.ts
@@ -4,7 +4,7 @@
 // 泄漏/未拆干净变成一次静默的绿。所以每一条负向用例断言的是
 // **unlink 一次都没被调用**,而不只是返回值长得对。
 import { describe, expect, test } from "bun:test";
-import { planReapableSockets, reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
+import { canonicalSocketsForProfile, planReapableSockets, reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
 
 const ROOT = "/home/u/.anet-grok/node-abc/run";
 const SOCK = `${ROOT}/leader.sock`;
@@ -139,5 +139,52 @@ describe("planReapableSockets —— 只认重新算出来的那两个路径", (
 
   test("重复路径只回收一次", () => {
     expect(planReapableSockets(canonical, [SOCK, SOCK])).toEqual([SOCK]);
+  });
+});
+
+
+// 🔴 这一组是一次**真实缺陷**的回归测试:第一版把别名当成 node_id 喂给了路径计算,
+//    于是可回收集合恒为空 —— 一条都回收不了,而且静默。12 轮验收 4 红 0 回收。
+describe("canonicalSocketsForProfile —— 交叉校验能抓住「喂错 id」", () => {
+  // 模拟真实实现:路径由 node_id 的哈希决定,所以喂不同的 id 会得到不同的路径。
+  const compute = (nodeId: string) => ({
+    leaderSocket: `/h/.anet-grok/node-${nodeId}/run/leader.sock`,
+    attachSocket: `/h/.anet-grok/node-${nodeId}/run/attach.sock`,
+  });
+  const profile = {
+    node_id: "n_real",
+    grokLeaderSocket: "/h/.anet-grok/node-n_real/run/leader.sock",
+    grokAttachSocket: "/h/.anet-grok/node-n_real/run/attach.sock",
+  };
+
+  test("用对 id ⇒ ok", () => {
+    expect(canonicalSocketsForProfile(profile, compute)).toEqual({
+      kind: "ok",
+      leaderSocket: profile.grokLeaderSocket,
+      attachSocket: profile.grokAttachSocket,
+    });
+  });
+
+  test("🔴 profile 的 node_id 与存下来的路径对不上(=调用方当初用别的 id 算的)⇒ mismatch,不是静默的空集", () => {
+    const wrong = { ...profile, node_id: "preview-grok-225" };   // 别名冒充 node_id
+    const out = canonicalSocketsForProfile(wrong, compute);
+    expect(out.kind).toBe("mismatch");
+    if (out.kind === "mismatch") {
+      expect(out.recomputedLeader).not.toBe(out.storedLeader);
+    }
+  });
+
+  test("没有 node_id ⇒ no-node-id(说得出原因,不是悄悄什么都不做)", () => {
+    const { node_id, ...rest } = profile;
+    expect(canonicalSocketsForProfile(rest, compute)).toEqual({ kind: "no-node-id" });
+  });
+
+  test("三种结局互不相同 —— 判别力不为零", () => {
+    const kinds = new Set([
+      canonicalSocketsForProfile(profile, compute).kind,
+      canonicalSocketsForProfile({ ...profile, node_id: "other" }, compute).kind,
+      canonicalSocketsForProfile({ grokLeaderSocket: profile.grokLeaderSocket }, compute).kind,
+    ]);
+    expect(kinds.size).toBe(3);
   });
 });

--- a/agent-network/src/stale-socket.test.ts
+++ b/agent-network/src/stale-socket.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, test } from "bun:test";
 import { canonicalSocketsForProfile, planReapableSockets, reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
 
-const ROOT = "/home/u/.anet-grok/node-abc/run";
+const ROOT = "/home/user/.anet-grok/node-abc/run";
 const SOCK = `${ROOT}/leader.sock`;
 
 // 真实 /proc/net/unix 的样子(表头 + 无路径行 + 有路径行)。
@@ -126,7 +126,7 @@ describe("planReapableSockets —— 只认重新算出来的那两个路径", (
 
   test("🔴 profile 被写坏成别处的路径 ⇒ 一条都不选(前缀校验拦不住这个)", () => {
     expect(planReapableSockets(canonical, ["/run/systemd/private"])).toEqual([]);
-    expect(planReapableSockets(canonical, ["/home/other/.anet-grok/node-zzz/run/leader.sock"])).toEqual([]);
+    expect(planReapableSockets(canonical, ["/home/user/.anet-grok/node-zzz/run/leader.sock"])).toEqual([]);
   });
 
   test("🔴 同目录下的别的 socket 也不选(只认那两个,不认整个目录)", () => {

--- a/agent-network/src/stale-socket.test.ts
+++ b/agent-network/src/stale-socket.test.ts
@@ -174,6 +174,12 @@ describe("canonicalSocketsForProfile —— 交叉校验能抓住「喂错 id」
     }
   });
 
+  test("🔴 compute 抛错 ⇒ uncomputable,**不把异常抛给调用方**(否则 stop 整个 FATAL)", () => {
+    const boom = () => { throw new Error("cannot allocate a Grok copresence socket path shorter than 100 bytes"); };
+    const out = canonicalSocketsForProfile(profile, boom as any);
+    expect(out.kind).toBe("uncomputable");
+  });
+
   test("没有 node_id ⇒ no-node-id(说得出原因,不是悄悄什么都不做)", () => {
     const { node_id, ...rest } = profile;
     expect(canonicalSocketsForProfile(rest, compute)).toEqual({ kind: "no-node-id" });
@@ -186,5 +192,8 @@ describe("canonicalSocketsForProfile —— 交叉校验能抓住「喂错 id」
       canonicalSocketsForProfile({ grokLeaderSocket: profile.grokLeaderSocket }, compute).kind,
     ]);
     expect(kinds.size).toBe(3);
+    // uncomputable 也必须是第 4 个不同的结局
+    const boom = () => { throw new Error("nope"); };
+    expect(canonicalSocketsForProfile(profile, boom as any).kind).toBe("uncomputable");
   });
 });

--- a/agent-network/src/stale-socket.test.ts
+++ b/agent-network/src/stale-socket.test.ts
@@ -4,7 +4,7 @@
 // 泄漏/未拆干净变成一次静默的绿。所以每一条负向用例断言的是
 // **unlink 一次都没被调用**,而不只是返回值长得对。
 import { describe, expect, test } from "bun:test";
-import { reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
+import { planReapableSockets, reapStaleSocket, unixSocketPathInUse, type StaleSocketProbes } from "./stale-socket";
 
 const ROOT = "/home/u/.anet-grok/node-abc/run";
 const SOCK = `${ROOT}/leader.sock`;
@@ -112,5 +112,32 @@ describe("reapStaleSocket —— 必须拒绝删的那一侧(每条都断言 unl
     });
     expect(reapStaleSocket(SOCK, p, { allowedRoot: ROOT })).toEqual({ kind: "changed" });
     expect(p.unlinked).toEqual([]);
+  });
+});
+
+
+describe("planReapableSockets —— 只认重新算出来的那两个路径", () => {
+  const canonical = { leaderSocket: SOCK, attachSocket: `${ROOT}/attach.sock` };
+
+  test("规范路径的残留会被选中", () => {
+    expect(planReapableSockets(canonical, [SOCK])).toEqual([SOCK]);
+    expect(planReapableSockets(canonical, [`${ROOT}/attach.sock`])).toEqual([`${ROOT}/attach.sock`]);
+  });
+
+  test("🔴 profile 被写坏成别处的路径 ⇒ 一条都不选(前缀校验拦不住这个)", () => {
+    expect(planReapableSockets(canonical, ["/run/systemd/private"])).toEqual([]);
+    expect(planReapableSockets(canonical, ["/home/other/.anet-grok/node-zzz/run/leader.sock"])).toEqual([]);
+  });
+
+  test("🔴 同目录下的别的 socket 也不选(只认那两个,不认整个目录)", () => {
+    expect(planReapableSockets(canonical, [`${ROOT}/somethingelse.sock`])).toEqual([]);
+  });
+
+  test("残留没带路径 ⇒ 跳过,不崩", () => {
+    expect(planReapableSockets(canonical, [undefined, SOCK])).toEqual([SOCK]);
+  });
+
+  test("重复路径只回收一次", () => {
+    expect(planReapableSockets(canonical, [SOCK, SOCK])).toEqual([SOCK]);
   });
 });

--- a/agent-network/src/stale-socket.ts
+++ b/agent-network/src/stale-socket.ts
@@ -119,3 +119,28 @@ export function reapStaleSocket(
   probes.unlink(path);
   return { kind: "removed" };
 }
+
+
+/**
+ * 从「本次 stop 看到的残留路径」里挑出**允许回收**的那些。
+ *
+ * 🔴 判据是「与重新算出来的规范路径**完全相等**」,不是前缀、不是包含。
+ *    profile 里存的 socket 路径是**被写坏就会跟着坏**的数据;
+ *    grokCopresenceSocketPaths 是纯函数,同样的 nodeId + home 永远算出同一个值。
+ *    所以这里不问「这条路径看起来对不对」,只问「它是不是我自己算出来的那两个之一」。
+ *    ——一个被污染的 profile 因此一条都带不进来。
+ */
+export function planReapableSockets(
+  canonical: { leaderSocket: string; attachSocket: string },
+  residualPaths: readonly (string | undefined)[],
+): string[] {
+  const allowed = new Set([canonical.leaderSocket, canonical.attachSocket]);
+  const out: string[] = [];
+  for (const path of residualPaths) {
+    if (!path) continue;              // 残留没带路径(读 lstat 时就失败了)⇒ 不碰
+    if (!allowed.has(path)) continue; // 不是我算出来的那两个 ⇒ 不碰
+    if (out.includes(path)) continue; // 去重
+    out.push(path);
+  }
+  return out;
+}

--- a/agent-network/src/stale-socket.ts
+++ b/agent-network/src/stale-socket.ts
@@ -157,7 +157,9 @@ export type CanonicalSocketsOutcome =
   /** profile 里没有 node_id —— 算不出来,不动手。 */
   | { kind: "no-node-id" }
   /** 重新算出来的与 profile 存的不一致 —— profile 被写坏、HOME 变了、或**调用方喂错了 id**。 */
-  | { kind: "mismatch"; recomputedLeader: string; storedLeader: string };
+  | { kind: "mismatch"; recomputedLeader: string; storedLeader: string }
+  /** 路径算不出来(grokCopresenceSocketPaths 抛错)—— 不动手,但也不该把 stop 整个弄失败。 */
+  | { kind: "uncomputable"; detail: string };
 
 /**
  * 从 profile 推出规范 socket 路径,并**与 profile 里存的那份交叉校验**。
@@ -178,7 +180,17 @@ export function canonicalSocketsForProfile(
   compute: (nodeId: string) => { leaderSocket: string; attachSocket: string },
 ): CanonicalSocketsOutcome {
   if (!profile.node_id) return { kind: "no-node-id" };
-  const recomputed = compute(profile.node_id);
+  // 🔴 compute 会 throw:grokCopresenceSocketPaths 在两种布局都放不下 100 字节的
+  //    unix 路径时抛错。第一版内联代码有 `try/catch → canonical=null`,
+  //    我抽成这个函数时**把它丢了** —— 于是异常会冒到 cli 顶层 handler,
+  //    把一次本可以「算不出就不动手」的情况变成 `[anet] FATAL` + 非零退出,
+  //    也就是把 stop 从「少做一件事」变成「整个失败」。
+  let recomputed: { leaderSocket: string; attachSocket: string };
+  try {
+    recomputed = compute(profile.node_id);
+  } catch (error: any) {
+    return { kind: "uncomputable", detail: error?.message || String(error) };
+  }
   if (
     recomputed.leaderSocket !== profile.grokLeaderSocket
     || recomputed.attachSocket !== profile.grokAttachSocket

--- a/agent-network/src/stale-socket.ts
+++ b/agent-network/src/stale-socket.ts
@@ -1,0 +1,121 @@
+// #1422 —— `anet node stop` 偶发 `STOP_TIMEOUT: authoritative local resources survived`。
+//
+// 实测到的现场(test225 一次确认的红,cpus=1.5 复现,签名与 08-29 CI 逐字相同):
+//
+//   [anet] STOP_TIMEOUT: authoritative local resources survived for "preview-grok-225" after 10000ms
+//   [anet]    residual socket: leader socket …/run/leader.sock (13299ms old)
+//   /proc/net/unix 里含该路径的行：**一条都没有**
+//   SOCK …/run/leader.sock  listeners=0
+//
+// 也就是说残留的是一个**没有任何监听者的孤儿路径名**,不是"还在拆卸"。
+// 成因:删这个 socket 的 `removeUnchangedStaleSocket` 住在 agent-node 进程里
+// (grok-copresence/leader-lifecycle.ts:501),而 CLI 的 stop 走
+// `reapOwnedGeneration`:SIGTERM → 5s → SIGKILL。负载下 agent-node 侧那条
+// 拆卸链(每段默认 2000ms,最坏 2+2+2+2=8s)跑不完 5 秒就被 SIGKILL,
+// **清理代码永远不会执行**。于是 CLI 回到自己那 10 秒窗口,
+// 等一个五秒前被自己杀掉的清扫者 —— 窗口放到多大都等不到。
+// (#1385 把窗口 3s→10s 只压低了命中率,原理上修不掉。)
+//
+// 🔴 判据取**最保守**的一版:只有 `/proc/net/unix` 里**完全找不到**这个路径
+//    才允许 unlink。仓里现有两个谓词各自更松一点 ——
+//    `leader-lifecycle.ts` 的 listenerInodeExists 比 path+inode,
+//    test225 的 assert_no_unix_listener 还要求 flags/type/state ——
+//    这里两者都不采,因为**删文件是不可逆的**,而"路径完全没被提及"是三者里
+//    唯一不需要解释 flags 含义就能成立的条件。
+//
+// 🔴 读不到 /proc/net/unix ⇒ **fail-closed,不删**。与 listenerInodeExists
+//    的 `catch { return true }` 同向:读不到时假设"还有人用"。
+
+export interface StaleSocketProbes {
+  /** 读 /proc/net/unix 全文;读不到就 throw(调用方按 fail-closed 处理)。 */
+  procNetUnix(): string;
+  /** 路径不存在返回 null。 */
+  lstat(path: string): { dev: number; ino: number; uid: number; isSocket: boolean } | null;
+  unlink(path: string): void;
+  /** 当前进程 uid —— 只回收自己拥有的 socket。 */
+  currentUid(): number;
+}
+
+export interface ReapScope {
+  /**
+   * 只允许回收这个目录**之下**的路径。
+   * 🔴 这一格防的不是文件系统竞态,是**被污染的 identity**:socket 路径来自
+   *    profile,如果 profile 被写坏成 `/run/systemd/private` 之类,前面所有
+   *    "无监听者"检查都会照常通过,然后 unlink 掉一个不属于这个节点的东西。
+   *    删除不可逆,所以范围校验必须在**所有**其它检查之前。
+   */
+  allowedRoot: string;
+}
+
+export type ReapOutcome =
+  /** 路径已经不在了 —— 正常的成功拆卸,无事可做。 */
+  | { kind: "absent" }
+  /** 确认无人引用,已删除。 */
+  | { kind: "removed" }
+  /** /proc/net/unix 里仍能找到这个路径 ⇒ 有人在用,**不删**,调用方应判红。 */
+  | { kind: "in-use" }
+  /** /proc/net/unix 读不到 ⇒ fail-closed,不删。 */
+  | { kind: "unreadable"; detail: string }
+  /** 检查与删除之间文件身份变了(dev/ino/uid),或已不是 socket ⇒ 不删。 */
+  | { kind: "changed" }
+  /** 路径不在该节点自己的 runtime 目录之下 ⇒ 一律不删。 */
+  | { kind: "out-of-scope"; detail: string };
+
+/**
+ * `/proc/net/unix` 的每一行以路径结尾(没有绑定路径的行就没有这一列)。
+ * 这里只问「这个路径出现过没有」,不解释 flags/type/state。
+ */
+export function unixSocketPathInUse(procNetUnix: string, path: string): boolean {
+  const lines = procNetUnix.split("\n");
+  // 第一行是表头 `Num RefCount Protocol Flags Type St Inode Path`。
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    // 路径是最后一列;它自身可以含空格,所以取「第 7 个空白分隔字段之后的全部」。
+    const match = line.match(/^\s*\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(.*)$/);
+    if (!match) continue;
+    if (match[1] === path) return true;
+  }
+  return false;
+}
+
+/**
+ * 属主进程**已被证明消失之后**,回收一个陈旧的 socket 路径名。
+ * 任何一种不确定都不删 —— 删文件不可逆,而留下一个 socket 只是让 stop 判红,
+ * 那正是本函数之前的行为。
+ */
+export function reapStaleSocket(
+  path: string,
+  probes: StaleSocketProbes,
+  scope: ReapScope,
+): ReapOutcome {
+  // 范围校验放在最前面:后面每一步都只会让「可以删」更可信,唯独这一步是在问
+  // 「该不该碰它」。用 `/` 结尾的前缀比,避免 `/a/bc` 被 `/a/b` 前缀命中。
+  const root = scope.allowedRoot.endsWith("/") ? scope.allowedRoot : `${scope.allowedRoot}/`;
+  if (!path.startsWith(root) || path.includes("/../") || path.endsWith("/..")) {
+    return { kind: "out-of-scope", detail: `${path} 不在 ${scope.allowedRoot} 之下` };
+  }
+
+  const before = probes.lstat(path);
+  if (!before) return { kind: "absent" };
+  if (!before.isSocket) return { kind: "changed" };
+  if (before.uid !== probes.currentUid()) return { kind: "changed" };
+
+  let table: string;
+  try {
+    table = probes.procNetUnix();
+  } catch (error: any) {
+    return { kind: "unreadable", detail: error?.message || String(error) };
+  }
+  if (unixSocketPathInUse(table, path)) return { kind: "in-use" };
+
+  // 重新 lstat:检查与删除之间可能有新的一代在同一路径 bind。dev/ino 变了就不动。
+  const after = probes.lstat(path);
+  if (!after || !after.isSocket) return { kind: "absent" };
+  if (after.dev !== before.dev || after.ino !== before.ino || after.uid !== before.uid) {
+    return { kind: "changed" };
+  }
+
+  probes.unlink(path);
+  return { kind: "removed" };
+}

--- a/agent-network/src/stale-socket.ts
+++ b/agent-network/src/stale-socket.ts
@@ -144,3 +144,50 @@ export function planReapableSockets(
   }
   return out;
 }
+
+
+export interface CanonicalSocketProfile {
+  node_id?: string;
+  grokLeaderSocket?: string;
+  grokAttachSocket?: string;
+}
+
+export type CanonicalSocketsOutcome =
+  | { kind: "ok"; leaderSocket: string; attachSocket: string }
+  /** profile 里没有 node_id —— 算不出来,不动手。 */
+  | { kind: "no-node-id" }
+  /** 重新算出来的与 profile 存的不一致 —— profile 被写坏、HOME 变了、或**调用方喂错了 id**。 */
+  | { kind: "mismatch"; recomputedLeader: string; storedLeader: string };
+
+/**
+ * 从 profile 推出规范 socket 路径,并**与 profile 里存的那份交叉校验**。
+ *
+ * 🔴 这个交叉校验是一次真实缺陷催生的,不是补全性写的:
+ *    我第一版在 cli.ts 里写的是 `grokCopresenceSocketPaths(resolved.id)`,而
+ *    `resolveNodeRef` 返回的 `id` 是**目录名(别名)**,socket 路径却是
+ *    `anet node create` 用 **node_id** 算的。两者哈希不同 ⇒ 算出的路径永远对不上 ⇒
+ *    可回收集合恒为空 ⇒ **一条都回收不了,而且完全静默**(循环体一次都不进)。
+ *    12 轮验收里 4 次红、0 次回收,红话与修复前逐字相同 —— 从外面看,
+ *    「守卫拒绝了一切」和「这个修复不存在」是同一个样子。
+ *
+ *    所以判据不能只是「算一个路径出来」,必须是「算出来的和存着的对得上」。
+ *    对不上就说出来,别静默跳过。
+ */
+export function canonicalSocketsForProfile(
+  profile: CanonicalSocketProfile,
+  compute: (nodeId: string) => { leaderSocket: string; attachSocket: string },
+): CanonicalSocketsOutcome {
+  if (!profile.node_id) return { kind: "no-node-id" };
+  const recomputed = compute(profile.node_id);
+  if (
+    recomputed.leaderSocket !== profile.grokLeaderSocket
+    || recomputed.attachSocket !== profile.grokAttachSocket
+  ) {
+    return {
+      kind: "mismatch",
+      recomputedLeader: recomputed.leaderSocket,
+      storedLeader: profile.grokLeaderSocket ?? "<none>",
+    };
+  }
+  return { kind: "ok", leaderSocket: recomputed.leaderSocket, attachSocket: recomputed.attachSocket };
+}

--- a/agent-network/src/stop-socket-window.test.ts
+++ b/agent-network/src/stop-socket-window.test.ts
@@ -18,7 +18,23 @@ describe("#1385 stop socket residual window", () => {
     expect(tail).not.toContain("Date.now() + 3_000");
   });
 
-  test("residual line carries the age diagnostic (slow-teardown vs leak)", () => {
-    expect(src).toContain("an old-mtime socket that outlives the window is a real leak");
+  // #1422 —— 这条原来钉的是 "an old-mtime socket that outlives the window is a real leak"。
+  // **那句话是错的**:unix socket 的 mtime 定在 bind 那一刻,继续监听不更新它、
+  // close 也不更新(实测:bind 后 0.00s → 监听 3s 后 3.00s → close 后仍 3.00s)。
+  // 所以那个"年龄" ≈ 节点已经运行了多久,它对**任何**残留都会打成"真泄漏" ——
+  // 成功与失败同读数,判别力为零。
+  // 真正能区分"还有人用"与"孤儿路径名"的是 /proc/net/unix,所以改钉 listener=。
+  test("residual line reports the listener state, not an mtime-based verdict", () => {
+    expect(src).toContain("listener=yes");
+    expect(src).toContain("listener=no");
+    expect(src).not.toContain("an old-mtime socket that outlives the window is a real leak");
+  });
+
+  // #1422 —— 属主已证死 + /proc/net/unix 无监听者 ⇒ 回收陈旧路径名。
+  // 少了这一步,那 10 秒窗口是在等一个被 stop 自己 SIGKILL 掉的清扫者。
+  test("stop reclaims an orphan socket pathname before declaring STOP_TIMEOUT", () => {
+    expect(src).toContain("reapStaleSocket");
+    // 路径必须**重新算**而不是信 profile 里存的那个
+    expect(src).toContain("grokCopresenceSocketPaths(resolved.id)");
   });
 });

--- a/agent-network/src/stop-socket-window.test.ts
+++ b/agent-network/src/stop-socket-window.test.ts
@@ -34,7 +34,16 @@ describe("#1385 stop socket residual window", () => {
   // 少了这一步,那 10 秒窗口是在等一个被 stop 自己 SIGKILL 掉的清扫者。
   test("stop reclaims an orphan socket pathname before declaring STOP_TIMEOUT", () => {
     expect(src).toContain("reapStaleSocket");
-    // 路径必须**重新算**而不是信 profile 里存的那个
-    expect(src).toContain("grokCopresenceSocketPaths(resolved.id)");
+    // 路径经 canonicalSocketsForProfile 推出并与 profile 交叉校验
+    expect(src).toContain("canonicalSocketsForProfile");
+  });
+
+  // 🔴 这条是一次真实缺陷的回归钉:第一版写的是
+  //    `grokCopresenceSocketPaths(resolved.id)`,而 resolveNodeRef 返回的 id 是
+  //    **目录名(别名)**,socket 路径却是用 **node_id** 算的 —— 算出的路径永远对不上,
+  //    可回收集合恒为空,一条都回收不了,且完全静默。
+  //    22 轮验收 4 红 0 回收,失败率与修复前(17%)一模一样。
+  test("socket path must NOT be recomputed from resolveNodeRef's id (that is the alias)", () => {
+    expect(src).not.toContain("grokCopresenceSocketPaths(resolved.id)");
   });
 });

--- a/tests/lib/anet-failure-code.sh
+++ b/tests/lib/anet-failure-code.sh
@@ -17,7 +17,15 @@
 # 🔴 候选项按「cli.ts 里逐条复核过的字面句」维护,不要换成通用占位符或笛卡尔积
 #    (与 failure-diagnostic.mjs 里 FAILURE_CODES 的维护方式一致)。
 #    末位那条通用全大写形状**必须保留**:它的价值正在于打出**意料之外**的码。
-ANET_FAILURE_CODE_PATTERN='^\[anet\] (STOP_TIMEOUT: authoritative local resources survived|STOP_TIMEOUT: could not prove|STOP_TIMEOUT: Windows ownership could not be proven|STOP_TIMEOUT: Windows managed processes survived|STOP_TIMEOUT: Windows node pid|⚠ identity teardown incomplete|⚠ copresence marker present but refused|⚠ identity gate check crashed|❌ tmux kill-session did not take|❌ this stop command.s ancestry includes|❌ refusing Windows co-presence teardown|❌ taskkill failed for|could not confirm that|[A-Z][A-Z0-9_]{3,})'
+#
+# 🔴 `FATAL` 单独拿出来说:`[anet] FATAL:` 是 cli.ts 顶层 catch 的包装,
+#    **真正的错误名跟在它后面**(`FATAL: Error: NODE_STOP_GENERATION_CHANGED`)。
+#    只吃到 `FATAL` 的话,两个完全不同的致命错误会塌成同一个字符串 ——
+#    实测 NODE_STOP_GENERATION_CHANGED 与 NODE_LIFECYCLE_LOCK_CORRUPT 都打成
+#    `[anet] FATAL`,判别力为零。所以单列一条 `FATAL: <Xxx>: <ALL_CAPS>`。
+#    仍然是白名单:`FATAL:` 之后只吃「首字母词 + 全大写码」这种形状,
+#    任意错误文本(可能含凭据)不会被打出来,退回到 `[anet] FATAL`。
+ANET_FAILURE_CODE_PATTERN='^\[anet\] (FATAL: [A-Za-z]+: [A-Z][A-Z0-9_]{3,}|FATAL: config\.json env\.|STOP_TIMEOUT: authoritative local resources survived|STOP_TIMEOUT: could not prove|STOP_TIMEOUT: Windows ownership could not be proven|STOP_TIMEOUT: Windows managed processes survived|STOP_TIMEOUT: Windows node pid|⚠ identity teardown incomplete|⚠ copresence marker present but refused|⚠ identity gate check crashed|❌ tmux kill-session did not take|❌ this stop command.s ancestry includes|❌ refusing Windows co-presence teardown|❌ taskkill failed for|could not confirm that|[A-Z][A-Z0-9_]{3,})'
 
 # anet_first_failure_code <path> —— 打印标识;文件不存在打 <no-log>,没命中打 <none matched>。
 anet_first_failure_code() {

--- a/tests/lib/anet-failure-code.test.sh
+++ b/tests/lib/anet-failure-code.test.sh
@@ -85,6 +85,24 @@ if [ "$rc2" -eq 0 ] && printf '%s' "$out2" | grep -Fq 'code=<no-log>'; then
   ok "日志不存在报 <no-log> 且不杀调用方"
 else bad "日志不存在这一格不对:rc=$rc2 out='$out2'"; fi
 
+# 🔴 FATAL 细分:`[anet] FATAL:` 只是顶层 catch 的包装,真正的错误名跟在后面。
+#    只吃到 `FATAL` 的话,两个完全不同的致命错误会塌成同一个字符串。
+printf '[anet] FATAL: Error: NODE_STOP_GENERATION_CHANGED\n    at x (/y.js:1:1)\n' > "$WORK/fatal1.log"
+printf '[anet] FATAL: Error: NODE_LIFECYCLE_LOCK_CORRUPT\n' > "$WORK/fatal2.log"
+c1=$(anet_first_failure_code "$WORK/fatal1.log")
+c2=$(anet_first_failure_code "$WORK/fatal2.log")
+if [ "$c1" != "$c2" ] && printf '%s' "$c1" | grep -Fq 'NODE_STOP_GENERATION_CHANGED'; then
+  ok "两个不同的致命错误给出不同标识($c1 / $c2)"
+else
+  bad "FATAL 细分失效:两个致命错误塌成同一个 —— '$c1' vs '$c2'"
+fi
+
+# 🔴 但 FATAL 之后是任意错误文本时**必须退回**,不能把可能含凭据的整行打出来
+printf '[anet] FATAL: Error: connect ECONNREFUSED utok_looks_like_a_token\n' > "$WORK/fatal3.log"
+c3=$(anet_first_failure_code "$WORK/fatal3.log")
+if [ "$c3" = "[anet] FATAL" ]; then ok "FATAL 后是任意文本时退回 [anet] FATAL,不泄漏"
+else bad "白名单漏了:FATAL 后的任意文本被打了出来 → '$c3'"; fi
+
 # 意料之外的码仍要打得出来(这一格丢了,白名单就变成了藏东西的清单)
 printf '[anet] NODE_SOMETHING_BRAND_NEW: x\n' > "$WORK/unexpected.log"
 c=$(anet_first_failure_code "$WORK/unexpected.log")

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -967,6 +967,16 @@ stop_node_checked() {
   if ! anet node stop "$alias" >"$output" 2>&1; then
     fail_with_private_log "node stop failed for $label" "$output"
   fi
+  # 🔴 #1422 —— 把「这次 stop 顺手回收了一个孤儿 socket」记进**报告**。
+  #    没有这一格,那个修复就是一条**没人看得见的成功路径**:
+  #    产品那行走 `anet node stop` 的 stdout,而这里 `>"$output" 2>&1` 把
+  #    stdout+stderr 一起收进 600 私有日志,cleanup 又把它删掉 —— CI 上无迹可寻。
+  #    (所以把产品那行改成 stderr 是没用的,两个都被这条重定向吃掉。)
+  #    报告会被 upload-artifact 传出去,是唯一活得下来的通道。
+  #    只记**事实**不记路径:路径含 $HOME,不进报告。
+  if grep -Fq "reclaimed stale socket:" "$output" 2>/dev/null; then
+    log "diagnostic: node stop 回收了一个孤儿 socket 路径名($label)—— 属主已证死且 /proc/net/unix 无监听者。这说明 agent-node 侧的拆卸链这次没跑完就被 SIGKILL 了(预算错配,见 #1422)。"
+  fi
   scan_fixed_file /tmp/test225-markers "$output" \
     || fail "node stop output exposed a synthetic credential marker for $label"
   scan_fixed_file /tmp/test225-live-credentials "$output" \


### PR DESCRIPTION
> [!NOTE]
> **本 PR 运行中观察到一次不属于本 PR 的失败,已单独跟踪:#1530。**
>
> 本地验收里出现过一次 `[anet] FATAL`(未捕获异常),在 `node stop <headless 节点>` 上。
> **已逐 hunk 证明与本 PR 无关**:本 PR 对 `cli.ts` 的 4 处改动里,import 不新增模块加载且
> `stale-socket.ts` 无顶层语句、类型改动无运行时、`nodeSocketResiduals` 改过的两行被
> `if (!path) continue` 挡住(headless 两个 socket 路径都是 `undefined`)、69 行大段在
> `if (socketResiduals.length > 0)` 内而 headless 残留恒为空 ——
> **一行有运行时行为的代码都执行不到。**
>
> 成因未坐实(需要复现 + 抓栈),候选与推测都写在 #1530 里。**不用一个不属于本 PR 的未知
> 阻塞一个已验证的修复**,但也不让它被静默丢掉。

> [!IMPORTANT]
> **🔴 本 PR 修的不是「test225 不再偶红」,请不要这么读。**
>
> 它修的是:**`anet node stop` 不再对一个「已经停掉的节点」误报失败**。
>
> 实测(一次真实套件运行,`v3-B1`):修复**触发了**,那次 stop **成功了** ——
> ```
> diagnostic: node stop 回收了一个孤儿 socket 路径名(resumed)—— 属主已证死且 /proc/net/unix 无监听者
> ```
> **但同一轮仍然红了**,红在 stop 之后的另一条断言上:
> ```
> FAIL: post-stop cleanup retained pinned project sandbox placeholder: .grok
> ```
> 也就是说:**红只是从 `node stop failed for <X>` 换成了 `retained … .grok`。**
>
> 假设(**一次观察,推的,未直接坐实**):产生孤儿 socket 的那个 SIGKILL,**同时**让 agent-node 来不及清掉
> `$WORK/.grok`;以前 stop 在那一步就失败、套件早停,这条下游断言**从没跑过**。
> ⇒ **被 SIGKILL 的清扫者留下的不止 socket 一样东西,逐个回收残留是打地鼠。**
> 真正的病是 **#1522** 的预算错配。本 PR 用 `Refs #1422`,**不 close 它**。

## Author & Helpers

**Author (Primary)**: 通信测试马

**Helpers**:
- 通信龙: 派工 / 独立复现了 #1519 那个 set -e 缺陷 / 批准本 PR 的修法方向并补了「路径范围校验」这一条

**Tier review gate**: 通信龙

## Why

Refs #1422

`anet node stop` 偶发 `STOP_TIMEOUT: authoritative local resources survived`,把**无关 PR** 判红 —— test225 的 `known-failures.txt` 是 `baseline_entries=0`,于是一次概率性 flaky 就成了确定性红。

**实测现场**(`--cpus=1.5` 复现,签名与 2026-08-29 那次 CI 逐字相同;该轮最终 `rc=1 / FAIL: node stop failed for fallback`,证据属于一次**确认的红**,不是构造的场景):

```
[anet] STOP_TIMEOUT: authoritative local resources survived for "preview-grok-225" after 10000ms
[anet]    residual socket: leader socket …/.anet-grok/node-<id>/run/leader.sock (13299ms old)

/proc/net/unix 里含该路径的行：**一条都没有**
SOCK …/run/leader.sock  mtime_age=13s  listeners=0
```

🔴 残留的是一个**没有监听者的孤儿路径名**,不是「还在拆卸」。

**成因(读码 + 实测)**:删这个 socket 的 `removeUnchangedStaleSocket` 住在 **agent-node 进程里**(`grok-copresence/leader-lifecycle.ts:501`),而 CLI 的 stop 走 `reapOwnedGeneration`:**SIGTERM → 5s → SIGKILL**。负载下 agent-node 侧那条拆卸链(`terminateOwnedGrokLeader`,`runtime.ts:2027` 不传 `timeoutMs` ⇒ 每段默认 `2_000`)最坏 **2+2+2+2 = 8s** 才轮到那句 unlink。

**5 秒等一条最坏 8 秒的链** —— 越线即 SIGKILL,**清理代码永远不会执行**。于是 CLI 回到自己那 10 秒窗口,等一个五秒前被自己杀掉的清扫者。

**所以放宽窗口是死路**:SIGKILL 落下之后,没有任何人会再删那个路径名,3s→10s→任意值都一样。那次放宽(PR #1393)只压低了命中率(实测本配置下仍有 ~17%)。

## What

属主进程**已被证明消失之后**,`anet node stop` 自己回收 `/proc/net/unix` 里完全找不到的 socket 路径名;有监听者、或任何一种不确定,一律保留并继续判红。

三个提交:
1. 修复本体 + 14 条单测 + 三向见红
2. 把「只回收重新算出来的那两个路径」抽成纯函数 `planReapableSockets` + 5 条测试 + 第四向见红
3. 把「这次 stop 回收了一个孤儿 socket」记进 test225 的**报告**(见下面那节副作用)

## How to verify

```bash
# 单元(19 条)
cd agent-network && bun test src/stale-socket.test.ts        # 19 pass 0 fail

# 四向见红 —— 每一向都把**被测的那道守卫**拿掉
sed -i 's#if (unixSocketPathInUse(table, path)) return { kind: "in-use" };#//#' src/stale-socket.ts
#   → 「表里还有这个路径 ⇒ 绝不删」红
sed -i 's#return { kind: "unreadable", detail: error?.message || String(error) };#table = "";#' src/stale-socket.ts
#   → 「/proc/net/unix 读不到 ⇒ fail-closed」红
sed -i 's#if (!path.startsWith(root) || path.includes("/../") || path.endsWith("/..")) {#if (false) {#' src/stale-socket.ts
#   → out-of-scope 三条红
sed -i 's#    if (!allowed.has(path)) continue.*#//#' src/stale-socket.ts
#   → 「profile 被写坏成别处路径 ⇒ 一条都不选」「同目录下别的 socket 也不选」红

# 全量(与基线单变量对照:只把 cli.ts 退回 HEAD)
bun test    # 794 pass / 11 fail / 11 errors   基线 793 / 11 / 11
            # 11 条 error 两边逐条相同(缺可选依赖 markdown-it、飞书 SDK,与本改动无关)
            # +1 pass 可推导:stop-socket-window 那条测试换成了两条

# 文档行号 pin(cli.ts +64/−8 行会挤漂 pin,所以必须跑)
python3 scripts/check-doc-source-pins.py     # broken_pins=0
```

**投递语义自答**:n/a —— 本 PR 不改动任何带投递含义的返回值。它确实改变了 `anet node stop` 的**退出码**在某一种情形下的取值(孤儿 socket 从 exit(1) 变成成功),而那正是本 PR 的目的:那种情形下节点**确实已经停了**,报失败才是错的。所有「还没停干净」的情形(有监听者 / 读不到 `/proc/net/unix` / 身份不符 / 不是 socket)**仍然 exit(1)**,并且每一条都有一个断言 `unlink` 一次都没被调用的负向用例守着。

## Test evidence

### 🔴 端到端,确定性,两向 —— 走真实 CLI,不依赖那个 18% 的 flake

造一个真孤儿(起监听者 → `kill -9`,不给它 unlink 的机会),再让 `anet node stop` 去处理。**两格都先断言前提成立**,前提不成立就作废、不给结论。

**情形 A —— 孤儿路径名**(前提:监听者=1 → SIGKILL → 文件在、监听者=0):

```
| [anet] reclaimed stale socket: …/run/leader.sock (owner proven gone, no listener in /proc/net/unix)
| [anet] "preview-grok-225" is not running locally (server notified offline)
>>> rc=0   socket 文件还在=no        ✅ 回收了,stop 不再误报失败
```

**情形 B —— 活监听者(负向对照,必须拒绝删)**(前提:监听者=1):

```
| [anet]    kept …/run/leader.sock: in-use
| [anet] STOP_TIMEOUT: authoritative local resources survived … 
| [anet]    residual socket: … (11146ms since bind, listener=yes — someone still holds it; teardown did not finish)
>>> rc=1   socket 文件还在=yes       ✅ 没删,门的强度没降
```

**同一个探针打修复前的镜像** → `❌ 没有打 reclaimed stale socket`、rc=1、socket 仍在 —— 所以它同时是本 PR 的见证红。

顺带:新的 `listener=yes` / `listener=no` 在两种情形下给出**不同读数**,判别力是实测出来的,不是声称的。

### 单元

- `bun test src/stale-socket.test.ts` → **23 pass 0 fail**
- 五向见红,每一向拿掉的都是**被测的那道守卫本身**,红话点名对应项:
  拿掉 `in-use` 检查 / `/proc/net/unix` 读不到改成继续删 / 拿掉范围校验 / 拿掉「只认规范路径」/ 拿别名冒充 node_id
- 每条负向用例断言的是 **`unlink` 一次都没被调用**,不只是返回值长得对

### 回归对照

- agent-network 全量:**794 pass / 11 fail / 11 errors** vs 基线(只把 cli.ts 退回 HEAD)**793 / 11 / 11**;11 条 error 两边**逐条相同**(缺可选依赖 `markdown-it`、飞书 SDK,与本改动无关)
- `check-doc-source-pins.py` → `broken_pins=0`
- 棘轮:拿真实报告追加新 diagnostic 行喂给 `check-known-failures.py` → `rc=0 / pass_lines=11 (floor=7) / fail_lines=0`

## 🔴 这个 PR 里最该被读到的一段:第一版修复**一次都没执行过**

第一版接线写的是

```ts
grokCopresenceSocketPaths(resolved.id)      // ✗
```

而 `resolveNodeRef(ref)` 在 `loadProfile(ref)` 成功时返回 `{ id: ref }` —— **那是目录名,也就是别名**;socket 路径却是 `anet node create` 用 **`node_id`** 算的:

```
sha256("n_a2f4eb5f")[:24]       → node-ecdfd90e…    ← 磁盘上真实目录
sha256("preview-grok-225")[:24] → node-b8a8802d…    ← 我算出来的
```

永不相等 ⇒ 可回收集合恒为空 ⇒ **一条都回收不了**。而且**完全静默**:循环体一次都不进,一行输出都没有。

**从外面看,「守卫拒绝了一切」和「这个修复根本不存在」是同一个样子。**

发现它靠的是两件事:

**① 验收判据不是「跑 N 轮不红」。** 串行跑的前 8 轮**全绿**;如果按"没红就算过"验收,一个**完全无效**的修复会被合进 main,而且 CI 上大概率也是绿的(串行、低负载)。判据定的是「**必须看见 `reclaimed stale socket:` 真的打出来**」,而它一次都没打出来。

**② 失败率对照。** 修复前 12 轮 2 红 = **17%**;带那版"修复" 22 轮 4 红 = **18%**。**一致 = 没生效**,而不是"生效了但不够"。只看 after 永远看不出来。

**已加的三道防线**(都在本 PR 里):
- 改用 `profile.node_id`;
- `canonicalSocketsForProfile`:推出路径后**与 profile 里存的交叉校验**,`ok` / `mismatch` / `no-node-id` 三种结局互不相同、**每一种都打得出话** —— 判据不能只是「算出一个路径」,必须是「算出来的和存着的对得上」;
- 有残留却一条都不可回收 → 打 `matched none of N residual(s)`,**不再静默**。

**回归钉**:拿别名冒充 node_id → `mismatch`(不是静默空集);源码钉禁止 `grokCopresenceSocketPaths(resolved.id)` 复现。

## 设计上两处特意的选择

**1. 路径「重新算」,不信 profile 里存的那个。** 通信龙 要求做路径范围校验防止被污染的 identity 把别处的 socket 带进来删。我用了更强的一版:`grokCopresenceSocketPaths(nodeId)` 是纯函数,同样的 nodeId + home 永远算出同一个值 —— 只有与它算出的路径**完全相等**的残留才允许回收。**前缀校验做不到这一点**(同目录下别的 socket 会被放行),`planReapableSockets` 的两条测试钉的就是这个差别。范围前缀校验仍然保留在 `reapStaleSocket` 里作为第二道。

**2. 判据取最保守的一版。** 仓里已有两个「有没有监听者」的谓词:`leader-lifecycle.ts` 的 `listenerInodeExists` 比 path+inode,test225 的 `assert_no_unix_listener` 还要求 flags/type/state。本 PR **两个都不采**,只问「`/proc/net/unix` 里**完全没有**这个路径」—— 因为删文件不可逆,而这是三者里唯一不需要解释 flags 含义就能成立的条件。

## 顺带修掉的一处误导性诊断

PR #1393 给残留行加的这句被删掉了:

> an old-mtime socket that outlives the window is a real leak; a fresh one means teardown was still in flight

**它是错的。** 实测 unix socket 的 mtime 定在 **bind 那一刻**,继续监听不更新、`close` 也不更新:

```
bind 后           mtime 年龄 = 0.00s
监听 3 秒后        mtime 年龄 = 3.00s
close 之后(路径还在) mtime 年龄 = 3.00s
```

所以那个「年龄」≈ 节点已经运行了多久,它对**任何**残留都会打成「真泄漏」——**成功与失败同读数,判别力为零**。`stop-socket-window.test.ts` 里钉住那句话的断言一并改成钉 `listener=`(真正能区分的那一格),并加了一条负向断言防止那句话回来。

## 引用说明(避免下一个人走弯路)

`cli.ts` 里 `SOCKET_RESIDUAL_WINDOW_MS` 上方的注释写的是 `#1385`,而 **#1385 的标题和正文讲的是另一个 flake**(`test17-user-journey` 容器里 `routing.test.ts:128`),正文里 `socket` / `stop` / `residual` / `test225` **一次都没出现**。这一族的讨论在它的**评论串**里(10 处命中),实现是 **PR #1393**。

我在本 PR 里一律引 **#1393**。点进 #1385 只会看到一个不相干的标题,那是这条线索最容易断掉的地方。

## 🔴 这个修法的副作用,以及本 PR 里对它的处置

**它把症状修好了,同时也会把底层竞态变成不可见的。**

真正的病是**预算错配**:CLI 给 5s 宽限,agent-node 侧的拆卸链最坏要 8s(4 段 × 默认 2000ms)。本 PR 不动它 —— 修复让 stop 在清理者被 SIGKILL 之后自己收摊,于是那次 SIGKILL **不再产生任何可见后果**,而产生它的条件**频率一点没变**。

产品那行 `[anet] reclaimed stale socket: …` 走 `anet node stop` 的 stdout,对直接用 CLI 的人是可见的。但 test225 里是

```bash
anet node stop "$alias" >"$output" 2>&1
```

**stdout 和 stderr 一起**被收进 600 私有日志,cleanup 再删掉 —— CI 上无迹可寻。(所以把产品那行改成 stderr 没有用,两个都被这条重定向吃掉;这一点我核过才下的结论。)

**处置**:第 3 个提交让套件在成功路径上扫一次私有日志,把**事实**记进报告(报告是 upload-artifact 的产物,唯一活得下来的通道),**不记路径**(路径含 `$HOME`)。于是「这个修复还在生效吗」有据可查,「拆卸链又一次没跑完」也重新有了信号。

棘轮不受影响:`check-known-failures.py` 只认 `^FAIL:` 与 `^PASS:`。拿真实报告追加该行喂进去实测 `rc=0 / pass_lines=11 (floor=7) / fail_lines=0`。

**预算错配本身单开了 #1522**,不搭本 PR 的车 —— 改宽限会抬高**每次** stop 的最坏耗时,是个要单独权衡的决定。

## 🔴 一个必须成立的前提,已实测

整个修复的安全性建立在一件事上:**`/proc/net/unix` 在目标环境里确实列得出活监听者的路径**。

如果它列不出(比如某个容器/命名空间下拿不到),那么 `unixSocketPathInUse` 会恒返回 false ⇒ 「有监听者就不删」这道守卫**永远不触发** ⇒ 修复会从「回收孤儿路径名」变成「**删掉活着的 socket**」。

这一格是**量过的**,不是假设的:在同一个容器镜像里起一个监听者,`/proc/net/unix` 里能看到它的路径;上面负向对照(情形 B)的 `listener=yes` + `kept … : in-use` 就是这条前提在真实路径上成立的证据。

(读不到 `/proc/net/unix` 时走 `unreadable` ⇒ **fail-closed 不删**,与 `leader-lifecycle.ts` 里 `listenerInodeExists` 的 `catch { return true }` 同向。)

## 已知边界

- **只在 Linux 上真正生效**。macOS/Windows 没有 `/proc/net/unix`,`readFileSync` 抛错 ⇒ `unreadable` ⇒ **不删**,行为与本 PR 之前完全一致(不引入新风险,也不解决那两个平台上的同类问题)。
- 本 PR **不改** `SOCKET_RESIDUAL_WINDOW_MS`(PR #1393 把它从 3s 放到 10s)。窗口对「还在拆卸」那一类仍然有用,只是不再是孤儿路径名唯一的出路。
- 端到端验收用的镜像构建于 `planReapableSockets` 抽取**之前**;该抽取是纯提取(同一判据、加了去重),行为等价,由上面 5 条新测试覆盖。

## Checklist

- [x] Relevant tests pass locally(`bun test`,见上)
- [ ] `docs-site/docs/changelog.md` updated — n/a(缺陷修复,行为对用户不可见:原本该成功的 stop 不再误报失败)
- [ ] Docs synced — n/a
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`fix:` / `test:`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] Issue 链接用对了关键字:`Refs #1422`
- [x] **投递语义自答**:见 How to verify 末段
