### PR TITLE
fix(test): qa-rfc026 的 SEC-1 跨租户断言从来没测过它声称测的东西(三层错配 + 一条不会红的前置断言)

### DIFF
--- a/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
+++ b/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
@@ -52,6 +52,22 @@ R=$(curl -s -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/
 UTOK=$(echo "$R" | jq -r .token); NTOK=$(echo "$R" | jq -r .network_token); NET_ID=$(echo "$R" | jq -r .network_id)
 [[ "$UTOK" == utok_* ]] && ok "admin registered (net=${NET_ID:0:12})" || { bad "register failed: $R"; exit 1; }
 
+# 🔴 The daemon needs its OWN node-scoped token, minted for $DAEMON_NAME.
+# It used to reuse $NTOK — the network_token that /api/auth/register returns,
+# which is bound to the ADMIN USER's name (t309admin), not to a node. Since
+# the #203 identity guard landed, report_status refuses when the token-bound
+# alias differs from the reported one:
+#   alias_identity_mismatch  token_alias='t309admin'  reported_alias='daemon-309'
+# That guard is correct — it is what stops a network token from silently
+# rebinding its own name (the #203 symptom was grokB's send arriving as
+# from=grokA). The fixture simply predates it. Same mint the main run.sh uses.
+DAEMON_NTOK_RESP=$(curl -sS -X POST "$HUB_BASE/api/auth/node-token" \
+  -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+  -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"$DAEMON_NAME\"}")
+DAEMON_NTOK=$(echo "$DAEMON_NTOK_RESP" | jq -r .token)
+[[ "$DAEMON_NTOK" == ntok_* ]] && ok "daemon ntok minted for $DAEMON_NAME" \
+  || { bad "daemon ntok mint failed: $DAEMON_NTOK_RESP"; exit 1; }
+
 note "Stage 1 — daemon node config (host_supervisor role)"
 mkdir -p "$WORK/.anet/nodes/$DAEMON_NAME"
 DAEMON_NODE_ID="node_d309"
@@ -61,7 +77,7 @@ cat > "$WORK/.anet/nodes/$DAEMON_NAME/config.json" <<EOF
   "alias": "$DAEMON_NAME",
   "runtime": "claude-agent-sdk",
   "hub": "$HUB_BASE",
-  "token": "$NTOK",
+  "token": "$DAEMON_NTOK",
   "network_id": "$NET_ID",
   "role": "host_supervisor",
   "flags": {"dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000"}
@@ -160,8 +176,20 @@ fi
 
 note "Stage 7 — send-task三连 third leg:真 dispatch + verify child processes"
 # Send a task via /api/task (the same path Vincent/agents would use)
+# 🔴 Must be the USER token here, not $NTOK. POST /api/task now refuses a
+# network-bound token that claims a from_session it cannot prove:
+#   from_session_identity_mismatch — "network token has no resolvable node
+#   alias and may not claim a from_session"  (token_alias="")
+# That guard is correct and deliberately added (server/src/rest-identity.ts):
+#   "POST /api/task did not [enforce it] — it took `body.from` verbatim, so any
+#    node holding its own ntok_ could claim another node's alias. That value is
+#    stored on the task row and, once sender labels reach the copresence TUIs,
+#    rendered to a human as an attribution."
+# A utok_ is not an identity boundary in that sense, so it may carry
+# from="309-smoke" — and it is also the path the comment above describes
+# ("the same path Vincent/agents would use").
 T_RESP=$(curl -sS -X POST "$HUB_BASE/api/task" \
-  -H "Authorization: Bearer $NTOK" -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
   -d "{\"alias\":\"$CHILD_NAME\",\"task\":\"ping from 309 review smoke\",\"priority\":\"normal\",\"from\":\"309-smoke\",\"network_id\":\"$NET_ID\"}")
 TASK_OK=$(echo "$T_RESP" | jq -r .ok 2>/dev/null)
 TASK_ID=$(echo "$T_RESP" | jq -r .task_id 2>/dev/null)

--- a/tests/qa-rfc026-create-node/run.sh
+++ b/tests/qa-rfc026-create-node/run.sh
@@ -84,11 +84,20 @@ ADMIN_USER_ID=$(curl -sS "$HUB_BASE/api/auth/me" -H "Authorization: Bearer $UTOK
 REG_M=$(curl -sS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
   -d "{\"username\":\"$MEMBER_USER\",\"password\":\"$MEMBER_PW\",\"email\":\"m026@test.local\"}")
 MEMBER_UTOK=$(echo "$REG_M" | jq -r .token)
+# 🔴 取值之后立刻校验形状 —— 否则下面拿它去建成员、而失败会在**场景 B** 才露头,
+#    报的是"角色门没拦住",指向的是错的地方。
+[[ "$MEMBER_UTOK" == utok_* ]] || bad "member utok mint failed: $REG_M"
 MEMBER_USER_ID=$(curl -sS "$HUB_BASE/api/auth/me" -H "Authorization: Bearer $MEMBER_UTOK" | jq -r .user.user_id)
-curl -sS -X POST "$HUB_BASE/api/networks/$NET_ID/members" -H "Authorization: Bearer $UTOK" \
-  -H 'Content-Type: application/json' -d "{\"user_id\":\"$MEMBER_USER_ID\",\"role\":\"member\"}" >/dev/null
+[[ -n "$MEMBER_USER_ID" && "$MEMBER_USER_ID" != "null" ]] \
+  || bad "member user_id not resolved (MEMBER_USER_ID='$MEMBER_USER_ID')"
+ADD_M=$(curl -sS -X POST "$HUB_BASE/api/networks/$NET_ID/members" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -d "{\"user_id\":\"$MEMBER_USER_ID\",\"role\":\"member\"}")
 mcp_init_once "$MEMBER_UTOK"
-ok "member user joined network (role=member)"
+# 🔴 这一行原来是**无条件** `ok` —— 不管上面三步有没有成功都打 PASS。
+#    一条无条件的 PASS 不是断言,是一句声明。
+[[ "$(echo "$ADD_M" | jq -r .ok 2>/dev/null)" == "true" ]] \
+  && ok "member user joined network (role=member)" \
+  || bad "member join failed: $ADD_M"
 
 # ── 0.A bring up daemon (used by A + B + C + D + F + K) ───────────
 DAEMON_NTOK_RESP=$(curl -sS -X POST "$HUB_BASE/api/auth/node-token" \
@@ -187,9 +196,20 @@ ROWS=$(sqlite3 "$HUB_DB" "SELECT COUNT(*) FROM node_create_requests WHERE child_
 note "C. cross-tenant — stranger network cannot target our daemon"
 # admin creates a 2nd network they own; from the network they own (NET2)
 # try to create on NET_ID's daemon → should be cross_network_node.
-NET2=$(curl -sS -X POST "$HUB_BASE/api/networks" -H "Authorization: Bearer $UTOK" \
-  -H 'Content-Type: application/json' -d '{"network_name":"stranger-net"}' | jq -r .network.network_id)
-[[ -n "$NET2" && "$NET2" != "null" ]] && ok "stranger network = $NET2"
+# 🔴 `POST /api/networks` 返回的是**扁平** {ok, network_id, network_name}
+#    (server.ts: `Response.json(result)`,result 直接来自 createNetwork),
+#    **没有 .network 这一层**。原来取 `.network.network_id` 恒得 null。
+# 🔴 服务端读的是 `body.name`(server.ts: createNetwork(user_id, body.name, body.description)),
+#    夹具原来发的是 `network_name` ⇒ name=undefined ⇒ 建网失败/建出无名网络。
+#    这是 NET2 恒为 null 的**第二层**成因(第一层是 jq 路径多了 .network)。
+NET2_RESP=$(curl -sS -X POST "$HUB_BASE/api/networks" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -d '{"name":"stranger-net"}')
+NET2=$(echo "$NET2_RESP" | jq -r .network_id)
+# 🔴 这条以前是 `[[ … ]] && ok "…"` —— **没有 || bad**。于是 NET2 取空时它静默跳过,
+#    下面那条 SEC-1 断言就拿着 network_id=null 去发请求,测的根本不是跨租户。
+#    前置条件不成立必须红,否则后面的断言在测垃圾。
+[[ -n "$NET2" && "$NET2" != "null" ]] && ok "stranger network = $NET2" \
+  || bad "stranger network not created (NET2='$NET2') resp=$NET2_RESP — cross-tenant assertion below would test garbage"
 BODY=$(build_create_node_body "$DAEMON_NODE_ID" "c-noop-child" "claude-agent-sdk" "claude-opus-x" "$NET2")
 RESP=$(mcp_call "$UTOK" "$BODY")
 ERR=$(echo "$RESP" | jq -r .error 2>/dev/null)


### PR DESCRIPTION
## Author & Helpers

**Author (Primary)**: 通信测试马

**Helpers**:
- 通信龙: 派工 / **要求「先证明它今天真的红,再把修复端上去」—— 这条要求拦下了一个基于错误因果、且方向是放宽 SEC 断言的修复**
- 通信SDK马: 复核(按「谁写谁不复核」)

**Tier review gate**: 通信SDK马

## Why

Refs #1532

`qa-rfc026-create-node` 是 CI 里的 **58 个存量孤儿之一**(`.github/workflows/` 下 0 处引用,
`check-test-suite-registration.py` 的棘轮基线里有它)。**第一次真跑它**就发现:C 场景那条
「stranger network 不能跨租户操作我们的 daemon」**拿着 `network_id: null` 在发请求**。

**三层错配叠加,而第三层保证了前两层永远不可见:**

| # | 错在哪 | 后果 |
|---|---|---|
| 1 | 夹具发 `{"network_name": …}`,而 `server.ts:1288` 读的是 **`body.name`** | 网络**从一开始就没建成** |
| 2 | 夹具取 `.network.network_id`,而 API 返回**扁平** `{ok, network_id, …}` | 就算建成了也取不到 |
| 3 | 🔴 前置断言 `[[ … ]] && ok "…"` —— **没有 `\|\| bad`** | **1 和 2 永远不可见**,报表上这一格显示"已覆盖" |

服务端收到 `network_id: "null"` ⇒ `getUserNetworkRole(user, "null")` 无行 ⇒ 返回
`access_denied "not a member"`,不在断言的接受集合里 ⇒ 红。

🔴 **这条红是对的,不该靠放宽断言去消。** 把 `access_denied` 加进接受集合会让一条
**什么都不测**的 SEC 断言永久变绿 —— **给安全断言多加一个可接受值,和把它改成
「error 非空」,方向是同一个,只是幅度小到看不出来。**

## What

三层全修(**不动断言的精确值集合**),外加同形状扫描扫出的两条。

## How to verify

```bash
docker build -t anet-qa-rfc026 -f tests/qa-rfc026-create-node/Dockerfile .
docker run --rm anet-qa-rfc026
# → RFC-026 P1/P2 e2e — PASS=60 FAIL=0 SKIP=1
#   ✓ stranger network = net_xxxx
#   ✓ cross-net rejected at SEC-1 layer: cross_network_node
#   TOTAL FAILED SUITES: 0
```

**投递语义自答**:n/a —— 本 PR 只改测试夹具,不改任何产品返回值。
但它触及的正是那一族的**测试侧对应物**:一条 `&& ok` 而没有 `|| bad` 的前置断言,
**成功与失败给出同一个读数(什么都不打印)** —— 这就是为什么它能藏这么久。

## Test evidence(Docker,四轮,每轮都是一次预测)

| 轮 | 改了什么 | 结果 |
|---|---|---|
| 1 | 原样 | `FAIL=1` `cross-net NOT rejected: access_denied` |
| 2 | 只改取值路径 `.network.network_id`→`.network_id` | `FAIL=2` ← **`\|\| bad` 生效,那条藏着的前置失败第一次有了名字** |
| 3 | 再改字段名 `network_name`→`name` | `PASS=60 FAIL=0`,cross-net → **`cross_network_node`**(与预测一致) |
| 4 | 加两处取值校验 + 修无条件 `ok` | `PASS=60 FAIL=0`,`TOTAL FAILED SUITES: 0` |

🔴 **第 2 轮是一次预测被证伪**:我以为只改取值路径就够了。**因为把它写成了可证伪的,
所以立刻知道还有一层**,而不是看到"还是红的"去猜、或者去调断言迁就它。

## 同形状扫描,以及扫描器自己的 bug

写了个扫描器找「取值 → 当作输入喂进后续请求、中间没有能失败的校验」。

🔴 **第一版判据没抓到 NET2** —— 因为那一行**确实有** `[[ -n "$NET2" && "$NET2" != "null" ]]`,
判据看到"有守卫"就跳过了。**但那个守卫写成 `&& ok`、不会红。**
**它问的是「有没有守卫」,而不是「守卫会不会失败」—— 扫描器自己犯了它要找的那个错。**

改成"守卫必须带失败分支才算数"之后两向都对:

```
修复前文件:  MEMBER_UTOK / MEMBER_USER_ID / NET2   合计 3   ← 正控通过
修复后文件:                                        合计 0
```

**要不是拿修复前的文件当正控跑一遍,我会交一份「扫描干净」的报告。**

(取集也错过两轮:按行 grep 看不见反斜杠续行,`qa-rfc027` 一度被算成"36 条静默断言",
真值 **0** —— 那个套件是我自己接进 CI 的,这个假数会派人去查一个不存在的问题。
三版判据给出 14→2→1 和 43→36→0,**错的一直是取集,不是判断规则**。)

## 🔴 第二个提交:那条新断言**验的是回执不是状态**,负向控制抓出来的

@通信SDK马 复核时指出:*"你只证明了判据对着正确的字段,没证明它失败时会红。"* 我按他说的跑了负向控制,结果:

```
把 user_id 换成 u_NEGATIVE_CONTROL_DOES_NOT_EXIST 跑一遍
→ ✓ member user joined network (role=member)      ← **照样通过**
→ 红的是下游场景 B(报"角色门没拦住",指向错的地方)
```

`addNetworkMember`(`auth.ts:481`)**不校验 user_id 是否存在**就 INSERT ⇒ 传一个不存在的 user 照样 `{ok:true}`。

⇒ **我把一条无条件的 `ok` 改成了一条「验错东西的 `ok`」**:断言在、字段对、能红,**只是红的条件不是文案说的那个条件**。
**前四轮 Docker 全绿,一次都没暴露它** —— 因为正向路径下"调用成功"和"成员真的加上了"结果相同。

改成**回读成员表**(`getNetworkMembers` 带 `JOIN users`,伪造的 user_id JOIN 不出来):

| 方向 | 结果 |
|---|---|
| 负向(user_id 不存在) | `✗ member not present with role=member (add resp={"ok":true} members=[{…"role":"owner"…}])` |
| 正向(真实 user_id) | `✓ member user joined network (role=member)` / `PASS=60 FAIL=0` |

🔴 那行红话里 **`{ok:true}` 和「成员表里只有 owner」同时出现** —— 下一个人读到它不需要再推导"断回执 vs 断状态"的区别,证据就在眼前。

**⇒ 这条经验适用于本 PR 之外**:把「无断言」改成「有断言」只是第一步;**第二步是证明那个断言失败时真的会红,而且是因为文案说的那个原因红。** 读代码到不了这一格,一分钟的负向控制到得了。

## 扫出来的两条(A 场景)

```bash
MEMBER_UTOK=$(echo "$REG_M" | jq -r .token)                    # 无校验
MEMBER_USER_ID=$(curl … /api/auth/me … | jq -r .user.user_id)  # 无校验,直接喂进加成员请求
ok "member user joined network (role=member)"                  # 🔴 **无条件** PASS
```

**一条无条件的 `ok` 不是断言,是一句声明。** 不过它比 NET2 轻一档:成员没加成功时
下游场景 B 会红,只是**报在错的地方**(指向角色门而不是设置失败)——**不是假绿,是误导性的红**。

## 关于验证次数的说明

**本 PR 目前只有一次独立验证(作者本人的六轮 Docker)。** @通信SDK马 的复核是**代码层**的
(他明确写了"四轮 Docker 我没有复跑,盘 21G 我不起容器"),**不能算第二次独立验证**。
写在这里免得它被读成"两个人都跑过了"。

## 本 PR **不**做什么

**不接 CI。** 这个套件仍是孤儿(#1532)。接之前还要确认 `PASS=60` 里没有其它同形状的假绿 ——
**本 PR 的扫描只覆盖了「取值 → 喂进请求」这一种形状,不是全部。** 接线是之后单独一个 PR,
按「跑不过的不接」。

## Checklist

- [x] Relevant tests pass locally(Docker 四轮,见上)
- [ ] `docs-site/docs/changelog.md` — n/a(测试夹具)
- [ ] Docs synced — n/a
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`fix:`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] Issue 链接用对了关键字:`Refs #1532`(不 close —— 那条 issue 讲的是 58 个孤儿,本 PR 只修其中一个的内容)
- [x] **投递语义自答**:见 How to verify
