### PR TITLE
feat(skillhub): 新增 skill「Prove the fix executed」

### DIFF
--- a/docs-site/docs/public/skillhub/catalog.json
+++ b/docs-site/docs/public/skillhub/catalog.json
@@ -44,6 +44,26 @@
     },
     {
       "schema_version": 1,
+      "slug": "prove-the-fix-executed",
+      "name": "Prove the fix executed",
+      "description": "An inert fix and a guard that rejects everything look identical; require that the fix fired and the metric moved.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "testing",
+        "debugging",
+        "regression"
+      ],
+      "published_at": "2026-08-30",
+      "content_sha256": "aebc358363b4bf1525f7d295054b4dfed0213e79373e38c8b2675a39ae13610a",
+      "content_url": "/skillhub/skills/prove-the-fix-executed/1.0.0/SKILL.md"
+    },
+    {
+      "schema_version": 1,
       "slug": "public-skill-review-checklist",
       "name": "Public skill review checklist",
       "description": "Safe promotion checklist from private SkillHub to the public catalog.",

--- a/docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/SKILL.md
@@ -1,0 +1,64 @@
+# Prove the fix executed
+
+Use this workflow when a change is meant to fix an intermittent failure, and the
+only evidence available is that the suite is now green.
+
+## The failure this prevents
+
+A fix can be **inert**: the code is present, reads correctly, has unit tests, and
+never executes on the path it was written for. From the outside, an inert fix and
+a guard that correctly rejects everything look identical — no output, no action,
+and the failure rate is unchanged.
+
+Real case: a reclaim step was fed a directory alias where the persisted node id
+was required. The computed paths never matched, so the candidate set was always
+empty and the loop body never ran. Failure rate before the fix: 2 red in 12 runs.
+With the fix: 4 red in 22 runs. Same signature, byte for byte.
+
+## Do not accept "N runs green" as the acceptance criterion
+
+At a 17% failure rate, six consecutive green runs happen about 35% of the time.
+A run of greens is compatible with the fix working, with the fix being inert, and
+with the triggering condition simply not occurring. Greens cannot separate those.
+
+Worse, low-load CI reproduces intermittent conditions less often than the loaded
+environment where they were found, so an inert fix is more likely to look green in
+CI than on the machine where the bug was seen.
+
+## Require two signals
+
+1. **The fix fired.** A log line, counter, or persisted event emitted by the new
+   code path itself, observed in a run that would otherwise have failed.
+2. **The metric moved.** Failure rate measured under the same conditions as the
+   original measurement — same concurrency, same CPU budget, same image.
+
+Either signal alone is insufficient. A fired log line without a metric change can
+mean the fix runs but does not repair. A metric change without a fired log line
+can mean the condition stopped occurring.
+
+## When the rare condition will not cooperate, construct it
+
+Waiting for a 17%-probability event burns time and evidence. Build the bad state
+directly instead: create the artifacts on disk, start the process that owns them,
+kill it in a way that skips its cleanup, then run the real command against the
+result.
+
+Assert the premise inside the probe. Before judging the outcome, verify that the
+state you meant to create actually exists — the listener count, the file, the dead
+owner. A probe whose premise silently failed produces a confident, meaningless
+result, and it looks exactly like a successful run.
+
+Cover both directions: the condition the fix should handle, and the neighbouring
+condition it must still refuse. A fix that reclaims orphaned resources must be
+shown to leave live ones alone.
+
+## Make "nothing happened" audible
+
+Any step that can legitimately do nothing must say so, and distinguish its cases:
+matched none of N candidates, precondition absent, owner still alive. When a code
+path can exit silently, its inert form is indistinguishable from its working form,
+and every later investigation inherits that ambiguity.
+
+Where a value is recomputed from an identifier, cross-check the computed value
+against the stored one and report `ok`, `mismatch`, and `missing` separately.
+Computing a value proves nothing; agreeing with the recorded value does.

--- a/docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "slug": "prove-the-fix-executed",
+  "name": "Prove the fix executed",
+  "description": "An inert fix and a guard that rejects everything look identical; require that the fix fired and the metric moved.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": [
+    "testing",
+    "debugging",
+    "regression"
+  ],
+  "published_at": "2026-08-30"
+}

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -196,9 +196,17 @@ broken=$(printf '%s' "$out" | sed -nE 's/^broken_pins=([0-9]+)$/\1/p')
 # 仍然**只有 `files` 变了**,`uniq` 仍 9、`occ` 仍 24(两页都没有 #L 源码行号 pin)。
 # CI 上先红("预期扫 127 …,实际 129")才来抬分母,顺序是对的。
 #
