### PR TITLE
feat(profile): #1521 internal prep for anet node resume codex-copresence — schema + helpers + RFC (no user-facing CLI surface)

### DIFF
--- a/agent-network/src/codex-copresence-profile-resume.test.ts
+++ b/agent-network/src/codex-copresence-profile-resume.test.ts
@@ -1,0 +1,166 @@
+// #1521 — unit tests for the codex-copresence-resume Phase 0 preflight
+// (config-shape validation + Q7=C actionable diagnostic).
+//
+// The hint text is operator-facing: a broken hint is worse than a broken
+// gate because it points the operator at the wrong fix (see 通信龙 df6d26d9
+// "指不出下一步的报错等于把人卡在原地"). These tests pin the concrete
+// contract:
+//   - every missing field surfaces with its own diagnostic bullet
+//   - the JSON patch template contains ONLY the missing keys (not the
+//     already-present ones — else operators overwrite good config)
+//   - the single-node #1527 warning appears iff codexProbePeer is missing
+//   - `anet node ls` is named in the codexProbePeer hint (concrete next step)
+
+import { describe, expect, test } from "bun:test";
+import {
+  missingCodexResumeFields,
+  codexResumeMissingConfigHint,
+  CODEX_RESUME_REQUIRED_FIELDS,
+  CODEX_COPRESENCE_RUNTIME,
+} from "./codex-copresence-profile.js";
+
+describe("#1521 missingCodexResumeFields — Phase 0 shape validation", () => {
+  test("empty profile → all three fields missing", () => {
+    const missing = missingCodexResumeFields({});
+    expect(missing.sort()).toEqual(["codexLaunchAdapter", "codexProbePeer", "codexProjectDir"]);
+  });
+
+  test("all three fields present + well-shaped → 0 missing", () => {
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/home/user/project",
+      codexLaunchAdapter: "codex-standard",
+      codexProbePeer: "some-peer-alias",
+    });
+    expect(missing).toEqual([]);
+  });
+
+  test("codexProjectDir must be absolute path (relative rejected as missing)", () => {
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "relative/path",  // NOT absolute
+      codexLaunchAdapter: "codex-standard",
+      codexProbePeer: "peer",
+    });
+    expect(missing).toEqual(["codexProjectDir"]);
+  });
+
+  test("codexLaunchAdapter enum enforced (unknown value → missing, per v7 fail-closed on unknown adapter)", () => {
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/x",
+      codexLaunchAdapter: "some-unknown-adapter" as any,
+      codexProbePeer: "peer",
+    });
+    expect(missing).toEqual(["codexLaunchAdapter"]);
+  });
+
+  test("codexLaunchAdapter accepts both codex-standard and codex-custom-wrapper (v7 Q5)", () => {
+    for (const adapter of ["codex-standard", "codex-custom-wrapper"] as const) {
+      const missing = missingCodexResumeFields({
+        codexProjectDir: "/x",
+        codexLaunchAdapter: adapter,
+        codexProbePeer: "peer",
+      });
+      expect(missing).toEqual([]);
+    }
+  });
+
+  test("codexProbePeer empty string treated as missing (guard against zero-length placeholder)", () => {
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/x",
+      codexLaunchAdapter: "codex-standard",
+      codexProbePeer: "",  // shape check reject
+    });
+    expect(missing).toEqual(["codexProbePeer"]);
+  });
+
+  test("partial missing: only codexProbePeer absent → surfaces just that field", () => {
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/x",
+      codexLaunchAdapter: "codex-standard",
+      // codexProbePeer absent
+    });
+    expect(missing).toEqual(["codexProbePeer"]);
+  });
+});
+
+describe("#1521 codexResumeMissingConfigHint — actionable Q7=C diagnostic", () => {
+  test("names the alias in the first line so operator knows which node the message is about", () => {
+    const hint = codexResumeMissingConfigHint("my-node", CODEX_RESUME_REQUIRED_FIELDS);
+    expect(hint.split("\n")[0]).toContain("my-node");
+    expect(hint.split("\n")[0]).toContain("missing 3 required field(s)");
+  });
+
+  test("JSON patch template contains ONLY the missing fields, not the already-present ones", () => {
+    // Regression guard: if the operator's config already has codexProjectDir
+    // and only codexProbePeer is missing, the template must NOT include
+    // codexProjectDir (else operator applies it and overwrites good config).
+    const hint = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
+    expect(hint).toContain("codexProbePeer");
+    expect(hint).not.toContain("codexProjectDir");
+    expect(hint).not.toContain("codexLaunchAdapter");
+  });
+
+  test("codexProbePeer hint names the concrete next step (anet node ls)", () => {
+    // Per 通信龙 df6d26d9: "指不出下一步的报错等于把人卡在原地".
+    const hint = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
+    expect(hint).toContain("anet node ls");
+  });
+
+  test("single-node #1527 warning appears iff codexProbePeer is in the missing set", () => {
+    // With codexProbePeer missing: warning present
+    const withPeer = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
+    expect(withPeer).toContain("#1527");
+    expect(withPeer).toContain("single-node");
+
+    // Without codexProbePeer missing (only other fields): NO warning
+    // (the single-node caveat is specifically about peer availability;
+    // don't scare operators whose only issue is a missing project dir).
+    const withoutPeer = codexResumeMissingConfigHint("n", ["codexProjectDir"]);
+    expect(withoutPeer).not.toContain("#1527");
+    expect(withoutPeer).not.toContain("single-node");
+  });
+
+  test("terminates with the exact re-run command so the loop is closed", () => {
+    // Operator's mental model: read error → apply patch → re-run.
+    // The message must literally end (or nearly end) with the re-run command.
+    const hint = codexResumeMissingConfigHint("my-node", CODEX_RESUME_REQUIRED_FIELDS);
+    expect(hint).toContain("anet node resume my-node");
+    // "anet node config apply" is the apply verb; both together prove the
+    // 3-step loop (edit patch → apply → re-run) is spelled out end-to-end.
+    expect(hint).toContain("anet node config apply my-node");
+  });
+
+  test("does NOT leak secrets or fs paths beyond what the operator already provides", () => {
+    // Message is composed only from the alias + the enum of missing fields.
+    // Guard: no `process.env`, `HOME`, absolute paths, tokens, or PIDs in
+    // the hint. Cheap regex sweep.
+    const hint = codexResumeMissingConfigHint("n", CODEX_RESUME_REQUIRED_FIELDS);
+    // Template placeholders like `<absolute path, e.g. /home/user/my-project>`
+    // are examples inside angle-brackets — allowed. But a bare `/home/someone`
+    // outside brackets would be a leak. Since we only render templates, the
+    // only `/home/` occurrences must be inside angle-brackets.
+    //
+    // 🔴 Meta: this comment itself only names `/home/someone` (in the gate's
+    // NOT_A_PERSON allowlist) — never a bare name outside the allowlist. See
+    // 通信龙 f55a7e25: "解释规则的文字触发了规则本身" — the first draft of
+    // this comment used a placeholder name that WASN'T in the allowlist, and
+    // the gate correctly red-flagged the comment. Fixed by using an allowlisted
+    // placeholder throughout.
+    const bareHomeMatches = hint.match(/\/home\/[a-z]/gi) || [];
+    for (const m of bareHomeMatches) {
+      const idx = hint.indexOf(m);
+      const beforeChar = hint[idx - 1];
+      // Every /home/ occurrence should be inside a `<...>` placeholder or
+      // in a code-fence example section.
+      const isPlaceholder = hint.slice(0, idx).lastIndexOf("<") > hint.slice(0, idx).lastIndexOf(">");
+      expect(isPlaceholder).toBe(true);
+    }
+  });
+});
+
+describe("#1521 CODEX_COPRESENCE_RUNTIME constant", () => {
+  test("value is the string cli.ts routes on", () => {
+    // Sanity: the runtime string that resumeCommand branches on MUST be
+    // this constant, not a duplicated literal that could drift.
+    expect(CODEX_COPRESENCE_RUNTIME).toBe("codex-app-server");
+  });
+});

