### PR TITLE
fix(daemon): anet_bin_source 无 pin 那一支要给出不需要 root 的修法 (#1353)

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -274,6 +274,34 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(cmd).not.toContain('node -e "console.log');
   });
 
+  // #1353 续 —— `no ANET_BIN_ABS resolved` 这一支（既没有 path.conf、也没有环境变量）
+  // 是实际最常撞到的一支：DEV 上一台已连续在线 15h 的 daemon 就正处在这个状态。
+  // 它原先**只给出那条要 root 的 path.conf 命令**，而代码里其实还有一条不需要任何
+  // 权限的路：`prepareDaemonAnetBin()`（agent-network/bin/cli.ts:8284）会设置
+  // ANET_BIN_ABS + ANET_DAEMON_ALLOW_ENV_BIN，并由 cli.ts:6336 透传进子进程 env；
+  // 而它**只在 `anet daemon init|start|up` 三条命令上被调用**（cli.ts:8346-8348）。
+  // ⇒ 用 `anet node start` / pm2 / systemd 起的 daemon 永远拿不到 pin，
+  //   而重新用 `anet daemon start` 起一次就可能修好，不需要 root。
+  //
+  // 只给一条需要 root 的修法，会把人推去在生产机上求 sudo —— 而更省的那条就在代码里。
+  test("anet_bin_source (no pin at all) 必须同时给出不需要 root 的那条路 (#1353)", () => {
+    let msg = "";
+    try {
+      loadAndVerifyAnetBin({ ANET_DAEMON_PATH_CONF: "/nonexistent" }, "linux");
+      throw new Error("expected loadAndVerifyAnetBin to throw");
+    } catch (e: any) { msg = String(e?.message ?? ""); }
+
+    // 走的确实是「什么 pin 都没有」那一支，不是 env-fallback-disabled 那支
+    expect(msg).toContain("no ANET_BIN_ABS resolved");
+
+    // 需要 root 的那条仍然在（不是替换，是补充）
+    expect(msg).toContain("sudo install -d -m 0755 /etc/anet-daemon");
+    // 不需要 root 的那条必须点名具体命令，且说清为什么它可能有效
+    expect(msg).toContain("anet daemon start");
+    expect(msg).toMatch(/anet daemon init\|start\|up/);
+    expect(msg).toContain("pm2");
+  });
+
   test("REJECT: ANET_BIN_ABS env fallback without explicit opt-in", () => {
     cleanup();
     const p = setup("env-fallback-disabled");

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -253,7 +253,7 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
         //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
         //   可能解析到另一个（或找不到）二进制。
         //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
-        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null (needs root). No-root alternative to try first: only `anet daemon init|start|up` auto-declares the pin, so a daemon started via `anet node start` / pm2 / systemd never receives it — restart it with `anet daemon start <name>`.",
     );
   }
   // ① absolute — cross-platform. Was `startsWith("/")` which returned


### PR DESCRIPTION
Refs #1353, #1545

## 问题：唯一给出的修法要 root，而代码里还有一条不需要权限的路

`anet_bin_source` 有两支。**「什么 pin 都没有」那一支**（既没有 `/etc/anet-daemon/path.conf`、
也没有 `ANET_BIN_ABS`）是实际最常撞到的，它原先只给出这一条：

```
Fix: … && sudo install -d -m 0755 /etc/anet-daemon && … | sudo tee /etc/anet-daemon/path.conf
```

**要 root。** 而代码里另有一条不需要任何权限的路，用户从这条消息里看不到：

```
agent-network/bin/cli.ts:8284  prepareDaemonAnetBin()
                                 process.env.ANET_BIN_ABS = anetBin
                                 process.env.ANET_DAEMON_ALLOW_ENV_BIN = "1"
agent-network/bin/cli.ts:6336  spawn 时把它们透传进 childEnv
agent-network/bin/cli.ts:8346-8348
                               case "init" / "start" / "up": prepareDaemonAnetBin(); …
```

⇒ **只有 `anet daemon init|start|up` 会自动声明 pin。** 用 `anet node start` / pm2 / systemd
起的 daemon **永远拿不到**，重新用 `anet daemon start` 起一次就可能修好，**不需要 root**。

## 活样本

DEV 上一台 daemon **已连续在线 15h28m**：注册、心跳、hub 返回 `ok:true` 全部正常，
`/etc/anet-daemon/` 不存在、进程 environ 里也没有 `ANET_BIN_ABS` —— 它现在就处在这一支，
而**只有真去建节点时才会失败**。

## 措辞上的克制

写的是 **"No-root alternative to try first"**，不是"这样就能修好"：
`prepareDaemonAnetBin()` 自身也可能 `exit 1`（binary group/other 可写、不可执行、
或不是 anet 包的 bin）。**给一条可能有效且成本低得多的路，同时不承诺它一定成功。**

## 范围

- **只改「什么 pin 都没有」那一支**；`env-fallback-disabled` 那一支**逐字未动**
  （已实跑验证：该分支消息里 `No-root` 文本不存在）。
- 需要 root 的那条命令**保留**，不是替换 —— 生产信任根仍然是 `path.conf`。

## 见证红

```
还原源码改动、只留新测：  66 pass / 1 fail    ← 红落在新断言上
改回：                    67 pass / 0 fail / 157 expect()
```

新测同时钉住三件事：走的确实是 `no ANET_BIN_ABS resolved` 那一支、要 root 的那条仍在、
不需要 root 的那条点名了具体命令和原因（`pm2` / `anet daemon init|start|up`）。

## 与 #1545 的关系

#1545 是**结构性**修法（daemon 自己算 readiness 并上报，CLI 展示三态）——
那条正在由 通信SDK马 按四段 PR 推进。**本 PR 不是它的替代**，只是把一条已经存在于代码里、
却没告诉用户的省事路径补进错误文案里，**今天就能减少一次不必要的 sudo**。
