### PR TITLE
chore(release): bump —— agent-node .54 / agent-network .69

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.68",
+  "version": "2.3.0-preview.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.68",
+      "version": "2.3.0-preview.69",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.68",
+  "version": "2.3.0-preview.69",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.68";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.53";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.69";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.54";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.53",
+  "version": "2.5.0-preview.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.53",
+      "version": "2.5.0-preview.54",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.53",
+  "version": "2.5.0-preview.54",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.68 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.69 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.68` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.69` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.68 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.69 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.68`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.69`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.69.md
+++ b/docs/tests/release-v2.3.0-preview.69.md
@@ -1,0 +1,49 @@
+# @sleep2agi/agent-network 2.3.0-preview.69 — release notes
+
+一条 CLI 修复：**`anet node stop` 不再对「已经停掉的节点」误报失败。**
+
+- **回收无监听者的陈旧 socket 路径名**（PR #1526，#1422 的一格）。
+  症状：grok 共存节点 stop 之后偶发
+  `STOP_TIMEOUT: authoritative local resources survived …` + 非零退出，
+  而**节点其实已经停了**。
+
+  根因不是「拆得慢」：CLI 给整棵树的宽限是 **5s**（`reapOwnedGeneration`：SIGTERM → 5s → SIGKILL → 3s），
+  而 agent-node 侧 Leader 拆卸链最坏 **8s**（每段默认 2000ms × 4）。越线即 SIGKILL ⇒
+  删 socket 的 `removeUnchangedStaleSocket` **永不执行** ⇒ 留下**孤儿路径名**；
+  CLI 随后在自己的 10s 窗口里**等一个它刚杀掉的清扫者**。所以放宽窗口原理上无效。
+
+  修法：属主**已证死**之后，CLI 自己做一次**带守卫**的 unlink——
+  核文件身份 → 查 `/proc/net/unix` **无监听者** → unlink；
+  **读不到 `/proc/net/unix` 时 fail-closed 不删**；
+  **只回收按 `profile.node_id` 重算出的规范路径**（被写坏的 profile 带不进别处的 socket）。
+  **有监听者时照旧判红**，门的强度没有下降。
+
+🔴 **这不是「test225 偶红修好了」**：同一条被掐断的清理链上还有别的痕迹（`.grok` 等
+project sandbox placeholder、`stateFiles`、`nativeLeaderLockBinding` …）。红可能从
+`node stop failed for <X>` 变成 `retained … .grok`。**真正的病是预算错配，在 #1522 跟踪。**
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.69 @sleep2agi/agent-node@2.5.0-preview.54
+anet hub start
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.69
+anet hub restart
+curl -fsS http://127.0.0.1:9200/health
+```
+
+🔴 别只看进程起来了 —— `/health` 返回才证明它在响应。
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1526 | #1422（一格，不 close） | 属主已证死后回收无监听者的陈旧 socket 路径名 |
+
+pin 链：`PINNED_SERVER_VERSION` 仍为 `0.9.0-preview.43`（server 本轮无改动）、
+`PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.54`。

--- a/docs/tests/release-v2.5.0-preview.54.md
+++ b/docs/tests/release-v2.5.0-preview.54.md
@@ -1,0 +1,48 @@
+# @sleep2agi/agent-node 2.5.0-preview.54 — release notes
+
+一条修复，但它修的是**用户照着官方提示做也修不好**的那种。
+
+- **`anet_bin_source` 给出的修复命令根本跑不通**（PR #1521，#1353）。daemon 丢了 `ANET_BIN` pin 之后，
+  错误信息里的 `Fix:` 是用户拿到的**唯一**修法，而它有两个独立缺陷，**都不会报「你没权限」**：
+
+  ① **shell 语法就不成立**：`"$(node -e \"…\" …)"` —— `$( )` 内部的 `\"` 不是转义、是语法错误。
+     实测 `bash -n` **rc=2**：`syntax error near unexpected token '('`。粘进终端**一步都不执行**。
+  ② **sudo 盖错了半边**：`install -d -m 0755 /etc/anet-daemon` **没有** sudo，普通用户下实测 exit 1
+     （`install: cannot change permissions of '/etc/anet-daemon': No such file or directory`）
+     ⇒ `&&` 当场断链 ⇒ 后面的 `sudo tee` **根本不执行** ⇒ path.conf 没写成。
+
+  **一条跑不通的修复建议比没有建议更糟：它让人以为自己已经修过了。**
+
+  现在的命令（POSIX 分支；Windows 那条是 PowerShell、不受影响）：
+
+  ```bash
+  ANET_BIN_REAL="$(node -e 'console.log(require("fs").realpathSync(process.argv[1]))' "$(command -v anet)")" \
+    && sudo install -d -m 0755 /etc/anet-daemon \
+    && printf 'ANET_BIN_ABS=%s\n' "$ANET_BIN_REAL" | sudo tee /etc/anet-daemon/path.conf >/dev/null
+  ```
+  node 内联脚本改用单引号包（内部才用 `"fs"`，两层引号不再打架）；`sudo` 盖住建目录；
+  realpath 在 sudo **之前**算好存进变量（root 环境里 `command -v anet` 可能解析到另一个二进制）。
+  实测 `bash -n` rc=0、非 sudo 段真跑通。
+
+🔴 **#1353 的持久化方向本身不在本版**：那两条路被堵是**设计**（`/etc/anet-daemon/path.conf` 是
+root 拥有的 production trust root），**不要**改成"用户可写的 path.conf" —— daemon 用这个路径
+**执行**每个子节点，一旦它由 daemon 自己那个用户可写，拿到该用户权限的东西就能把它指向自己的脚本。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.69 @sleep2agi/agent-node@2.5.0-preview.54
+```
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.54
+anet node restart <节点名>
+```
+
+## 本版包含
+
+| PR | issue | 内容 |
+|---|---|---|
+| #1521 | #1353 | `anet_bin_source` 的修复命令改成实测可执行（bash -n rc=0 + sudo 盖住建目录） |


