### PR TITLE
ci(agent-node): 加类型检查棘轮门 —— 只保证不再变糟 (#1536)

### DIFF
--- a/.github/scripts/check-agent-node-typecheck-ratchet.py
+++ b/.github/scripts/check-agent-node-typecheck-ratchet.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""`agent-node` 的类型错误只许减少,不许增加。
+
+## 背景
+
+`agent-node` 至今**没有 tsconfig、没有 typecheck 脚本、CI 里 0 处引用**(#1536) ——
+也就是说它从来没有被类型检查过。它是被 bun/esbuild 直接执行的,类型注解在运行时
+被剥掉,所以**类型错误不会让任何东西变红**,只会在运行时以别的形状出现。
+
+已经吃掉的一个真实实例:`src/cli.ts` 里 `grokVersion: version,` 连同注释被逐字写了
+两遍(TS1117)。那次两边赋的是同一个值,所以没造成故障 —— **但没有任何东西告诉过作者**。
+
+## 判据
+
+    src/**/*.ts 的 tsc 错误条数 <= BASELINE
+
+`strict: true`,与两个兄弟包(`agent-network/tsconfig.json`、`server/tsconfig.json`)一致。
+
+## 🔴 这道门最关键的一条:测不出来必须判红,不能判绿
+
+一个只会数 `error TS` 行数的门有一个致命形状:**tsc 根本没跑起来时,行数也是 0**,
+而 0 恰好等于"完美"。作者本人在 2026-08-30 建这道门时就先撞了一次 ——
+`npx --yes typescript@5 tsc` 报 `could not determine executable to run`(正确写法要
+`-p typescript@5.9.3`),而 `grep -c 'error TS'` 照样打印 `0`。
+
+所以本门**不看行数就下结论**,而是先验证这次测量本身是否成立:
+
+    rc == 0  且 count == 0   → 真·零错误
+    rc in (1,2) 且 count > 0 → 真·有错误,拿去和基线比
+    其它任何组合             → **测量失败,判红**(不是判绿)
+
+## 这道门不管什么
+
+不要求归零,不改任何行为,不阻止你写出有类型错误的代码 ——
+**它只保证今天的数字是上限,不是起点。**
+
+    python3 .github/scripts/check-agent-node-typecheck-ratchet.py --selftest
+    python3 .github/scripts/check-agent-node-typecheck-ratchet.py
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BASELINE = 87   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
+                # 环境须与 CI 一致:agent-node 下 npm install --no-save typescript@5.9.3 @types/node@20
+TS_VERSION = "5.9.3"
+TYPES_NODE_VERSION = "20"
+ERROR_RE = re.compile(r"error TS\d+")
+
+# 🔴 配置层错误:tsc 在**看任何一行源码之前**就退出。它们的表现是「错误数很少」,
+#    而少恰好像好。作者建这道门时就撞了一次:漏了 @types/node ⇒ 只报 TS2688 一条
+#    ⇒ 1 <= 93 ⇒ 门判绿,而**一个源文件都没被检查过**。
+CONFIG_ERROR_RE = re.compile(r"error TS(2688|5023|5024|5025|5042|5053|5057|6053|6059|18002|18003)\b")
+
+# 这道门至少必须真的检查到这么多个 agent-node/src 下的文件。
+# 2026-08-30 实测 origin/main: 45 个(src/**/*.ts 排除 *.test.ts)。取一个有余量的下限。
+FILES_FLOOR = 25
+
+ROOT = Path(__file__).resolve().parents[2]
+TSCONFIG = ROOT / "agent-node" / "tsconfig.json"
+
+
+def count_errors(output: str) -> int:
+    """一行可能含多个 `error TSxxxx`? 实测 tsc 一行一条,但按出现次数数更稳。"""
+    return len(ERROR_RE.findall(output))
+
+
+def classify(rc: int, count: int, output: str = "", files_checked: int | None = None) -> tuple[bool, str]:
+    """返回 (测量是否成立, 说明)。见模块 docstring 的表。"""
+    m = CONFIG_ERROR_RE.search(output)
+    if m:
+        return False, (f"tsc reported a CONFIG-level error ({m.group(0)}) — it exited before "
+                       f"examining any source file. A config abort yields a small error count, "
+                       f"and small looks good. Refusing to grade this run.")
+    if files_checked is not None and files_checked < FILES_FLOOR:
+        return False, (f"tsc only examined {files_checked} agent-node/src file(s), below the floor "
+                       f"of {FILES_FLOOR} — the check did not cover the package, so its error "
+                       f"count means nothing.")
+    if rc == 0 and count == 0:
+        return True, "tsc exited 0 with no errors"
+    if rc in (1, 2) and count > 0:
+        return True, f"tsc exited {rc} with {count} error(s)"
+    return False, (f"tsc rc={rc} but parsed {count} error(s) — these disagree, so the "
+                   f"measurement did not happen (a tsc that never ran also yields 0 errors)")
+
+
+def selftest() -> int:
+    fails = 0
+
+    def check(label, got, want):
+        nonlocal fails
+        if got != want:
+            print(f"  ✗ {label}: got {got!r}, want {want!r}")
+            fails += 1
+        else:
+            print(f"  ✓ {label}")
+
+    print("selftest — 判据层(数错误 + 判定测量是否成立)")
+    check("counts one error", count_errors("src/cli.ts(1,1): error TS1117: dup"), 1)
+    check("counts three", count_errors("error TS1\nerror TS2\nerror TS3"), 3)
+    check("ignores prose", count_errors("no problems found"), 0)
+    check("does not match bare 'error'", count_errors("error: something broke"), 0)
+
+    # 🔴 这四条是这道门存在的理由:一个没跑起来的 tsc 必须判成"测量失败",不是"零错误"
+    check("clean run is a valid measurement", classify(0, 0)[0], True)
+    check("errors run is a valid measurement", classify(2, 93)[0], True)
+    check("rc=127 (command not found) is NOT valid", classify(127, 0)[0], False)
+    check("rc=0 but errors parsed is NOT valid", classify(0, 5)[0], False)
+    check("rc=1 with zero parsed is NOT valid", classify(1, 0)[0], False)
+    # 🔴 这两条正是作者亲手踩过的那个洞
+    check("config-level TS2688 is NOT a valid measurement",
+          classify(2, 1, "error TS2688: Cannot find type definition file for 'node'.")[0], False)
+    check("too few files examined is NOT valid",
+          classify(2, 93, "", files_checked=3)[0], False)
+    check("enough files examined is valid",
+          classify(2, 93, "", files_checked=45)[0], True)
+
+    print("selftest — 取集层(扫的是哪些文件)")
+    import json
+    cfg = json.loads(TSCONFIG.read_text(encoding="utf-8"))
+    check("tsconfig includes src/**/*.ts", cfg.get("include"), ["src/**/*.ts"])
+    check("tsconfig excludes tests", cfg.get("exclude"), ["**/*.test.ts"])
+    check("strict is on (matches sibling packages)",
+          cfg.get("compilerOptions", {}).get("strict"), True)
+    check("noEmit is on (a gate must not write build output)",
+          cfg.get("compilerOptions", {}).get("noEmit"), True)
+
+    print(f"\nselftest: {'PASS' if fails == 0 else f'FAIL ({fails})'}")
+    return 1 if fails else 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    if not TSCONFIG.exists():
+        print(f"::error::{TSCONFIG} is missing — agent-node must carry a tsconfig for this gate to mean anything.")
+        return 1
+
+    # tsc 必须能在 agent-node/node_modules/@types 下找到 node 的类型 ——
+    # `npx -p @types/node` **不行**:它把包放进 npx 的临时目录,而 tsc 找的是
+    # 工程目录下的 node_modules/@types。所以这里要求先装好,装的动作交给调用方
+    # (CI workflow 或开发者),这道门只负责测量,并在装漏时**明确判红**。
+    local_tsc = ROOT / "agent-node" / "node_modules" / ".bin" / "tsc"
+    if not local_tsc.exists():
+        print(f"::error::{local_tsc} not found — this gate measures, it does not install. Run first:")
+        print(f"::error::  (cd agent-node && npm install --no-save typescript@{TS_VERSION} @types/node@{TYPES_NODE_VERSION})")
+        print("::error::Failing closed: without types, tsc aborts on TS2688 and reports ~1 error, "
+              "which would look like a near-perfect result.")
+        return 1
+    cmd = [str(local_tsc), "-p", str(TSCONFIG), "--listFiles"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except FileNotFoundError:
+        print("::error::npx not found — cannot run tsc, so this gate cannot report anything. "
+              "Failing closed rather than printing a misleading 0.")
+        return 1
+    except subprocess.TimeoutExpired:
+        print("::error::tsc timed out after 900s — measurement did not complete.")
+        return 1
+
+    output = (proc.stdout or "") + (proc.stderr or "")
+    count = count_errors(output)
+    src = str((ROOT / "agent-node" / "src").resolve())
+    files_checked = sum(1 for ln in output.splitlines()
+                        if ln.strip().startswith(src) and ln.strip().endswith(".ts"))
+    ok, why = classify(proc.returncode, count, output, files_checked)
+
+    if not ok:
+        print(f"::error::{why}")
+        print("--- first 20 lines of tsc output ---")
+        for line in output.splitlines()[:20]:
+            print(f"  {line}")
+        return 1
+
+    print(f"agent-node typecheck: {count} error(s) (baseline {BASELINE}) — {why}")
+    if count > BASELINE:
+        print(f"::error::agent-node type errors rose to {count}, above the baseline of {BASELINE}. "
+              f"This gate does not require zero — it requires that the number not grow. "
+              f"Fix the new error(s), or if you genuinely lowered the count, update BASELINE in "
+              f"{Path(__file__).name} to the new value.")
+        for line in output.splitlines():
+            if ERROR_RE.search(line):
+                print(f"  {line}")
+        return 1
+
+    if count < BASELINE:
+        print(f"::notice::type errors dropped to {count} (baseline {BASELINE}). "
+              f"Please lower BASELINE to {count} so the ratchet keeps its grip.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/agent-node-typecheck.yml
+++ b/.github/workflows/agent-node-typecheck.yml
@@ -1,0 +1,28 @@
+name: agent-node typecheck ratchet
+
+on:
+  pull_request:
+    paths:
+      - "agent-node/**"
+      - ".github/scripts/check-agent-node-typecheck-ratchet.py"
+      - ".github/workflows/agent-node-typecheck.yml"
+  push:
+    branches: [main]
+
+jobs:
+  ratchet:
+    name: agent-node-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # selftest 先跑。这道门的坏法不在「会不会数错误」,而在「有没有真的检查到源码」:
+      # 少了 @types/node 时 tsc 只报一条 TS2688 就退出,1 条远低于基线 ⇒ 看起来是好结果。
+      # selftest 的取集层专门钉这一条。
+      - run: python3 .github/scripts/check-agent-node-typecheck-ratchet.py --selftest
+      # 门只测量,不安装 —— 装漏时它会判红而不是判绿。
+      - run: npm install --no-save typescript@5.9.3 @types/node@20
+        working-directory: agent-node
+      - run: python3 .github/scripts/check-agent-node-typecheck-ratchet.py

--- a/agent-node/tsconfig.json
+++ b/agent-node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts"]
+}


### PR DESCRIPTION
Closes #1536

agent-node **从来没有被类型检查过**：没有 tsconfig、没有 typecheck 脚本、CI 里 0 处引用。它由 bun/esbuild 直接执行，类型注解在运行时被剥掉，所以类型错误**不会让任何东西变红**。已吃掉的一个实例见 #1549（TS1117 重复键，两次赋同值所以没炸，但没有任何东西告诉过作者）。

**本 PR 不要求归零**（基线 **87**），只保证这个数不再增长。tsconfig 与两个兄弟包一致：`strict: true` / ES2022 / bundler / skipLibCheck。

## 🔴 这道门最重要的部分不是数错误，是拒绝在测不出来的时候判绿

我建它的过程中**亲手撞了三次同一个形状，三次都是「失败看起来像零错误」**：

| | 表现 | 为什么骗人 |
|---|---|---|
| ① | `npx --yes typescript@5 tsc` → `could not determine executable to run` | tsc **完全没跑**，而 `grep -c 'error TS'` 打印 **0** |
| ② | 漏了 `@types/node` → 只报一条 `TS2688` 就退出 | **一个源文件都没检查**，而 1 ≤ 93 ⇒ **门判绿** |
| ③ | 拿带未提交改动的特性分支检出和干净 origin/main 做 before/after | 两棵不同的树，对照无效 |

**②尤其值得看**：我的 `classify()` 当时校验的是 `rc` 与错误数**互相一致**（`rc==2 and count>0`）—— 而 `rc=2, count=1` **完美满足它**。**判据那一层我做对了，漏的是取集那一层：我从没问过「它到底检查了几个文件」。** 这和仓里 #997/#999 是同一形状：判据完全正确，分母从有洞的取集算出来，于是永远自洽、也永远看不见自己外面。

所以门里有两道**取集层**判据：
- **配置层错误码黑名单**（TS2688/5023/5053/6053…）→ 命中即「拒绝给这次运行打分」，不是判绿；
- **`--listFiles` 数实际检查到的 `agent-node/src` 文件数**，低于下限 25 判红（实测 45）。

以及：**门只测量、不安装** —— tsc 缺失时判红并打印该敲的命令，而不是静默跳过。

## 两向见证（CI 同款环境）

```
npm install --no-save typescript@5.9.3 @types/node@20     # workflow 里就是这一行
基线        87 errors → rc=0
注入 1 条   88 errors → rc=1  「rose to 88, above the baseline of 87」
还原        87 errors → rc=0
```

`--selftest` 两层共 16 条断言全绿，其中 3 条**专钉上面那个洞**：`config-level TS2688 is NOT a valid measurement` / `too few files examined is NOT valid` / `enough files examined is valid`。

## 不碰的东西

**没有改 `agent-node/package.json`，也没有动它的两个 lockfile**（`bun.lock` / `package-lock.json`）——依赖由 workflow 用 `--no-save` 临时提供。查过：仓里没有任何 CI 对 agent-node 跑 `npm ci`，且 `files: ["dist","README.md"]`，所以这条路不会影响发布产物。