+# 2026-08-30:files 129 → 131。新增一条 public skillhub skill(#1540):
+#     docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/SKILL.md
+#     docs-site/docs/public/skillhub/skills/prove-the-fix-executed/1.0.0/metadata.json
+#   🔴 **是 +2 不是 +1**:`check-doc-source-pins.py` 的 `SCANNED_SUFFIXES` 是
+#   (.md .ts .tsx .js .json .vue) —— **.json 也算文档文件**。我第一次看到 +2 时
+#   以为哪里多算了(只加了一个 .md),是去读那个常量才对上的。**别按"我加了几个 .md"推。**
+#   `uniq` 仍 9、`occ` 仍 24(新加的 skill 里没有 #L 源码行号 pin)。
+#   catalog.json 由 scripts/build-public-skillhub.mjs 生成,不是手改。
 # 🔴 下面三条是 `-eq`(精确相等),**不是下界** —— job 名里的 "floor" 会误导。
 #    新增/删除文档都会让 files 变,必须回来按实际值更新,并写清变的是哪个数、为什么。
-[[ "$files" -eq 129 ]] || fail "预期扫 129 个文档文件(= git ls-files 的结果),实际 $files"
+[[ "$files" -eq 131 ]] || fail "预期扫 131 个文档文件(= git ls-files 的结果),实际 $files"
 [[ "$uniq"  -eq 9  ]] || fail "预期 9 个唯一 pin,实际 $uniq"
 [[ "$occ"   -eq 24 ]] || fail "预期 24 处原始出现,实际 $occ"
 echo "  OK  walk 路径与 git 路径给出同一份清单($files 文件 / $uniq 唯一 pin / $occ 处)"


### PR DESCRIPTION
## 为什么是这一条

/goal 的余力项（skills hub）。内容不是总结出来的，是今天在 #1422 这条线上**实际付出代价换来的**，形状与现有的 `witnessed-red-regression-gate` / `invariant-denominator-check` 同族。

**它防的失败**：一个修复可以是**惰性的** —— 代码在、读起来对、单测全绿、四向见红都红，**而它在目标路径上一次都没执行过**。从外面看，惰性修复和「守卫正确地拒绝了一切」**完全一样**：没有输出、没有动作、失败率不变。

真实数据（写进 skill）：修复前 **12 轮 2 红（17%）**，带"修复" **22 轮 4 红（18%）**，**红话逐字相同**。根因：把目录别名喂给了需要持久化 node id 的哈希函数 ⇒ 候选集恒空 ⇒ 循环体一次没进。

## skill 给出的判据

1. **不要拿「跑 N 轮不红」当验收** —— 17% 下 6 轮全绿概率约 35%；且**低负载 CI 比发现 bug 的高负载环境更不容易复现**，惰性修复在 CI 上反而更容易看起来绿；
2. **要两个信号**：修复**真的触发过** + **指标在同条件下变了**（任一单独都不够）；
3. **稀有条件不配合就构造它**，并把**前提断言写进探针**（前提悄悄失败的探针会给出自信而无意义的结果，且看起来和成功运行一样）；两向都要覆盖；
4. **让「什么都没做」发得出声**，凡按标识符重算的值都与存储值交叉校验并分报 `ok`/`mismatch`/`missing` —— **算出一个值什么都不证明，和记录一致才证明**。

## 验证

| | |
|---|---|
| `node scripts/build-public-skillhub.mjs` | catalog 6 → **7** 条 |
| `--check`（test600 用的同一条命令） | **PASS (7 entries, catalog current)** |
| **见证红**：往 SKILL.md 追加一行 → `--check` | **rc=1**（content hash 不符） |
| 还原 → `--check` | rc=0，文件 `cmp` 逐字相同 |
| doc-symbol-anchors / docs-integrity / home-path-baseline | 全 rc=0 |

catalog 由 `scripts/build-public-skillhub.mjs` **生成**，我没有手改 `catalog.json`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)