--- a/agent-network/src/codex-copresence-profile-resume.test.ts
+++ b/agent-network/src/codex-copresence-profile-resume.test.ts
@@ -87,10 +87,7 @@ describe("#1521 missingCodexResumeFields — Phase 0 shape validation", () => {
     expect(missing).toEqual(["codexProbePeer"]);
   });
 
-  test("codexProbePeer whitespace-only treated as missing (per TMHR 4bab8196 附加建议 — trim before length check)", () => {
-    // Without .trim(), `" "` would pass the length > 0 check and reach
-    // hub liveness check as an obviously-invalid alias — cheap defensive
-    // filter at the shape layer.
+  test("codexProbePeer whitespace-only treated as missing", () => {
     for (const ws of [" ", "  ", "\t", "\n", " \t \n "]) {
       const missing = missingCodexResumeFields({
         codexProjectDir: "/x",
@@ -101,15 +98,34 @@ describe("#1521 missingCodexResumeFields — Phase 0 shape validation", () => {
     }
   });
 
-  test("codexProbePeer with leading/trailing whitespace but non-empty core is treated as valid (trim, don't reject)", () => {
-    // We trim to check emptiness, we don't mutate the field. A peer alias
-    // like " realalias " passes shape check; Phase 0's hub liveness lookup
-    // is where trimmed vs raw semantics get decided against the hub schema
-    // — not here.
+  test("codexProbePeer with leading/trailing whitespace treated as missing (TMHR 048d0061 R2: Hub exact-alias lookup — must equal its own trim)", () => {
+    // Rationale: codexProbePeer is a Hub exact-lookup key. A value like
+    // " realalias " (or "realalias " / " realalias") will 100% fail the
+    // Hub exact-alias lookup at Phase 0 liveness check, so it's not a
+    // "well-shaped" value — pinning it as valid at the shape layer would
+    // teach readers that shape-OK is meaningful when it isn't. The shape
+    // check now requires `value === value.trim()`.
+    //
+    // This is the witnessed-red canary TMHR 048d0061 R2 asked for.
+    for (const withWs of [" realalias", "realalias ", " realalias ", "\treal\t"]) {
+      const missing = missingCodexResumeFields({
+        codexProjectDir: "/x",
+        codexLaunchAdapter: "codex-standard",
+        codexProbePeer: withWs,
+      });
+      expect(missing).toEqual(["codexProbePeer"]);
+    }
+  });
+
+  test("codexProbePeer with no surrounding whitespace passes shape (positive control for the trim rule)", () => {
+    // Confirms the rule is `value === value.trim()`, not "reject any
+    // string containing whitespace" (which would break aliases with
+    // internal spaces if the Hub ever allowed them — we don't decide
+    // that, we only assert the trim invariant).
     const missing = missingCodexResumeFields({
       codexProjectDir: "/x",
       codexLaunchAdapter: "codex-standard",
-      codexProbePeer: " realalias ",
+      codexProbePeer: "realalias",
     });
     expect(missing).toEqual([]);
   });

--- a/agent-network/src/codex-copresence-profile-resume.test.ts
+++ b/agent-network/src/codex-copresence-profile-resume.test.ts
@@ -1,20 +1,19 @@
-// #1521 — unit tests for the codex-copresence-resume Phase 0 preflight
-// (config-shape validation + Q7=C actionable diagnostic).
+// #1521 — unit tests for the codex-copresence-resume Phase 0 shape validation.
 //
-// The hint text is operator-facing: a broken hint is worse than a broken
-// gate because it points the operator at the wrong fix (see 通信龙 df6d26d9
-// "指不出下一步的报错等于把人卡在原地"). These tests pin the concrete
-// contract:
-//   - every missing field surfaces with its own diagnostic bullet
-//   - the JSON patch template contains ONLY the missing keys (not the
-//     already-present ones — else operators overwrite good config)
-//   - the single-node #1527 warning appears iff codexProbePeer is missing
-//   - `anet node ls` is named in the codexProbePeer hint (concrete next step)
+// Historical note (TMHR 4bab8196 blocker on PR #1538):
+//   An earlier draft of this file also tested `codexResumeMissingConfigHint`,
+//   an operator-facing diagnostic that referenced `anet node config apply`.
+//   TMHR flagged that command doesn't exist in the tree — the hint would
+//   have shipped a "3-step apply/re-run loop" whose middle step was
+//   non-executable, and the tests would have false-greened it as "loop is
+//   closed". Classic 存在 ≠ 会执行 pattern. Both the hint helper and its
+//   tests are deliberately deferred: they land with a real caller in the
+//   PR that either implements `config apply` or reworks the hint to
+//   reference existing commands only.
 
 import { describe, expect, test } from "bun:test";
 import {
   missingCodexResumeFields,
-  codexResumeMissingConfigHint,
   CODEX_RESUME_REQUIRED_FIELDS,
   CODEX_COPRESENCE_RUNTIME,
 } from "./codex-copresence-profile.js";
@@ -43,6 +42,22 @@ describe("#1521 missingCodexResumeFields — Phase 0 shape validation", () => {
     expect(missing).toEqual(["codexProjectDir"]);
   });
 
+  test("codexProjectDir startsWith('/') is a shape check, NOT the final security gate", () => {
+    // Regression note: this passes shape check but Phase 0 (in #1528) MUST
+    // additionally realpath/canonicalize and reject NUL/`/`/untrusted
+    // targets before letting the value reach `codex resume -C <dir>`.
+    // TMHR 4bab8196 附加建议: "不能把 startsWith('/') 当最终安全门".
+    // This test pins the shape-only intent so any future reader knows
+    // NOT to trust this helper's OK result as security clearance.
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/",  // shape-valid but semantically dangerous
+      codexLaunchAdapter: "codex-standard",
+      codexProbePeer: "peer",
+    });
+    // Shape says OK. Phase 0 must reject on separate grounds.
+    expect(missing).toEqual([]);
+  });
+
   test("codexLaunchAdapter enum enforced (unknown value → missing, per v7 fail-closed on unknown adapter)", () => {
     const missing = missingCodexResumeFields({
       codexProjectDir: "/x",
@@ -63,104 +78,64 @@ describe("#1521 missingCodexResumeFields — Phase 0 shape validation", () => {
     }
   });
 
-  test("codexProbePeer empty string treated as missing (guard against zero-length placeholder)", () => {
+  test("codexProbePeer empty string treated as missing (zero-length placeholder guard)", () => {
     const missing = missingCodexResumeFields({
       codexProjectDir: "/x",
       codexLaunchAdapter: "codex-standard",
-      codexProbePeer: "",  // shape check reject
+      codexProbePeer: "",
     });
     expect(missing).toEqual(["codexProbePeer"]);
+  });
+
+  test("codexProbePeer whitespace-only treated as missing (per TMHR 4bab8196 附加建议 — trim before length check)", () => {
+    // Without .trim(), `" "` would pass the length > 0 check and reach
+    // hub liveness check as an obviously-invalid alias — cheap defensive
+    // filter at the shape layer.
+    for (const ws of [" ", "  ", "\t", "\n", " \t \n "]) {
+      const missing = missingCodexResumeFields({
+        codexProjectDir: "/x",
+        codexLaunchAdapter: "codex-standard",
+        codexProbePeer: ws,
+      });
+      expect(missing).toEqual(["codexProbePeer"]);
+    }
+  });
+
+  test("codexProbePeer with leading/trailing whitespace but non-empty core is treated as valid (trim, don't reject)", () => {
+    // We trim to check emptiness, we don't mutate the field. A peer alias
+    // like " realalias " passes shape check; Phase 0's hub liveness lookup
+    // is where trimmed vs raw semantics get decided against the hub schema
+    // — not here.
+    const missing = missingCodexResumeFields({
+      codexProjectDir: "/x",
+      codexLaunchAdapter: "codex-standard",
+      codexProbePeer: " realalias ",
+    });
+    expect(missing).toEqual([]);
   });
 
   test("partial missing: only codexProbePeer absent → surfaces just that field", () => {
     const missing = missingCodexResumeFields({
       codexProjectDir: "/x",
       codexLaunchAdapter: "codex-standard",
-      // codexProbePeer absent
     });
     expect(missing).toEqual(["codexProbePeer"]);
   });
 });
 
-describe("#1521 codexResumeMissingConfigHint — actionable Q7=C diagnostic", () => {
-  test("names the alias in the first line so operator knows which node the message is about", () => {
-    const hint = codexResumeMissingConfigHint("my-node", CODEX_RESUME_REQUIRED_FIELDS);
-    expect(hint.split("\n")[0]).toContain("my-node");
-    expect(hint.split("\n")[0]).toContain("missing 3 required field(s)");
-  });
-
-  test("JSON patch template contains ONLY the missing fields, not the already-present ones", () => {
-    // Regression guard: if the operator's config already has codexProjectDir
-    // and only codexProbePeer is missing, the template must NOT include
-    // codexProjectDir (else operator applies it and overwrites good config).
-    const hint = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
-    expect(hint).toContain("codexProbePeer");
-    expect(hint).not.toContain("codexProjectDir");
-    expect(hint).not.toContain("codexLaunchAdapter");
-  });
-
-  test("codexProbePeer hint names the concrete next step (anet node ls)", () => {
-    // Per 通信龙 df6d26d9: "指不出下一步的报错等于把人卡在原地".
-    const hint = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
-    expect(hint).toContain("anet node ls");
-  });
-
-  test("single-node #1527 warning appears iff codexProbePeer is in the missing set", () => {
-    // With codexProbePeer missing: warning present
-    const withPeer = codexResumeMissingConfigHint("n", ["codexProbePeer"]);
-    expect(withPeer).toContain("#1527");
-    expect(withPeer).toContain("single-node");
-
-    // Without codexProbePeer missing (only other fields): NO warning
-    // (the single-node caveat is specifically about peer availability;
-    // don't scare operators whose only issue is a missing project dir).
-    const withoutPeer = codexResumeMissingConfigHint("n", ["codexProjectDir"]);
-    expect(withoutPeer).not.toContain("#1527");
-    expect(withoutPeer).not.toContain("single-node");
-  });
-
-  test("terminates with the exact re-run command so the loop is closed", () => {
-    // Operator's mental model: read error → apply patch → re-run.
-    // The message must literally end (or nearly end) with the re-run command.
-    const hint = codexResumeMissingConfigHint("my-node", CODEX_RESUME_REQUIRED_FIELDS);
-    expect(hint).toContain("anet node resume my-node");
-    // "anet node config apply" is the apply verb; both together prove the
-    // 3-step loop (edit patch → apply → re-run) is spelled out end-to-end.
-    expect(hint).toContain("anet node config apply my-node");
-  });
-
-  test("does NOT leak secrets or fs paths beyond what the operator already provides", () => {
-    // Message is composed only from the alias + the enum of missing fields.
-    // Guard: no `process.env`, `HOME`, absolute paths, tokens, or PIDs in
-    // the hint. Cheap regex sweep.
-    const hint = codexResumeMissingConfigHint("n", CODEX_RESUME_REQUIRED_FIELDS);
-    // Template placeholders like `<absolute path, e.g. /home/user/my-project>`
-    // are examples inside angle-brackets — allowed. But a bare `/home/someone`
-    // outside brackets would be a leak. Since we only render templates, the
-    // only `/home/` occurrences must be inside angle-brackets.
-    //
-    // 🔴 Meta: this comment itself only names `/home/someone` (in the gate's
-    // NOT_A_PERSON allowlist) — never a bare name outside the allowlist. See
-    // 通信龙 f55a7e25: "解释规则的文字触发了规则本身" — the first draft of
-    // this comment used a placeholder name that WASN'T in the allowlist, and
-    // the gate correctly red-flagged the comment. Fixed by using an allowlisted
-    // placeholder throughout.
-    const bareHomeMatches = hint.match(/\/home\/[a-z]/gi) || [];
-    for (const m of bareHomeMatches) {
-      const idx = hint.indexOf(m);
-      const beforeChar = hint[idx - 1];
-      // Every /home/ occurrence should be inside a `<...>` placeholder or
-      // in a code-fence example section.
-      const isPlaceholder = hint.slice(0, idx).lastIndexOf("<") > hint.slice(0, idx).lastIndexOf(">");
-      expect(isPlaceholder).toBe(true);
-    }
-  });
-});
-
-describe("#1521 CODEX_COPRESENCE_RUNTIME constant", () => {
-  test("value is the string cli.ts routes on", () => {
-    // Sanity: the runtime string that resumeCommand branches on MUST be
-    // this constant, not a duplicated literal that could drift.
+describe("#1521 CODEX_COPRESENCE_RUNTIME + CODEX_RESUME_REQUIRED_FIELDS constants", () => {
+  test("CODEX_COPRESENCE_RUNTIME is the string cli.ts routes on", () => {
     expect(CODEX_COPRESENCE_RUNTIME).toBe("codex-app-server");
+  });
+
+  test("CODEX_RESUME_REQUIRED_FIELDS enumerates exactly the three fields validated by missingCodexResumeFields", () => {
+    // Sanity: the auditable constant must stay in lockstep with the
+    // validator's behavior. If someone adds a fourth field to the
+    // validator but forgets the constant (or vice versa), this test
+    // fires.
+    expect(new Set(CODEX_RESUME_REQUIRED_FIELDS)).toEqual(
+      new Set(["codexProjectDir", "codexLaunchAdapter", "codexProbePeer"]),
+    );
+    expect(CODEX_RESUME_REQUIRED_FIELDS.length).toBe(3);
   });
 });

--- a/agent-network/src/codex-copresence-profile.ts
+++ b/agent-network/src/codex-copresence-profile.ts
@@ -73,9 +73,27 @@ export const CODEX_RESUME_REQUIRED_FIELDS: readonly CodexResumeRequiredField[] =
 
 /** Enumerate which of the three resume-required fields are absent /
  *  wrong-shaped on this profile. Returns [] when all three are present
- *  and well-shaped. Shape check (string / enum / absolute path) only —
- *  liveness of `codexProbePeer` (registered + online + non-self) is a
- *  separate check performed against the hub in Phase 0. */
+ *  and well-shaped.
+ *
+ *  🔴 SHAPE-ONLY validation:
+ *    - codexProjectDir : string starting with `/`. This is a CHEAP typo
+ *      filter, NOT the security gate. Phase 0 (in #1528) MUST additionally
+ *      `realpath`/canonicalize + reject NUL, `/`, and any untrusted target
+ *      before passing this value to `codex resume -C <dir>` (per TMHR
+ *      4bab8196: "startsWith('/') 不是最终安全门").
+ *    - codexLaunchAdapter : enum membership.
+ *    - codexProbePeer : non-empty AFTER trim. `.trim()` catches whitespace-
+ *      only values like `" "` that would otherwise slip through a naive
+ *      length check (per TMHR 4bab8196 附加建议). Liveness (registered +
+ *      online + non-self) is a separate hub-side check in Phase 0.
+ *
+ *  Deliberately NOT included: `codexResumeMissingConfigHint` — the earlier
+ *  operator-facing diagnostic that referenced a `config apply` verb that
+ *  doesn't exist yet. TMHR 4bab8196 blocked it: staging a hint that names
+ *  a non-existent command is the exact "存在 ≠ 会执行" antipattern the
+ *  gate lessons keep re-teaching. The hint helper lands with its real
+ *  caller (either after `config apply` is implemented in a separate PR,
+ *  or reworked to reference existing commands only when #1528 lands). */
 export function missingCodexResumeFields(
   profile: CodexCopresenceProfileFields,
 ): CodexResumeRequiredField[] {
@@ -87,81 +105,11 @@ export function missingCodexResumeFields(
   if (adapter !== "codex-standard" && adapter !== "codex-custom-wrapper") {
     missing.push("codexLaunchAdapter");
   }
-  if (typeof profile.codexProbePeer !== "string" || profile.codexProbePeer.length === 0) {
+  // TMHR 4bab8196: trim before length check. `" "` is not a valid peer alias.
+  if (typeof profile.codexProbePeer !== "string" || profile.codexProbePeer.trim().length === 0) {
     missing.push("codexProbePeer");
   }
   return missing;
-}
-
-/** #1521 — actionable multi-line diagnostic for the Q7=C flow: user hits
- *  `anet node resume <alias>` on a legacy codex-copresence node that never
- *  had these fields. Names the missing field(s), the shape requirement,
- *  and — critically — HOW to obtain a valid value (per 通信龙 df6d26d9
- *  "指不出下一步的报错等于把人卡在原地"). Modeled on the style adopted
- *  by #1521 (700b47f6) for `anet_bin_source` diagnostics: every error
- *  ends in a copy-pasteable next step.
- *
- *  Do NOT auto-write the config (TMHR v5 dry-run bonus: "dry-run 是渲染
- *  不是执行"). Print a JSON patch template + the exact command the user
- *  runs against it. */
-export function codexResumeMissingConfigHint(
-  alias: string,
-  missing: readonly CodexResumeRequiredField[],
-): string {
-  const lines: string[] = [];
-  lines.push(`anet node resume ${alias}: cannot start — codex-copresence config is missing ${missing.length} required field(s).`);
-  lines.push("");
-  lines.push("Missing:");
-  for (const f of missing) {
-    switch (f) {
-      case "codexProjectDir":
-        lines.push(`  - codexProjectDir : absolute path to the project directory (passed as \`-C <dir>\` to codex resume)`);
-        break;
-      case "codexLaunchAdapter":
-        lines.push(`  - codexLaunchAdapter : "codex-standard" (stock codex app-server) or "codex-custom-wrapper" (TMHR狗-class LLM API wrapper)`);
-        break;
-      case "codexProbePeer":
-        lines.push(`  - codexProbePeer : alias of another node in this network for identity attestation`);
-        lines.push(`      (must be registered + online + NOT this node itself; see #1527 for the single-node case)`);
-        break;
-    }
-  }
-  lines.push("");
-  lines.push("Fix — write a patch file and apply it:");
-  lines.push("");
-  lines.push("  cat > /tmp/codex-resume-patch.json <<'EOF'");
-  lines.push("  {");
-  const patchLines: string[] = [];
-  for (const f of missing) {
-    switch (f) {
-      case "codexProjectDir":
-        patchLines.push(`    "codexProjectDir": "<absolute path, e.g. /home/user/my-project>"`);
-        break;
-      case "codexLaunchAdapter":
-        patchLines.push(`    "codexLaunchAdapter": "codex-standard"`);
-        break;
-      case "codexProbePeer":
-        patchLines.push(`    "codexProbePeer": "<peer alias — run 'anet node ls' to pick an online peer>"`);
-        break;
-    }
-  }
-  lines.push(patchLines.join(",\n"));
-  lines.push("  }");
-  lines.push("  EOF");
-  lines.push("");
-  lines.push(`  anet node config apply ${alias} /tmp/codex-resume-patch.json`);
-  lines.push("");
-  lines.push("Then re-run:");
-  lines.push("");
-  lines.push(`  anet node resume ${alias}`);
-  if (missing.includes("codexProbePeer")) {
-    lines.push("");
-    lines.push("🔴 This command needs ≥2 registered nodes online — the target being resumed,");
-    lines.push("   plus the codexProbePeer that will attest its identity via a fresh Hub outbound");
-    lines.push("   ACK. If you only have one node, see #1527 (single-node attestation is a known");
-    lines.push("   deliberate gap in this initial cut, tracked for a follow-up).");
-  }
-  return lines.join("\n");
 }
 
 export const CODEX_COPRESENCE_RUNTIME = "codex-app-server";

--- a/agent-network/src/codex-copresence-profile.ts
+++ b/agent-network/src/codex-copresence-profile.ts
@@ -31,8 +31,17 @@ export interface CodexCopresenceProfileFields {
   //
   // NONE of the three is read by `anet node create` / `anet node start` — they
   // are only consulted by `resume`. Old codex-copresence configs without them
-  // continue to `start` normally; `resume` fail-closes with a diagnostic that
-  // names the missing field(s) and prints the JSON patch template (Q7=C).
+  // continue to `start` normally.
+  //
+  // Current state in main: the fields exist as OPTIONAL, and `missingCodexResumeFields`
+  // enumerates which are absent — but no code in this PR reads that enumeration.
+  // The resume dispatcher, `--help` copy, and Phase 0 preflight all remain
+  // staged for a follow-up PR (#1528, Draft). Once that PR lands, `resume`
+  // will fail-close with a Phase 0 diagnostic naming the missing field(s);
+  // the diagnostic shape and any operator remediation flow (JSON-patch or
+  // otherwise) will land with the PR that provides its real caller — see
+  // the TMHR 4bab8196 blocker note on `missingCodexResumeFields` below for
+  // why the earlier draft's `codexResumeMissingConfigHint` was removed.
   /** Absolute project directory to launch the codex TUI in. Passed as
    *  `-C <dir>` to `codex resume`. Also cross-checked against hub-reported
    *  `session.project_dir` in Phase 4.3. */
@@ -57,9 +66,12 @@ export interface CodexCopresenceProfileFields {
   readonly codexProbePeer?: string;
 }
 
-/** #1521 — the three fields `anet node resume <alias>` requires on a
- *  codex-copresence node. Any missing field is a Phase 0 fail-closed with
- *  actionable diagnostic (see `codexResumeMissingConfigHint`). */
+/** #1521 — the three fields `anet node resume <alias>` will require on a
+ *  codex-copresence node once the resume dispatcher lands (#1528, Draft).
+ *  In this PR, only shape-level enumeration exists (see
+ *  `missingCodexResumeFields` below); no CLI code reads that enumeration
+ *  and the operator-facing remediation flow is deliberately deferred
+ *  along with its real caller. */
 export type CodexResumeRequiredField =
   | "codexProjectDir"
   | "codexLaunchAdapter"
@@ -82,18 +94,21 @@ export const CODEX_RESUME_REQUIRED_FIELDS: readonly CodexResumeRequiredField[] =
  *      before passing this value to `codex resume -C <dir>` (per TMHR
  *      4bab8196: "startsWith('/') 不是最终安全门").
  *    - codexLaunchAdapter : enum membership.
- *    - codexProbePeer : non-empty AFTER trim. `.trim()` catches whitespace-
- *      only values like `" "` that would otherwise slip through a naive
- *      length check (per TMHR 4bab8196 附加建议). Liveness (registered +
- *      online + non-self) is a separate hub-side check in Phase 0.
+ *    - codexProbePeer : Hub exact-alias lookup, so value MUST equal its own
+ *      trim. Values with leading/trailing whitespace would fail Hub lookup
+ *      100% of the time; rejecting them at the shape layer is a witnessed-red
+ *      canary rather than a permissive pass-through (per TMHR 048d0061 R2:
+ *      "不要 pin 一个必然在 Hub exact lookup 阶段失败的 well-shaped 值").
+ *      Liveness (registered + online + non-self) is a separate hub-side
+ *      check in Phase 0.
  *
- *  Deliberately NOT included: `codexResumeMissingConfigHint` — the earlier
- *  operator-facing diagnostic that referenced a `config apply` verb that
- *  doesn't exist yet. TMHR 4bab8196 blocked it: staging a hint that names
- *  a non-existent command is the exact "存在 ≠ 会执行" antipattern the
- *  gate lessons keep re-teaching. The hint helper lands with its real
- *  caller (either after `config apply` is implemented in a separate PR,
- *  or reworked to reference existing commands only when #1528 lands). */
+ *  Deliberately NOT included: an operator-facing diagnostic helper. An
+ *  earlier draft included `codexResumeMissingConfigHint` that referenced
+ *  a `anet node config apply` verb which does not exist in the tree —
+ *  TMHR 4bab8196 blocked it as the exact "存在 ≠ 会执行" antipattern.
+ *  The diagnostic lands with its real caller in a later PR that either
+ *  (a) implements `anet node config apply` first, or (b) reworks the
+ *  diagnostic to reference existing commands only. */
 export function missingCodexResumeFields(
   profile: CodexCopresenceProfileFields,
 ): CodexResumeRequiredField[] {
@@ -105,8 +120,13 @@ export function missingCodexResumeFields(
   if (adapter !== "codex-standard" && adapter !== "codex-custom-wrapper") {
     missing.push("codexLaunchAdapter");
   }
-  // TMHR 4bab8196: trim before length check. `" "` is not a valid peer alias.
-  if (typeof profile.codexProbePeer !== "string" || profile.codexProbePeer.trim().length === 0) {
+  // TMHR 048d0061 R2: peer alias is a Hub exact-lookup key. Anything that
+  // won't match the raw stored alias — whitespace-only, or with leading/
+  // trailing whitespace — must fail at the shape layer, not silently pass
+  // and 100%-fail later at Hub lookup. Require the value to be its own
+  // trim + non-empty.
+  const peer = profile.codexProbePeer;
+  if (typeof peer !== "string" || peer.length === 0 || peer !== peer.trim()) {
     missing.push("codexProbePeer");
   }
   return missing;

--- a/agent-network/src/codex-copresence-profile.ts
+++ b/agent-network/src/codex-copresence-profile.ts
@@ -26,6 +26,142 @@ export interface CodexCopresenceProfileFields {
   readonly codexCopresence?: boolean;
   readonly codexCopresenceFullAccess?: boolean;
   readonly flags?: Record<string, unknown>;
+  // #1521 — three fields required by `anet node resume <alias>` for
+  // codex-copresence nodes. See docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md
+  //
+  // NONE of the three is read by `anet node create` / `anet node start` — they
+  // are only consulted by `resume`. Old codex-copresence configs without them
+  // continue to `start` normally; `resume` fail-closes with a diagnostic that
+  // names the missing field(s) and prints the JSON patch template (Q7=C).
+  /** Absolute project directory to launch the codex TUI in. Passed as
+   *  `-C <dir>` to `codex resume`. Also cross-checked against hub-reported
+   *  `session.project_dir` in Phase 4.3. */
+  readonly codexProjectDir?: string;
+  /** Which launch adapter to use in Phase 3.2. `"codex-standard"` = stock
+   *  `codex app-server` + `codex resume`; `"codex-custom-wrapper"` = TMHR狗-class
+   *  custom LLM API wrapper (hosted tool / compaction / image-output compat).
+   *  Unknown / absent → Phase 0 fail-closed (unknown adapters must not fall
+   *  through to a default that might not fit the node's real topology). */
+  readonly codexLaunchAdapter?: "codex-standard" | "codex-custom-wrapper";
+  /** Alias of the peer that will verify this node's identity in Phase 6.
+   *  Peer MUST be (a) registered in the same network, (b) online at resume
+   *  time, (c) not this node itself. Identity attestation uses a fresh
+   *  Hub outbound `send_task` from THIS node's Bridge to <codexProbePeer>
+   *  carrying a nonce; peer echoes the nonce back; CLI cross-checks Hub's
+   *  recorded `from_name / from_node_id / to_name / to_node_id`.
+   *
+   *  🔴 self-loop is deliberately not accepted here — it cannot prove
+   *  cross-node routing closure (design v7 Phase 6 = D, per TMHR
+   *  06cfb29a). Single-node users cannot run `anet node resume` in
+   *  this initial cut; tracked at #1527. */
+  readonly codexProbePeer?: string;
+}
+
+/** #1521 — the three fields `anet node resume <alias>` requires on a
+ *  codex-copresence node. Any missing field is a Phase 0 fail-closed with
+ *  actionable diagnostic (see `codexResumeMissingConfigHint`). */
+export type CodexResumeRequiredField =
+  | "codexProjectDir"
+  | "codexLaunchAdapter"
+  | "codexProbePeer";
+
+export const CODEX_RESUME_REQUIRED_FIELDS: readonly CodexResumeRequiredField[] = [
+  "codexProjectDir",
+  "codexLaunchAdapter",
+  "codexProbePeer",
+];
+
+/** Enumerate which of the three resume-required fields are absent /
+ *  wrong-shaped on this profile. Returns [] when all three are present
+ *  and well-shaped. Shape check (string / enum / absolute path) only —
+ *  liveness of `codexProbePeer` (registered + online + non-self) is a
+ *  separate check performed against the hub in Phase 0. */
+export function missingCodexResumeFields(
+  profile: CodexCopresenceProfileFields,
+): CodexResumeRequiredField[] {
+  const missing: CodexResumeRequiredField[] = [];
+  if (typeof profile.codexProjectDir !== "string" || !profile.codexProjectDir.startsWith("/")) {
+    missing.push("codexProjectDir");
+  }
+  const adapter = profile.codexLaunchAdapter;
+  if (adapter !== "codex-standard" && adapter !== "codex-custom-wrapper") {
+    missing.push("codexLaunchAdapter");
+  }
+  if (typeof profile.codexProbePeer !== "string" || profile.codexProbePeer.length === 0) {
+    missing.push("codexProbePeer");
+  }
+  return missing;
+}
+
+/** #1521 — actionable multi-line diagnostic for the Q7=C flow: user hits
+ *  `anet node resume <alias>` on a legacy codex-copresence node that never
+ *  had these fields. Names the missing field(s), the shape requirement,
+ *  and — critically — HOW to obtain a valid value (per 通信龙 df6d26d9
+ *  "指不出下一步的报错等于把人卡在原地"). Modeled on the style adopted
+ *  by #1521 (700b47f6) for `anet_bin_source` diagnostics: every error
+ *  ends in a copy-pasteable next step.
+ *
+ *  Do NOT auto-write the config (TMHR v5 dry-run bonus: "dry-run 是渲染
+ *  不是执行"). Print a JSON patch template + the exact command the user
+ *  runs against it. */
+export function codexResumeMissingConfigHint(
+  alias: string,
+  missing: readonly CodexResumeRequiredField[],
+): string {
+  const lines: string[] = [];
+  lines.push(`anet node resume ${alias}: cannot start — codex-copresence config is missing ${missing.length} required field(s).`);
+  lines.push("");
+  lines.push("Missing:");
+  for (const f of missing) {
+    switch (f) {
+      case "codexProjectDir":
+        lines.push(`  - codexProjectDir : absolute path to the project directory (passed as \`-C <dir>\` to codex resume)`);
+        break;
+      case "codexLaunchAdapter":
+        lines.push(`  - codexLaunchAdapter : "codex-standard" (stock codex app-server) or "codex-custom-wrapper" (TMHR狗-class LLM API wrapper)`);
+        break;
+      case "codexProbePeer":
+        lines.push(`  - codexProbePeer : alias of another node in this network for identity attestation`);
+        lines.push(`      (must be registered + online + NOT this node itself; see #1527 for the single-node case)`);
+        break;
+    }
+  }
+  lines.push("");
+  lines.push("Fix — write a patch file and apply it:");
+  lines.push("");
+  lines.push("  cat > /tmp/codex-resume-patch.json <<'EOF'");
+  lines.push("  {");
+  const patchLines: string[] = [];
+  for (const f of missing) {
+    switch (f) {
+      case "codexProjectDir":
+        patchLines.push(`    "codexProjectDir": "<absolute path, e.g. /home/user/my-project>"`);
+        break;
+      case "codexLaunchAdapter":
+        patchLines.push(`    "codexLaunchAdapter": "codex-standard"`);
+        break;
+      case "codexProbePeer":
+        patchLines.push(`    "codexProbePeer": "<peer alias — run 'anet node ls' to pick an online peer>"`);
+        break;
+    }
+  }
+  lines.push(patchLines.join(",\n"));
+  lines.push("  }");
+  lines.push("  EOF");
+  lines.push("");
+  lines.push(`  anet node config apply ${alias} /tmp/codex-resume-patch.json`);
+  lines.push("");
+  lines.push("Then re-run:");
+  lines.push("");
+  lines.push(`  anet node resume ${alias}`);
+  if (missing.includes("codexProbePeer")) {
+    lines.push("");
+    lines.push("🔴 This command needs ≥2 registered nodes online — the target being resumed,");
+    lines.push("   plus the codexProbePeer that will attest its identity via a fresh Hub outbound");
+    lines.push("   ACK. If you only have one node, see #1527 (single-node attestation is a known");
+    lines.push("   deliberate gap in this initial cut, tracked for a follow-up).");
+  }
+  return lines.join("\n");
 }
 
 export const CODEX_COPRESENCE_RUNTIME = "codex-app-server";

--- a/docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md
+++ b/docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md
@@ -1,0 +1,141 @@
+# `anet node resume <alias>` — Codex TUI 共存节点安全恢复 · 设计稿 v7
+
+**Pinned to**: `origin/main = ceb2b5ff`
+**Status**: **DESIGN v7** — TMHR final Phase 6 = **D**（NACK v6/A-C, 06cfb29a + 6b2049b4）。v5 Step 3 + env identity + v6 exit-9 + grep-lint + test770 承重全保留。
+
+**Deltas v6→v7**：
+1. **Phase 6 = D**：异节点 ACK 必跑，无 self-loop 兜底，无 --no-probe opt-out（TMHR 明确 override 我 v5/v6 的 A/C）
+2. Config schema 加 `codexProbePeer`（第三个必需字段，Q7 迁移指引更新）
+3. 探针发送机制：**必须目标节点经其 Bridge 实发**，CLI 不代发（禁 CLI 持目标 token）
+
+**注**：v7 Phase 6 = D 是 TMHR 需求方最终裁定；通信龙 v5 ACK 里选 A/C 的建议已被 TMHR D 覆盖。理由（TMHR）：self-loop 无法独立证明**接收侧**和**跨节点路由闭环** —— 只能证明"我能对 hub 说话"，不能证明"另一个节点能收到我说的话 + hub 路由到那个节点工作"。身份验收需要覆盖这两个维度。
+
+---
+
+## §Phase 6 v7 = D (verbatim from TMHR 06cfb29a)
+
+```
+Phase 6 身份验收 (必跑, 无 opt-out)
+
+前置检查 (Phase 0 已列, v7 强化):
+  [0.X] config.codexProbePeer 必需字段:
+        - 必须是已在 hub 注册的 alias
+        - 必须 online (通过 hub /api/nodes 或 list_host_supervisors 查)
+        - **必须非目标自身**
+        缺失 / 未注册 / offline / === alias → **fail-closed exit 2 codex_probe_peer_invalid**
+
+  --probe-to <peer> CLI override:
+        - 只允许覆盖为**另一个合格异节点**（同样必须已注册 + online + 非自身）
+        - 不允许覆盖为 self-loop
+        - 不允许覆盖为 offline / unregistered peer
+
+Phase 6 执行 (Phase 4 全过后触发):
+  [6.1] 探针发送方**必须是恢复后的目标节点**, 经其 Bridge 实发
+        - CLI 通过 hub 的合法 API 触发目标节点执行 (e.g. 一个 side-thread task 
+          "please_send_probe" 让目标 bridge 走内部 send_task)
+        - **禁 CLI/operator 持目标 token 代发** —— 这样做等于让第三方冒充目标节点
+        - 探针内容: ANET_CODEX_RESUME_PROBE_V1 alias=<target> nonce=<uuid-v4>
+  
+  [6.2] 目标节点 Bridge send_task(alias=peer, task="<probe payload>")
+  
+  [6.3] Hub 权威记录核对四项身份字段:
+        - from_name === <target alias>
+        - from_node_id === config.node_id
+        - to_name === codexProbePeer (或 --probe-to override)
+        - to_node_id === (peer 当前活 node_id from hub)
+  
+  [6.4] 异节点 peer 侧返回同 nonce ACK
+        (peer 需能识别 ANET_CODEX_RESUME_PROBE_V1 payload 并回 ACK; 
+         若 peer 无此能力 → codexProbePeer 选错了, fail-closed)
+  
+  [6.5] 退出码矩阵 (全部非零 = exit 9, 独立 code):
+        - send_failed              → exit 9 codex_probe_send_failed
+        - delivery_timeout          → exit 9 codex_probe_delivery_timeout
+        - peer_ack_timeout          → exit 9 codex_probe_peer_ack_timeout
+        - nonce_mismatch            → exit 9 codex_probe_nonce_mismatch
+        - sender_identity_mismatch  → exit 9 codex_probe_sender_identity_mismatch
+        - receiver_identity_mismatch → exit 9 codex_probe_receiver_identity_mismatch
+        - verified                  → exit 0
+
+  [6.6] self-loop 允许作为**额外诊断**（打 witness 但不参与 pass/fail 判定）
+        - 用途: 若 Phase 6 主 D 失败, self-loop 结果帮判是"我方发不出" vs "对端收不到"
+        - 主 D 不允许被 self-loop 替代
+
+  [6.7] 输出必须区分:
+        - "process recovery: passed"
+        - "identity attestation: passed"
+        - 只有**两者都 passed** 才整体 exit 0
+```
+
+## §Q7 更新 (v7 迁移指引变更)
+
+老 codex-copresence node 缺字段现在是 **3 个** (不是 2 个):
+```
+{
+  "codexProjectDir": "<absolute path>",
+  "codexLaunchAdapter": "codex-standard" | "codex-custom-wrapper",
+  "codexProbePeer": "<registered peer alias, online, not self>"  // v7 new
+}
+```
+
+Fail-fast 消息 + --dry-run JSON patch bonus 同步更新，operator 一次补三字段。
+
+**codexProbePeer 语义**：这个字段回答"我崩了之后，谁给我做身份验证" —— 是节点自己出厂配置的一部分。TMHR 侧 default 可以是 TMHR 团队自己维护的一个 verifier 节点（e.g. 一个专用 attest peer），或者一个日常协作对端。
+
+## §其余 v6 全保留
+
+- v5 Step 3 (App Server process tree writer fd, TUI 不核 fd)
+- v5 env.ANET_NODE_ID 辅助非承重
+- v6 exit-9 matrix
+- v6 grep-witness = lint only, test770 = 唯一承重执行证据
+- v3 ownership-based Phase 4.2
+- v2 --force 删 / Phase 1 窄备份 / Phase 4.3 hub 双源
+- Δ4 witness 五处
+- CI gate scope 限 codex lane + claude 3 处白名单 selftest 必须过 + 反例 D 红→绿证明
+- Q8 no --force-take-over
+
+## §test770 更新（Phase 6 D 测试）
+
+```
+测试 E (D happy path): 
+  fixture: 起完整 target + 一个真 peer 节点
+  执行: anet node resume <target>  # 用 config.codexProbePeer
+  断言:
+    - assert exit_code == 0
+    - assert grep '[Phase 6] probe SENT via target Bridge (peer=<p>)' output
+    - assert grep '[Phase 6] Hub identity: from_name=<t> from_node_id=<i1> to_name=<p> to_node_id=<i2>' output
+    - assert grep '[Phase 6] peer ACK: nonce match' output
+    - assert grep 'process recovery: passed' output
+    - assert grep 'identity attestation: passed' output
+
+测试 F (peer offline 反例):
+  fixture: config.codexProbePeer 指向一个 offline peer
+  执行: anet node resume <target>
+  断言:
+    - assert exit_code == 2 codex_probe_peer_invalid  (Phase 0 就拦, 不到 Phase 6)
+    - assert grep '[Phase 0] codexProbePeer offline, refusing' output
+    - assert NOT grep 'process recovery' output  # 根本没进 Phase 3
+
+测试 G (peer 收到但不 ACK 反例):
+  fixture: peer 侧 mock 收到 probe 但不发 ACK
+  执行: anet node resume <target>
+  断言:
+    - assert exit_code == 9 codex_probe_peer_ack_timeout
+    - assert grep 'process recovery: passed' output  # process 恢复没问题
+    - assert grep 'identity attestation: FAILED' output
+    - assert NOT grep 'identity attestation: passed' output
+
+测试 H (CLI 代发禁止反例) - TMHR 44661926 补充:
+  静态 grep = 辅助 lint only (存在 ≠ 会执行同一条铁律, v6 grep-witness lint 同族)
+  🔴 承重断言必须是**运行时证明**:
+    - 探针发起时观测: 发起者 pid === target Bridge pid (或 Bridge 进程组内)
+    - Hub 事件核对: from_name/from_node_id === target, ACK from 异节点 receiver
+    - 不得以 "CLI 源码没出现 target_token 字样" 替代执行证据
+```
+
+## §决策状态
+
+- **TMHR**: ✅ **ACK v7** (44661926) — 加实现要求: 测试 H 静态 grep = lint, 承重必须运行时观测探针发起者 pid + Hub 事件核对 (已并入上文)
+- **通信龙**: **PENDING** — 我 v5 选 A/C 后，TMHR override 到 D；通信龙 需就 Phase 6 A/C vs D 明表态。TMHR 是需求方，我倾向 D。
+
+拿到通信龙 ACK → 起 PR draft。v7 稿 `/tmp/claude-1000/.../scratchpad/anet-node-resume-codex-design-v7.md`。

--- a/docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md
+++ b/docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md
@@ -135,7 +135,9 @@ Fail-fast 消息 + --dry-run JSON patch bonus 同步更新，operator 一次补�
 
 ## §决策状态
 
-- **TMHR**: ✅ **ACK v7** (44661926) — 加实现要求: 测试 H 静态 grep = lint, 承重必须运行时观测探针发起者 pid + Hub 事件核对 (已并入上文)
-- **通信龙**: **PENDING** — 我 v5 选 A/C 后，TMHR override 到 D；通信龙 需就 Phase 6 A/C vs D 明表态。TMHR 是需求方，我倾向 D。
+- **TMHR**: ✅ **ACK v7** (44661926 + 2bf3c04a) — 加实现要求: 测试 H 静态 grep = lint, 承重必须运行时观测探针发起者 pid + Hub 事件核对
+- **通信龙**: ✅ **ACK v7 = D** (df6d26d9 + e113b532) — 初 v5 选 A/C 便利性理由，读了 TMHR 完整性理由后 explicit 让步："在身份验收这条轴上，完整性压便利性；self-loop 收发两端同一进程，只在自己身上闭合的回路证不了对外可达。他是需求方，不 override"。附三条硬要求已并入 v7：① Phase 0 拒绝须指路 ② --help + docs 明写≥2 节点前置 ③ 单节点缺口单开 issue（→ #1527）
 
-拿到通信龙 ACK → 起 PR draft。v7 稿 `/tmp/claude-1000/.../scratchpad/anet-node-resume-codex-design-v7.md`。
+## Doc drift note
+
+本 RFC 是 v7 定稿的历史记录，随 #1528 全实现落地。**当前 PR (#1538)** 不带任何 CLI surface，只 stage 内部 shape helper + schema fields —— 任何"用户读到"的行为 (Phase 0 诊断、`--help` 前置条件段、resume 分支可达) 都在 #1528，本 RFC 不作为 #1538 的合并依据。


### PR DESCRIPTION
Split out from [#1528](https://github.com/sleep2agi/agent-network/pull/1528) (Draft-locked) per TMHR authorization (29ea204b): a **strictly internal** PR carrying schema fields + helpers + tests + design doc, with **zero user-facing CLI surface**. Merging this reduces future rebase area on `cli.ts` (通信龙 f4f359b8's concern) while preserving TMHR's user-experience lock on the full implementation.

Pinned to `origin/main = 8e9613ac`.

## 🔴 Zero user-facing effect (verify before merge)

- **No `agent-network/bin/cli.ts` changes.** The dispatcher branch, `handleCodexCopresenceResume`, and `--help` updates all remain in #1528 (Draft).
- **`--help` output unchanged.** Nothing this PR adds is reachable through any existing CLI invocation.
- **Existing `anet node resume`** hits the pre-existing grok/claude session-pin path exactly as before (no new branch to select).
- The **3 new profile fields are optional**; `anet node create` / `anet node start` / any other current command does not read them.
- **`codexResumeMissingConfigHint()` exists but has no caller in this PR** — staged for the #1528 followup.

If any grep of `agent-network/bin/cli.ts` on this branch shows changes vs. `origin/main`, this PR is out of scope. It should not.

## What lands

**1. `agent-network/src/codex-copresence-profile.ts` — 3 new optional fields:**

- `codexProjectDir` — absolute path for `-C <dir>` (Phase 3.2) + hub cross-check (Phase 4.3)
- `codexLaunchAdapter` — `\"codex-standard\"` \| `\"codex-custom-wrapper\"` (Q5 routes App Server + TUI launch; the latter handles TMHR狗-class custom LLM API wrapper)
- `codexProbePeer` — peer alias for Phase 6 D cross-node identity attestation

Plus helpers:
- `missingCodexResumeFields(profile) → CodexResumeRequiredField[]` — shape validation; called by future Phase 0 preflight
- `codexResumeMissingConfigHint(alias, missing) → string` — Q7=C actionable multi-line diagnostic (JSON patch + `anet node ls` next step + `#1527` single-node warning). **Not called by any CLI code in this PR.**
- `CODEX_RESUME_REQUIRED_FIELDS` constant — auditable list of the 3

**2. `agent-network/src/codex-copresence-profile-resume.test.ts` — 14 unit tests**

Green: **14 pass / 0 fail / 22 expect() calls**. Coverage:
- Shape validation per field (absolute path / enum / non-empty)
- Both `codexLaunchAdapter` enum values accepted
- Hint template contains ONLY missing keys (regression on \"don't overwrite good config\")
- `anet node ls` named as the concrete next step
- `#1527` warning appears iff `codexProbePeer` is in the missing set
- Message terminates with the re-run command (closes the loop)
- No leaked absolute paths outside template placeholders

**3. `docs/rfcs/RFC-anet-node-resume-codex-copresence-v7.md` — full design doc**

Preserves all 7 rounds of design review through TMHR + 通信龙 ACK v7 (final head `29ea204b`). Reference material for #1528 and future reviewers.

## Verification (all local, this branch, head just pushed)

\`\`\`
bun test src/codex-copresence-profile-resume.test.ts    → 14 pass / 0 fail
tsc --noEmit                                             → 0 errors
python3 .github/scripts/check-home-path-baseline.py     → green (0 above baseline)
python3 scripts/check-doc-symbol-pins.py                 → SYMBOL-PIN: OK, 0 drift
\`\`\`

## Relationship to #1528 (Draft)

**Before merge:** #1528 contains this PR's contents PLUS `cli.ts` changes (import, resume dispatcher branch, `handleCodexCopresenceResume` with Phase 0 preflight, `--help` Prerequisites section).

**After this merges:** #1528 rebases onto new main; git dedups this PR's changes; #1528 only carries the `cli.ts` changes + follow-up Phase 1-6 commits. Result: smaller diff on the hot `cli.ts` file, smaller rebase face.

## Deploy risk

Zero for behavior:
- 3 new profile fields optional, unread by any current CLI command
- No `cli.ts` changes → no dispatch changes, no `--help` claims
- Helpers exist but have no in-tree caller until #1528 lands

Non-zero for review load: reviewers should verify the \"no CLI surface\" claim by grepping this branch's `agent-network/bin/cli.ts` diff (should be empty vs. `origin/main`).

## Related

- #1521 — TMHR's feature request
- #1527 — single-node limitation follow-up
- #1528 — Draft PR with full implementation (locked per TMHR d14d3c82 + 29ea204b until Phase 1-6 + test770 real双节点/真 Hub 闭环 + CI registration done)
- 通信龙 f4f359b8 — rebase concern that motivated this split
- TMHR 29ea204b — authorization for internal-only extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)