### PR TITLE
docs(api): index all 50 MCP tools and gate coverage

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -1,20 +1,93 @@
 # MCP Tools 参考
 
-CommHub Server 共注册约 40 个 MCP Tools；本页文档化其中 agent 日常协作最常用的 17 个核心工具（其余为节点管理、供应商配置等运维类工具）。全部通过 `POST /mcp`（Streamable HTTP）端点调用。
+CommHub Server 注册 **50 个** MCP Tools，全部经 `POST /mcp`（Streamable HTTP）调用。下表是完整索引；其中 17 个 agent 日常协作工具在本页有参数与返回值的详细说明，点名字直达。
 
-## 工具分类
+## 完整工具索引
 
-| 分组 | 数量 | 用途 |
-|------|------|------|
-| Agent 端工具 | 4 | 状态上报、收取消息 |
-| 任务管理工具 | 7 | 发任务、回复、重试、取消、转移 |
-| 查询工具 | 5 | 查任务详情、查任务列表、查状态、查完成 |
-| 广播工具 | 1 | 群发消息 |
+**协作（本页有详细说明）** · 17 个
 
-> **运维类 MCP 工具（本页不展开）**：除上述 17 个协作工具外，Hub 还注册了约 22 个运维类工具，**由 `anet` CLI / Dashboard 调用，普通 agent 用不到**：
-> - 节点生命周期：`create_node` / `delete_node` / `restart_node` / `start_node` / `stop_node` / `update_node_config`
-> - 供应商与密钥（OWNER / admin）：`upsert_provider` / `update_provider` / `list_providers` / `probe_provider_model` / `upsert_network_secret` / `list_network_secrets`
-> - 主机 daemon 协议（内部）：`list_host_supervisors` / `list_my_children` / `get_*_request` / `ack_*_request` 等
+| 工具 | 说明 |
+|------|------|
+| [`report_status`](#report_status) | 上报状态，返回 inbox_count |
+| [`report_completion`](#report_completion) | 上报任务完成与产物 |
+| [`get_inbox`](#get_inbox) | 取本会话待处理命令 |
+| [`ack_inbox`](#ack_inbox) | 确认已收到命令 |
+| [`send_task`](#send_task) | 按 alias 投任务进对方 inbox |
+| [`send_message`](#send_message) | 发消息，不建任务生命周期 |
+| [`send_reply`](#send_reply) | 回复 Dashboard 发起的任务；也是 agent 间任务的终结腿 |
+| [`send_ack`](#send_ack) | 确认收到任务，不进 inbox |
+| [`retry_task`](#retry_task) | 重试失败/过期/取消的任务 |
+| [`cancel_task`](#cancel_task) | 取消 delivered/acked/running 的任务 |
+| [`reassign_task`](#reassign_task) | 把任务转给另一个 agent |
+| [`get_task`](#get_task) | 按 task_id 查详情、状态、结果 |
+| [`list_tasks`](#list_tasks) | 带过滤条件列任务 |
+| [`get_all_status`](#get_all_status) | 列全部会话状态（Hub 巡检用） |
+| [`get_session_status`](#get_session_status) | 按 alias 查单个会话详情 |
+| [`get_completions`](#get_completions) | 查近期任务完成记录 |
+| [`broadcast`](#broadcast) | 群发消息给多个会话 |
+
+**桌面与用户消息** · 1 个
+
+| 工具 | 说明 |
+|------|------|
+| `send_desktop_message` | 向桌面用户 inbox 写一条可推送消息 |
+
+**SkillHub** · 4 个
+
+| 工具 | 说明 |
+|------|------|
+| `submit_skill` | 向本网络 SkillHub 提交一版不可变 SKILL.md |
+| `list_skills` | 列本网络已发布技能（owner/admin 可含待审） |
+| `get_skill` | 读一份 SKILL.md（待审内容仅 owner/admin 可见） |
+| `review_skill` | 发布或驳回待审技能（owner/admin） |
+
+**节点生命周期（`anet` CLI / Dashboard 调用）** · 6 个
+
+| 工具 | 说明 |
+|------|------|
+| `create_node` | 在 host-daemon 上创建并启动节点 |
+| `delete_node` | 停子进程 + 吊销 ntok + 删 hub 行（默认备份配置） |
+| `stop_node` | 停 agent-node 子进程，保留配置目录 |
+| `start_node` | 通过 host-daemon 启动已停止的子节点 |
+| `restart_node` | 不改配置直接重启节点 |
+| `update_node_config` | 设置节点目标配置（model + flags）并推门铃 |
+
+**主机 daemon 协议（内部，节点与 daemon 自动调用）** · 12 个
+
+| 工具 | 说明 |
+|------|------|
+| `get_config_update` | 节点拉取待应用的配置更新 |
+| `ack_config_update` | 节点回报配置更新结果 |
+| `list_my_pending_create_requests` | daemon 在 SSE 重连后补偿拉取待处理建节点请求 |
+| `list_my_pending_lifecycle_requests` | daemon 在 SSE 重连后补偿拉取待处理停/删/启动请求 |
+| `get_create_request` | daemon 拉取待处理的建节点请求 |
+| `ack_create_request` | daemon 回报 fork 后的启动结果 |
+| `get_stop_request` | daemon 拉取待处理的停/删请求 |
+| `ack_stop_request` | daemon 回报停/删完成或失败 |
+| `get_start_request` | daemon 拉取待处理的启动请求 |
+| `ack_start_request` | daemon 回报启动完成或失败 |
+| `list_host_supervisors` | 列本网络的 host_supervisor daemon（含在线状态） |
+| `list_my_children` | daemon 拉取自己派生的子节点清单 |
+
+**Provider 与密钥金库（owner/admin）** · 7 个
+
+| 工具 | 说明 |
+|------|------|
+| `list_providers` | 列本网络 provider 与模型（从不返回密钥值） |
+| `upsert_provider` | 新建或更新 provider |
+| `list_network_secrets` | 列金库密钥**名**（从不返回值），RFC-028 |
+| `upsert_network_secret` | 写入或替换金库密钥值（AES-GCM 加密） |
+| `probe_provider_model` | 向 daemon 派连通性探测 |
+| `get_probe_request` | daemon 拉取待处理的探测请求 |
+| `get_probe_results` | 查探测历史（可按 provider/model/daemon 过滤） |
+
+**内部信号（agent-node 自动调用）** · 3 个
+
+| 工具 | 说明 |
+|------|------|
+| `send_peer_reply` | 原子地终结一个节点任务并投一条无需回执的结果 |
+| `mark_tasks_consumed` | agent-node 内部信号：标记本轮实际消费的任务 |
+| `mark_tasks_runtime_submitted` | agent-node 内部信号：标记已提交给运行时的任务 |
 
 ---
 

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -1,20 +1,93 @@
 # MCP Tools Reference
 
-CommHub Server registers ~40 MCP Tools in total; this page documents the 17 core tools agents use most for day-to-day collaboration (the rest are node-management, provider-config, and other ops tools). All are called via the `POST /mcp` (Streamable HTTP) endpoint.
+CommHub Server registers **50** MCP Tools, all called through `POST /mcp` (Streamable HTTP). The index below is complete; the 17 tools agents use for day-to-day collaboration are documented in full further down — click the name to jump.
 
-## Tool Categories
+## Complete tool index
 
-| Group | Count | Purpose |
-|------|------|------|
-| Agent-side tools | 4 | Status reporting, message retrieval |
-| Task management tools | 7 | Send tasks, reply, retry, cancel, reassign |
-| Query tools | 5 | Query task detail, task list, status, completions |
-| Broadcast tools | 1 | Broadcast to all agents |
+**Collaboration — detailed below** · 17
 
-> **Ops-tier MCP tools (not detailed here)**: beyond the 17 collaboration tools above, the Hub registers ~22 ops tools **driven by the `anet` CLI / Dashboard — typical agents don't call these**:
-> - Node lifecycle: `create_node` / `delete_node` / `restart_node` / `start_node` / `stop_node` / `update_node_config`
-> - Providers & secrets (OWNER / admin): `upsert_provider` / `update_provider` / `list_providers` / `probe_provider_model` / `upsert_network_secret` / `list_network_secrets`
-> - Host-daemon protocol (internal): `list_host_supervisors` / `list_my_children` / `get_*_request` / `ack_*_request`, etc.
+| Tool | What it does |
+|------|------|
+| [`report_status`](#report_status) | Report agent status; returns inbox_count |
+| [`report_completion`](#report_completion) | Report task completion with results and artifacts |
+| [`get_inbox`](#get_inbox) | Fetch pending commands for this session |
+| [`ack_inbox`](#ack_inbox) | Acknowledge receipt of a command |
+| [`send_task`](#send_task) | Dispatch a task into a session's inbox by alias |
+| [`send_message`](#send_message) | Send a message with no task lifecycle |
+| [`send_reply`](#send_reply) | Reply to a Dashboard-originated task; also the terminal leg for agent-to-agent tasks |
+| [`send_ack`](#send_ack) | Acknowledge a task without entering the inbox |
+| [`retry_task`](#retry_task) | Retry a failed, expired, or cancelled task |
+| [`cancel_task`](#cancel_task) | Cancel a delivered/acked/running task |
+| [`reassign_task`](#reassign_task) | Reassign a task to a different agent |
+| [`get_task`](#get_task) | Get task detail, status, and result by task_id |
+| [`list_tasks`](#list_tasks) | List tasks with filters |
+| [`get_all_status`](#get_all_status) | List every session's status (Hub patrol loop) |
+| [`get_session_status`](#get_session_status) | Get one session's detail by alias |
+| [`get_completions`](#get_completions) | Query recent task completions |
+| [`broadcast`](#broadcast) | Send a message to multiple sessions |
+
+**Desktop and user messages** · 1
+
+| Tool | What it does |
+|------|------|
+| `send_desktop_message` | Write a pushable message into a desktop user's inbox |
+
+**SkillHub** · 4
+
+| Tool | What it does |
+|------|------|
+| `submit_skill` | Submit an immutable SKILL.md version to this network's SkillHub |
+| `list_skills` | List published skills (owners/admins may include pending) |
+| `get_skill` | Read one SKILL.md (pending content is owner/admin only) |
+| `review_skill` | Publish or reject a pending submission (owner/admin) |
+
+**Node lifecycle — driven by the `anet` CLI / Dashboard** · 6
+
+| Tool | What it does |
+|------|------|
+| `create_node` | Create and start a node on a host daemon |
+| `delete_node` | Stop child, revoke ntok, delete the hub row (config backed up by default) |
+| `stop_node` | Stop the agent-node child, keep the config dir |
+| `start_node` | Start a stopped child node through its host daemon |
+| `restart_node` | Restart a node without changing its config |
+| `update_node_config` | Set a node's desired config (model + flags) and ring its doorbell |
+
+**Host-daemon protocol — internal, called by nodes and daemons** · 12
+
+| Tool | What it does |
+|------|------|
+| `get_config_update` | Node pulls its pending config update |
+| `ack_config_update` | Node reports the config-update outcome |
+| `list_my_pending_create_requests` | Daemon compensates after SSE reconnect by listing pending create-node requests |
+| `list_my_pending_lifecycle_requests` | Daemon compensates after SSE reconnect by listing pending stop/delete/start requests |
+| `get_create_request` | Daemon pulls a pending create-node request |
+| `ack_create_request` | Daemon reports the post-fork start result |
+| `get_stop_request` | Daemon pulls a pending stop/delete request |
+| `ack_stop_request` | Daemon reports stop/delete completion or failure |
+| `get_start_request` | Daemon pulls a pending start request |
+| `ack_start_request` | Daemon reports start completion or failure |
+| `list_host_supervisors` | List host_supervisor daemons in this network, with online status |
+| `list_my_children` | Daemon pulls the list of children it spawned |
+
+**Providers & secret vault — owner/admin** · 7
+
+| Tool | What it does |
+|------|------|
+| `list_providers` | List providers and models (never returns secret values) |
+| `upsert_provider` | Create or update a provider |
+| `list_network_secrets` | List vault key NAMES only, never values (RFC-028) |
+| `upsert_network_secret` | Write or replace a vault secret (AES-GCM encrypted) |
+| `probe_provider_model` | Dispatch a connectivity probe to a daemon |
+| `get_probe_request` | Daemon pulls a pending probe request |
+| `get_probe_results` | Query probe history, optionally filtered by provider/model/daemon |
+
+**Internal signals — called by agent-node** · 3
+
+| Tool | What it does |
+|------|------|
+| `send_peer_reply` | Atomically finalize one node-owned task and enqueue a no-response result |
+| `mark_tasks_consumed` | Internal agent-node signal: which tasks this turn actually consumed |
+| `mark_tasks_runtime_submitted` | Internal agent-node signal: which task bodies reached the runtime |
 
 ---
 

--- a/scripts/check-mcp-tool-index-coverage.py
+++ b/scripts/check-mcp-tool-index-coverage.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""mcp-tools.md 的索引必须列全 server/src/tools.ts 注册的每一个 tool。
+
+⚠️ 仓里关于 mcp-tools.md 有**两道**门，判据不同，不要弄混：
+
+    scripts/check-mcp-tool-anchor-sections.py  —— 锚串**落在对的 tool 段**里
+    scripts/check-mcp-tool-index-coverage.py(本文件) —— 索引**列全了**每个 tool
+
+两者互不覆盖：一份索引可以每条锚点都正确，同时漏掉 27 个工具；反过来也成立。
+
+## 这道门为什么存在
+
+2026-08-26 实测：`server/src/tools.ts` 注册 **44** 个 tool，而 `mcp-tools.md`
+只写了 17 个，页首用「约 40 个」「约 22 个」这种含糊说法带过，并且点名了一个
+**代码里根本不存在**的 `update_provider`。
+
+漏写不会让任何东西变红 —— 文档少一行，读者只是不知道有这个能力。#173 就是这么来的：
+`send_reply` 支持 `attachments`（#507 起），参考页的参数表没写，于是全网 agent 都把
+`file_id` 贴进正文，桌面端把它当散文渲染。**一张参考表少一行，是没人知道这个能力存在的全部原因。**
+
+## 判据
+
+1. `tools.ts` 里每个 `server.tool("name", …)` 的 name，都必须在 mcp-tools.md 的
+   **索引区**（页首到第一个 `---` 之间）出现为 `` `name` `` 或 `` [`name`](#name) ``。
+2. 索引里出现的每个反引号工具名，都必须真的在 `tools.ts` 里注册过 —— 挡住
+   `update_provider` 那种「文档点名了一个不存在的工具」。
+3. 中英两页同时检查，且**两边的工具集合必须一致** —— 只更新一边是这类页面最常见的失效。
+4. 分母必须非零：解析不出注册点、或索引区为空，都直接判红，不许空扫成绿。
+
+退出码 0 = 全部通过；1 = 有差集；2 = 分母塌了（比 1 更严重，说明这道门没在看东西）。
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DOC_PATHS = [
+    "docs-site/docs/api/mcp-tools.md",
+    "docs-site/docs/en/api/mcp-tools.md",
+]
+TOOLS_TS = "server/src/tools.ts"
+
+# `server.tool(` 后面第一个字符串字面量就是 tool 名；注册点可能换行。
+# 🔴 字符类必须含数字：写成 [a-z_]+ 时 `probe_v2` 这类名字**看不见**，
+#    这道门会少算一个却仍然报绿 —— 盲区在「怎么把要判的东西收进来」，不在判据。
+#    2026-08-26 就是靠一次带数字的变异存活才发现的。
+REGISTRATION = re.compile(r'server\.tool\(\s*\n?\s*"([a-z0-9_]+)"')
+# 索引区里的工具名：`name` 或 [`name`](#name)
+INDEX_NAME = re.compile(r'\[?`([a-z0-9_]+)`')
+
+
+def registered_tools(root: Path) -> set[str]:
+    src = (root / TOOLS_TS).read_text(encoding="utf-8", errors="replace")
+    return set(REGISTRATION.findall(src))
+
+
+def index_region(text: str) -> str:
+    """页首到第一个水平分隔线 —— 详细小节从那之后开始，不算索引。"""
+    marker = text.find("\n---\n")
+    return text if marker < 0 else text[:marker]
+
+
+def indexed_tools(root: Path, rel: str) -> set[str]:
+    """只认表格行的**第一格**。
+
+    索引区的散文里也会出现反引号（分组标题写着「`anet` CLI / Dashboard 调用」），
+    把整片区域一起 findall 会把 `anet` 当成 tool 名，在干净树上就误报。
+    误拦的门比漏拦的门更糟——它教人绕过。工具名只出现在表格第一列，就只看那里。
+    """
+    text = (root / rel).read_text(encoding="utf-8", errors="replace")
+    found: set[str] = set()
+    for line in index_region(text).splitlines():
+        if not line.startswith("|"):
+            continue
+        first_cell = line.split("|")[1] if line.count("|") >= 2 else ""
+        found.update(INDEX_NAME.findall(first_cell))
+    return found
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+
+    registered = registered_tools(root)
+    print(f"tool_registrations={len(registered)}")
+    if not registered:
+        print("FAIL: 解析不出任何 server.tool 注册点 —— 分母塌了，这道门没在看东西", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    per_doc: dict[str, set[str]] = {}
+
+    for rel in DOC_PATHS:
+        path = root / rel
+        if not path.exists():
+            failures.append(f"{rel}: 文件不存在")
+            continue
+        listed = indexed_tools(root, rel)
+        per_doc[rel] = listed
+        print(f"indexed[{rel}]={len(listed)}")
+        if not listed:
+            print(f"FAIL: {rel} 的索引区一个工具名都没有 —— 分母塌了", file=sys.stderr)
+            return 2
+
+        missing = sorted(registered - listed)
+        if missing:
+            failures.append(
+                f"{rel}: 索引漏了 {len(missing)} 个已注册的 tool: {', '.join(missing)}"
+            )
+        ghost = sorted(listed - registered)
+        if ghost:
+            failures.append(
+                f"{rel}: 索引点名了 {len(ghost)} 个 tools.ts 里不存在的 tool: {', '.join(ghost)}"
+            )
+
+    # 只更新一边是这类双语页最常见的失效，所以单独判一次。
+    if len(per_doc) == 2:
+        (a_rel, a), (b_rel, b) = per_doc.items()
+        drift = sorted(a ^ b)
+        if drift:
+            failures.append(
+                f"中英两页索引的工具集合不一致，差集 {len(drift)} 个: {', '.join(drift)}"
+            )
+
+    if failures:
+        for line in failures:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(DOC_PATHS)} 份文档的索引各自列全了全部 {len(registered)} 个 tool，且无幽灵条目。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test831-doc-source-pins/Dockerfile
+++ b/tests/test831-doc-source-pins/Dockerfile
@@ -28,6 +28,7 @@ COPY agent-network /repo/agent-network
 COPY docs/doc-source-pins-baseline.txt /repo/docs/doc-source-pins-baseline.txt
 COPY scripts/check-doc-source-pins.py /repo/scripts/check-doc-source-pins.py
 COPY scripts/check-mcp-tool-anchor-sections.py /repo/scripts/check-mcp-tool-anchor-sections.py
+COPY scripts/check-mcp-tool-index-coverage.py /repo/scripts/check-mcp-tool-index-coverage.py
 COPY tests/test831-doc-source-pins /repo/tests/test831-doc-source-pins
 RUN chmod +x /repo/tests/test831-doc-source-pins/run.sh
 

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -482,4 +482,40 @@ cp /tmp/bl7.bak "$BASELINE"
 python3 "$CHECK" "$ROOT" >/dev/null || fail "L7 复原之后没有回绿"
 echo "  复原后回绿 ✓"
 
+# ---------------------------------------------------------------------------
+# L8 — mcp-tools.md 的索引必须列全 tools.ts 注册的每一个 tool
+#
+# 与 L6 判据不同,不要合并:L6 管「锚串落在对的 tool 段」,L8 管「一个都没漏」。
+# 一份索引可以每条锚点都正确、同时漏掉 27 个工具 —— 2026-08-26 实测就是这样
+# (注册 44 个、文档写 17 个、还点名了一个代码里不存在的 update_provider)。
+# 漏写不会让任何东西变红,读者只是不知道有这个能力;app#173 就是这么来的。
+# ---------------------------------------------------------------------------
+echo "[L8] the tool index lists every registered tool"
+COVCHECK="$ROOT/scripts/check-mcp-tool-index-coverage.py"
+[[ -f "$COVCHECK" ]] || fail "L8 的脚本不在镜像里:$COVCHECK"
+outc=$(python3 "$COVCHECK" "$ROOT") || fail "干净树上 L8 就红了:$(printf '%s' "$outc" | tail -4)"
+printf '%s\n' "$outc" | sed 's/^/  /'
+regs8=$(printf '%s' "$outc" | sed -nE 's/^tool_registrations=([0-9]+)$/\1/p')
+[[ "${regs8:-0}" -gt 0 ]] || fail "L8 没解析出任何 tool 注册点 —— 分母塌了"
+
+# witnessed-red:代码新增一个 tool 而文档没跟上,必须红。这是这道门唯一要防的事,
+# 所以在这里真造一次,而不是相信它"应该会红"。
+cp "$ROOT/server/src/tools.ts" /tmp/l8-tools.bak
+python3 - "$ROOT" <<'PYX'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])/'server'/'src'/'tools.ts'
+t = p.read_text(encoding='utf-8')
+needle = 'server.tool('
+assert t.count(needle) > 0, "L8 变异找不到注册点"
+p.write_text(t.replace(needle, 'server.tool(\n    "l8_probe_tool",\n    "probe",\n    {},\n    async () => ({}),\n  );\n  server.tool(', 1), encoding='utf-8')
+PYX
+if python3 "$COVCHECK" "$ROOT" >/dev/null 2>&1; then
+  cp /tmp/l8-tools.bak "$ROOT/server/src/tools.ts"
+  fail "L8 变异存活:新注册的 tool 没写进索引,门却是绿的"
+fi
+echo "  MUTATION_RED new-tool-not-in-index rc=1"
+cp /tmp/l8-tools.bak "$ROOT/server/src/tools.ts"
+python3 "$COVCHECK" "$ROOT" >/dev/null || fail "L8 复原之后没有回绿"
+echo "  复原后回绿 ✓"
+
 echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- Revives and rebases #1195 onto current `origin/main` (`93a9a8a6`).
- Replaces the vague MCP tools preamble with complete zh/en indexes for all 50 currently registered `server.tool(...)` entries.
- Removes the stale ghost reference to `update_provider`; the real provider write tool is `upsert_provider`.
- Adds `scripts/check-mcp-tool-index-coverage.py` and wires it into test831 as L8 so the index must stay complete and zh/en symmetric.

## Why this matters
The old reference page detailed only 17 collaboration tools while `server/src/tools.ts` registered many more. Missing rows do not fail builds; readers simply never learn capabilities exist. The original #1195 analysis called out the concrete `send_reply.attachments` documentation gap that led agents to paste `file_id` into message text instead of using attachments.

## Rebase notes
- #1195 originally indexed 44 tools. Current main registers 50, so this branch adds the six newer tools too: `send_desktop_message`, `start_node`, `get_start_request`, `ack_start_request`, `list_my_pending_create_requests`, and `list_my_pending_lifecycle_requests`.
- No new docs pages were added, so test831 `files` remains 129.
- `uniq`/`occ` remain 9/24; L8 covers index completeness separately from source-pin counts.

## Verification
- `python3 scripts/check-mcp-tool-index-coverage.py .`
- Witnessed-red for the coverage script: temporarily removed `send_desktop_message` from the zh index; script failed with missing-tool and zh/en drift, then passed after restore.
- `sg docker -c 'docker build -f tests/test831-doc-source-pins/Dockerfile -t anet-test831-doc-source-pins-revive .'`\n- `sg docker -c 'docker run --rm -e TEST831_SOURCE_COMMIT=e80117863caffb345a10b12fd3c1f3e22300d239 -e TEST831_RUNSH_BLOB=0f25dc6585fa59eb16bd263350834c96976c78a9 anet-test831-doc-source-pins-revive'` -> `RESULT: PASS`\n- `python3 .github/scripts/check-doc-symbol-anchors.py --selftest && python3 .github/scripts/check-doc-symbol-anchors.py`\n- `python3 .github/scripts/check-docs-integrity.py --selftest && python3 .github/scripts/check-docs-integrity.py`\n- `bash -n tests/test831-doc-source-pins/run.sh && python3 -m py_compile scripts/check-mcp-tool-index-coverage.py`\n- `npx vitepress build docs`\n\nNo deployment performed.