### PR TITLE
docs(daemon): 补「已在跑但没配对」的恢复路径 —— 先试不需要 root 的那条 (#1353)

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -199,6 +199,20 @@ anet daemon up
 `[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`,
 且新节点自己注册回 hub。**看不到这两行就是没配对**——它不会重试。
 
+**已经在跑的 daemon 没配对怎么办 —— 先试不需要 root 的那条。**
+只有 `anet daemon init` / `start` / `up` 会自动声明 pin（它们内部调用
+`prepareDaemonAnetBin()`）。用 `anet node start`、pm2、systemd 或手工拼命令起的
+daemon **永远拿不到**，而它照样注册、在线、心跳正常 —— 失败只在建节点那一刻出现。
+
+```bash
+anet node stop <name> && anet daemon start <name>    # 不需要 root
+```
+
+这条不保证成功（binary 若 group/other 可写、不可执行，或不是 anet 包的 bin，
+`anet daemon start` 会自己拒绝并告诉你原因），但它成本低得多，**值得在动 sudo 之前先试**。
+仍然不行再写 `/etc/anet-daemon/path.conf`（生产信任根，见上表）。
+
+
 ### 4. 确认它**进程**起来了
 
 ```bash

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -212,6 +212,22 @@ directly; do not work around it by editing untracked server startup files.
 node must register itself back to the hub. **Without those two lines it is not wired up** —
 it will not retry.
 
+**An already-running daemon that is not wired up — try the no-root path first.**
+Only `anet daemon init` / `start` / `up` auto-declare the pin (they call
+`prepareDaemonAnetBin()` internally). A daemon started via `anet node start`, pm2,
+systemd, or a hand-assembled command **never receives it** — yet it still registers,
+stays online, and heartbeats normally. The failure only surfaces when you create a node.
+
+```bash
+anet node stop <name> && anet daemon start <name>    # no root required
+```
+
+This is not guaranteed to work (`anet daemon start` refuses, and tells you why, if the
+binary is group/other-writable, not executable, or not an anet package bin), but it costs
+far less — **try it before reaching for sudo**. If it still fails, write
+`/etc/anet-daemon/path.conf` (the production trust root, see the table above).
+
+
 ### 4. Confirm the **process** came up
 
 ```bash


### PR DESCRIPTION
配合 #1546（同一缺陷的报错文案侧）。

§3.6 原先只讲**搭建时**怎么配 pin，没讲**已经在跑的 daemon 没配对时怎么办** —— 而后者才是实际最常撞到的情形。

**活样本**：DEV 上一台 daemon 在线 **15h28m**，注册、心跳、hub 返回 `ok:true` 全正常，`/etc/anet-daemon/` 不存在、environ 里也没有 `ANET_BIN_ABS` ⇒ 只有真去建节点时才失败。

补的恢复路径：

```bash
anet node stop <name> && anet daemon start <name>    # 不需要 root
```

依据（对着 origin/main 查的，不是推的）：只有 `anet daemon init|start|up` 三条命令调 `prepareDaemonAnetBin()`（`cli.ts:8346-8348`），它设置 `ANET_BIN_ABS` + `ANET_DAEMON_ALLOW_ENV_BIN`（`cli.ts:8315-8320`），再由 `cli.ts:6336` 透传进子进程 env。**用 `anet node start`/pm2/systemd 起的永远拿不到。**

**措辞上明确没有过度承诺**：写了它**不保证成功** —— binary group/other 可写、不可执行、或不是 anet 包的 bin 时 `anet daemon start` 会自己拒绝并说明原因（`prepareDaemonAnetBin` 里 8 处 `console.error`）。仍不行再写 `path.conf`。

**核过的事**：文中每条命令都存在（`anet node stop`；`anet daemon start` 要求节点已存在且 `role=host_supervisor`，否则报错并给出 init 提示）。zh + en 同步。`doc-symbol-anchors` rc=0、`home-path-baseline` rc=0、`vitepress build` rc=0（死链致命，已过）。