### PR TITLE
fix(agent-node): 去掉重复的 grokVersion 键 (#1536 的第一个实例)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4097,9 +4097,6 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       // 1.0.5 移除了 --no-memory / --no-auto-update 且硬拒未知 flag，
       // argv 必须按观测到的 build 决定。
       grokVersion: version,
-      // 1.0.5 移除了 --no-memory / --no-auto-update 且硬拒未知 flag，
-      // argv 必须按观测到的 build 决定。
-      grokVersion: version,
       env,
       sessionId: grokSessionId || undefined,
       newSession: NEW_SESSION,


### PR DESCRIPTION
Refs #1536

`grokVersion: version,` 连同上面两行注释在 `agent-node/src/cli.ts:3986-3990` **逐字写了两遍**。两次赋同一个值 ⇒ **运行时行为不变**；但这正是 TS1117，是类型检查存在的意义所在 —— 而 agent-node **至今没有 tsconfig**，所以没有任何东西会告诉作者。

## 同树单变量对照

同一个 clean `origin/main` 工作树，**只换 `cli.ts` 一个文件**：

| | errors | TS1117 |
|---|---|---|
| baseline | 69 | 1 |
| after | **68** | **0** |

恰好 −1，且减掉的就是被修的那一条。

## 🔴 我在度量这件事上错了两次，写在这里避免下一个人重蹈

| 我报过的数 | 错在哪 |
|---|---|
| **808** | 自造的 tsc 调用**没带 `@types/node`** —— TS2580/TS2307/TS2503 占 632 条，量的是**我的配置**，不是代码 |
| **52** | 带上 types 了，但跑在**带未提交改动的特性分支检出**上，和干净 `origin/main` **不是同一棵树**，不能做 before/after |
| **69** | ✅ 干净 origin/main + `@types/node`，这是真基线 |

两次都朝**同一个方向**错：第一次把配置问题算成代码问题（虚高），第二次把两棵不同的树当成一棵（对照无效）。**跑门之前先证明你扫的是哪个 ref**，这条今天我已经踩到第三次了。