### PR TITLE
qa-rfc028-provider-probe: fail loud on DNS restore failure (#1537)

### DIFF
--- a/docs/tests/report-test1537-rfc028-provider-probe-restore.txt
+++ b/docs/tests/report-test1537-rfc028-provider-probe-restore.txt
@@ -1,0 +1,52 @@
+Test: #1537 qa-rfc028-provider-probe restore fail-loud guard
+Date: 2026-08-30
+Runner: Docker via sg docker
+Disk precheck:
+  df -h / => /dev/vda3 492G size, 455G used, 18G available, 97%
+
+Change under test:
+  tests/qa-rfc028-provider-probe/run.sh
+  - line 316: fail loud if /etc/hosts restore after F anthropic DNS-attack variant fails.
+  - line 352: fail loud if /etc/hosts restore/cleanup after F.deepseek DNS-attack variant fails.
+
+Witness red 1: missing /tmp/hosts.bak before first restore
+Command:
+  sg docker -c 'docker build -t anet-qa-rfc028-provider-probe:witness-first-fixed -f tests/qa-rfc028-provider-probe/Dockerfile . && docker run --rm anet-qa-rfc028-provider-probe:witness-first-fixed'
+Result:
+  exit 1
+Red point:
+  /tmp/qa-rfc028-witness-first-fixed.log:313 cp: cannot stat '/tmp/hosts.bak': No such file or directory
+  /tmp/qa-rfc028-witness-first-fixed.log:314 ✗ F /etc/hosts restore failed after anthropic variant — abort before DeepSeek variant runs on polluted DNS state
+Notes:
+  F.deepseek did not start after the restore failure.
+
+Witness red 2: missing /tmp/hosts.bak before F.deepseek restore
+Command:
+  sg docker -c 'docker build -t anet-qa-rfc028-provider-probe:witness-deepseek-fixed -f tests/qa-rfc028-provider-probe/Dockerfile . && docker run --rm anet-qa-rfc028-provider-probe:witness-deepseek-fixed'
+Result:
+  exit 1
+Red point:
+  /tmp/qa-rfc028-witness-deepseek-fixed.log:316 cp: cannot stat '/tmp/hosts.bak': No such file or directory
+  /tmp/qa-rfc028-witness-deepseek-fixed.log:317 ✗ F.deepseek /etc/hosts restore/cleanup failed — abort before later assertions run on polluted DNS state
+Notes:
+  G and M did not start after the restore failure.
+
+Final full-suite run:
+Command:
+  sg docker -c 'docker build -t anet-qa-rfc028-provider-probe:final -f tests/qa-rfc028-provider-probe/Dockerfile . && docker run --rm anet-qa-rfc028-provider-probe:final'
+Result:
+  exit 0
+Summary:
+  RFC-028 P1 e2e — PASS=51 FAIL=0 SKIP=0
+Key restore assertions:
+  /tmp/qa-rfc028-final.log:310 ✓ F /etc/hosts restored after anthropic variant
+  /tmp/qa-rfc028-final.log:316 ✓ F.deepseek /etc/hosts restored
+
+--- Addendum (通信龙, backstop commit) -------------------------------
+本 PR 由 通信龙 代为提交：原作者 通信测试牛 的会话在开 PR 前
+codex-sdk 调用超时（300s）中断，改动与证据已完成但滞留在共享检出里未提交。
+
+代提时相对原始工作副本做了一处收窄：原工作副本的基线较旧，其 diff 会连带
+**删除** main 上 :158 的一行注释
+（"本套件绕过 `anet daemon`… 见 #1299"）。该删除不在批准范围内，已剔除。
+本 PR 对 run.sh 的改动经 diff 核对为**恰好 2 行**（两处 restore），注释保留。

--- a/tests/qa-rfc028-provider-probe/run.sh
+++ b/tests/qa-rfc028-provider-probe/run.sh
@@ -314,7 +314,7 @@ else
 fi
 
 # Restore /etc/hosts before staging the DeepSeek DNS-attack variant
-cp /tmp/hosts.bak /etc/hosts && ok "F /etc/hosts restored after anthropic variant"
+cp /tmp/hosts.bak /etc/hosts && ok "F /etc/hosts restored after anthropic variant" || { bad "F /etc/hosts restore failed after anthropic variant — abort before DeepSeek variant runs on polluted DNS state"; exit 1; }
 
 # ── Scenario F.deepseek — verify IP-block fires for newly-allowlisted host ──
 # RFC-028 SSRF allowlist extension (PR following N站马 e2e): anthropic
@@ -350,7 +350,7 @@ else
 fi
 
 # Restore /etc/hosts + cleanup F daemon
-cp /tmp/hosts.bak /etc/hosts && rm -f /tmp/hosts.bak && ok "F.deepseek /etc/hosts restored"
+cp /tmp/hosts.bak /etc/hosts && rm -f /tmp/hosts.bak && ok "F.deepseek /etc/hosts restored" || { bad "F.deepseek /etc/hosts restore/cleanup failed — abort before later assertions run on polluted DNS state"; exit 1; }
 kill "$F_DAEMON_PID" 2>/dev/null || true
 
 # ── Scenario G — secret-no-leak (zod .strict() via JSON-parsed error code) ──


### PR DESCRIPTION
Closes #1537（**部分** —— 只关这一项，见下）

## 改了什么

`tests/qa-rfc028-provider-probe/run.sh` 两处 `/etc/hosts` restore，原先是：

```bash
cp /tmp/hosts.bak /etc/hosts && ok "F /etc/hosts restored after anthropic variant"
```

`cp` 失败时**既不判红也不停下**，后续断言继续在被污染的 DNS 状态上跑 —— 产出的红和绿都不可读。改为失败时 `bad` 并 `exit 1`。

**对 `run.sh` 的改动经 diff 核对为恰好 2 行。**

## 见证红（原作者 通信测试牛 在 Docker 内两向见证）

红**落在 restore 行本身**，不是下游症状：

```
:313  cp: cannot stat '/tmp/hosts.bak': No such file or directory
:314  ✗ F /etc/hosts restore failed after anthropic variant — abort before DeepSeek variant runs on polluted DNS state
```

第二处（`F.deepseek`）同形状。正向整套：`RFC-028 P1 e2e — PASS=51 FAIL=0 SKIP=0`，exit 0。

## 🔴 本 PR **不修** #1541

这句必须写清楚，否则读的人会以为 `/etc/hosts` 的事已经解决了：

- #1541 的病灶是**备份点（`:290` `cp /etc/hosts /tmp/hosts.bak`）晚于初始 pin（`:69/:70`）**，且全脚本 **`trap` 计数为 0**；
- 也就是说**恢复的目标状态本身就含那条 pin** ⇒ 一次 exit 0 的成功运行也会留下 `127.0.0.1 api.anthropic.com canary.internal`；
- 通信测试马 已在容器内实测到该**稳定态残留恰好一行**（`169.254.169.254` 的两条已被恢复掉）；
- **补 `|| bad` 修不掉它。** #1541 单独修（修法是把备份点提到第一次修改之前 + `trap … EXIT`）。

严重性：该套件正规入口是 Dockerfile、`run.sh` 在容器内跑、销毁即消失，**只有直接在宿主 `bash run.sh` 才会留下** ⇒ footgun，不是 P0。

## 代提说明

原作者 通信测试牛 的会话在开 PR 前 **codex-sdk 调用超时（300s）**中断，改动与证据已完成但滞留在共享检出里未提交，由我代为提交（`Co-authored-by` 已标注）。

**代提时做了一处收窄**：原工作副本的基线较旧，直接从它出 PR 会**连带删除** main 上 `:158` 的一行注释（"本套件绕过 `anet daemon`（用 `anet node start`），CLI 的自动声明到不了这里 —— 见 #1299"）。该删除不在批准范围内，已剔除；注释保留（`grep -c` 验证 = 1）。

## 关于 #1537 的数字更正

#1537 原正文里「120/253」这个数是错的，**真值 7**（物理行 grep 漏掉了反斜杠续行上的 `|| bad`），三个 CI 套件真实是 0/1/0。通信测试马 已在 issue 上发更正。本 PR 正文不引用那个错数。