### PR DESCRIPTION
## 为什么

#1520 之后又合了两个面向用户的修复，目前**只在 main、不在任何已发布的包里**：

| 包 | 版本 | 内容 |
|---|---|---|
| agent-node | .53 → **.54** | **#1521** —— `anet_bin_source` 给用户的**唯一**修法**本身跑不通**：① `bash -n` **rc=2**（命令替换里的转义引号是语法错误）② `install -d /etc/anet-daemon` **少 sudo** ⇒ `&&` 断链 ⇒ 后面的 `sudo tee` 根本不执行。两个缺陷**都不报「你没权限」**，用户照敲一遍系统依旧没修好 |
| agent-network | .68 → **.69** | **#1526** —— `anet node stop` 不再对「已经停掉的节点」误报失败（回收无监听者的陈旧 socket 路径名；有监听者照旧判红，门的强度没降）。**#1422 一格，不 close** |

**commhub-server 本轮不动**：`git log ceb2b5ff..origin/main -- server/` = **0 条**，`PINNED_SERVER_VERSION` 保持 `0.9.0-preview.43`，`hub-daemon.sh` 的 `RUNTIME_DIR` 跟随它、也不需要改。

## 改了什么

- **脚本**（`sync-pinned-versions.sh --apply`）：package.json ×2 + lock 各两处 ×2 + `PAIRED_AGENT_NODE_VERSION` → `2.5.0-preview.54`
- **手改两处**：getting-started 版本戳 .68 → .69（中英四处）；release notes ×2
- **改戳前核过它承载的断言**：「`auth.ts` 自 `.49` 起零提交」在 .69 上仍成立（`git log --since=2026-08-27T02:25:00Z -- server/src/auth.ts` = **0 条**）

## 本地按 CI 口径跑过

`check-doc-version-claims` rc=0 · `check-release-channel-assertions` rc=0 · `check-hub-launcher-pin` rc=0 · `check-doc-symbol-anchors` rc=0

## 已知：版本号 bump PR 的 e2e 天然过不了

`PAIRED_AGENT_NODE_VERSION` 指着一个**尚未发布**的版本（#194 的先有鸡还是先有蛋）。release.yml 的 install-smoke 才是权威判据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)