### PR TITLE
fix(test): 那条 member-join 断言验的是回执不是状态 —— 负向控制抓出来的(#1539 的续)

### DIFF
--- a/tests/qa-rfc026-create-node/run.sh
+++ b/tests/qa-rfc026-create-node/run.sh
@@ -95,9 +95,22 @@ ADD_M=$(curl -sS -X POST "$HUB_BASE/api/networks/$NET_ID/members" -H "Authorizat
 mcp_init_once "$MEMBER_UTOK"
 # 🔴 这一行原来是**无条件** `ok` —— 不管上面三步有没有成功都打 PASS。
 #    一条无条件的 PASS 不是断言,是一句声明。
-[[ "$(echo "$ADD_M" | jq -r .ok 2>/dev/null)" == "true" ]] \
+#
+# 🔴 而且第一版补的是 `[[ $(jq -r .ok "$ADD_M") == true ]]` —— **那个也不够**:
+#    `addNetworkMember`(auth.ts:481)**不校验 user_id 是否存在**就 INSERT,
+#    所以传一个不存在的 user 照样 `{ok:true}`。**负向控制实测:用
+#    `u_NEGATIVE_CONTROL_DOES_NOT_EXIST` 跑,那条断言照样打 ✓。**
+#    ⇒ 它验的是"接口调用成功",而文案声称的是"这个人成了成员"。
+#
+#    改成回读成员表:`getNetworkMembers` 带 `JOIN users`,伪造的 user_id
+#    **不会出现在结果里**,所以这条才真的在验成员身份。
+#    (脏库上重跑会红:重复加成员返回 {ok:false,"user already a member"};
+#     本套件用独立 DB,但本地拿同一个 DB 重跑的人会看到,别误诊成产品坏了。)
+MEMBERS=$(curl -sS "$HUB_BASE/api/networks/$NET_ID/members" -H "Authorization: Bearer $UTOK")
+echo "$MEMBERS" | jq -e --arg u "$MEMBER_USER_ID" \
+  '.members[]? | select(.user_id==$u and .role=="member")' >/dev/null 2>&1 \
   && ok "member user joined network (role=member)" \
-  || bad "member join failed: $ADD_M"
+  || bad "member not present with role=member (add resp=$ADD_M members=$MEMBERS)"
 
 # ── 0.A bring up daemon (used by A + B + C + D + F + K) ───────────
 DAEMON_NTOK_RESP=$(curl -sS -X POST "$HUB_BASE/api/auth/node-token" \


### PR DESCRIPTION
## Author & Helpers

**Author (Primary)**: 通信测试马

**Helpers**:
- 通信SDK马: **"你只证明了判据对着正确的字段,没证明它失败时会红"** —— 这一句直接导出了本 PR;并核出 PR #1539 上没有这一版(我当时以为推上去了)

**Tier review gate**: 通信SDK马

## Why

Refs #1532 ・ 续 #1539

#1539 把一条**无条件的** `ok "member user joined network (role=member)"`(不管前面成没成功都打 PASS)改成了

```bash
[[ "$(echo "$ADD_M" | jq -r .ok 2>/dev/null)" == "true" ]] && ok … || bad …
```

**判据对着正确的字段、也确实能区分接口成败。** 但它验的是「**这次调用成功了**」,而那行文案声称的是「**这个人成了成员**」。

`addNetworkMember`(`auth.ts:481`)**不校验 user_id 是否存在**就 INSERT:

```ts
export function addNetworkMember(networkId, userId, role, invitedBy?) {
  const existing = db.get(…);                  // 只查"是不是已经是成员"
  if (existing) return { ok: false, … };
  db.run("INSERT INTO network_members …");     // ← 不校验 users 表里有没有这个 user
  return { ok: true };
}
```

**负向控制实测**(把 user_id 换成 `u_NEGATIVE_CONTROL_DOES_NOT_EXIST`,跑一次完整套件):

```
✓ member user joined network (role=member)      ← **照样通过**
红的是下游场景 B(报"角色门没拦住" —— 指向错的地方)
```

🔴 **⇒ 我把一条无条件的 `ok` 改成了一条「验错东西的 `ok`」**:断言在、字段对、能红,**只是红的条件不是文案说的那个条件**。

**#1539 的四轮 Docker 全绿,一次都没暴露它** —— 因为正向路径下「调用成功」与「成员真的加上了」结果相同。**任何数量的绿都区分不了这两者。**

## What

把判据从**读回执**改成**读状态**。

## How to verify

```bash
docker build -t anet-qa-rfc026 -f tests/qa-rfc026-create-node/Dockerfile . && docker run --rm anet-qa-rfc026
# → RFC-026 P1/P2 e2e — PASS=60 FAIL=0 SKIP=1 / TOTAL FAILED SUITES: 0

# 负向控制(证明它会红,而且是因为文案说的那个原因红):
sed -i 's/\\"user_id\\":\\"\$MEMBER_USER_ID\\"/\\"user_id\\":\\"u_DOES_NOT_EXIST\\"/' \
  tests/qa-rfc026-create-node/run.sh
# → ✗ member not present with role=member (add resp={"ok":true} members=[{…"role":"owner"…}])
```

**为什么新写法能区分**:`getNetworkMembers`(`auth.ts:468`)带 `JOIN users u ON nm.user_id = u.user_id` ⇒ 伪造的 user_id **JOIN 不出来**。所以它断的是成员身份的**状态**,不是那次调用的**回执**。

**投递语义自答**:这正是那一族的测试侧对应物。`{ok:true}` 是一个**带投递含义的返回值** —— 它说"这次调用被接受了",不说"世界变成了你要的样子"。**没人真正加入时,那个字段仍然是成功值** ⇒ 所以判据不能读它。本 PR 就是把判据从那个字段挪到状态上。

## Test evidence(两向,各一次完整 Docker 运行)

| 方向 | 结果 |
|---|---|
| 负向(user_id 不存在) | `✗ member not present with role=member (add resp={"ok":true} members=[{…"role":"owner"…}])` |
| 正向(真实 user_id) | `✓ member user joined network (role=member)` / `PASS=60 FAIL=0 SKIP=1` / `TOTAL FAILED SUITES: 0` |

🔴 那行红话里 **`{ok:true}` 与「成员表里只有 owner」同时出现** —— 下一个人读到它不需要再推导"断回执 vs 断状态"的区别。

## 为什么是单独一个 PR

**#1539 在这一版推上分支之前就被合并了**(squash,merge_commit `733b4a0a`,`merged_at 2026-08-30T04:27:36Z`)。合并**冻结了它的 head**,所以我那次 `git push`(输出 `19cb6a8d..a0a2d398`)确实落在了分支上,但**进不了 main**。

@通信SDK马 从两个来源(`headRefOid` + `refs/pull/1539/head`)核出"PR 上没有第二个提交"——**他是对的**;我当时只看了自己的 push 输出,那只证明**分支**更新了,不证明 **PR** 跟上了。

## 顺带记录:`addNetworkMember` 本身可能是个产品缺陷

它能把一个**不存在的 user_id** 插进 `network_members`,造出孤儿行。当前**不可达**(授权判定永远拿已鉴权用户的 id 去查,而孤儿行的 id 不对应任何可登录身份),读路径也被 `getNetworkMembers` 的 JOIN 过滤掉。

**本 PR 不修它**,只在这里记一笔 —— 归属在 hub 侧,而且它今天的价值恰恰是让上面那个负向控制得以成立。

## Checklist

- [x] Relevant tests pass locally(两向各一次完整 Docker)
- [ ] `docs-site/docs/changelog.md` — n/a(测试夹具)
- [ ] Docs synced — n/a
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`fix:`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] Issue 链接:`Refs #1532`(不 close)
- [x] **投递语义自答**:见 How to verify
