### PR TITLE
docs(mcp): send_desktop_message 补参数与示例，并写明收件人是用户身份不是节点 alias

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -32,6 +32,31 @@ CommHub Server 注册 **50 个** MCP Tools，全部经 `POST /mcp`（Streamable 
 |------|------|
 | `send_desktop_message` | 向桌面用户 inbox 写一条可推送消息 |
 
+::: tip send_desktop_message —— 收件人是**用户身份**，不是节点 alias
+这是本工具唯一容易搞错的地方，也是它和 `send_task` 的根本区别：
+
+- `send_task(alias=…)` 发给一个**会话/节点**（名册里能查到的那种）；
+- `send_desktop_message(to_user_id=… | to_username=…)` 发给一个**登录用户**，
+  推到他当前活跃的桌面端 / Web 客户端。
+
+**一个登录用户不一定有对应的会话 alias。** 拿 alias 去当收件人，或者反过来，
+都会发给错误的对象 —— 而两种情况**接口都会返回成功**，因为参数在各自的语义下都是合法的。
+
+```jsonc
+// 最小可用调用：二选一给 to_user_id 或 to_username
+{
+  "to_username": "alice",          // 或 "to_user_id": "u_9f2c1b7ae4d0"
+  "title": "构建完成",              // 可选，≤200
+  "message": "v0.9.0-preview.43 已发布到 npm。",   // 必填，1–10000
+  "severity": "success",           // info | success | warning | error，默认 info
+  "kind": "agent_message"          // 默认 agent_message，用于客户端分类
+}
+```
+
+`to_user_id` 和 `to_username` **至少给一个**；两个都给时会做一致性校验，对不上会被拒。
+`network_id` 通常不用传（单网络的 user token 会自动解析；`ntok` 恒定绑在它自己的网络上）。
+:::
+
 **SkillHub** · 4 个
 
 | 工具 | 说明 |

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -32,6 +32,34 @@ CommHub Server registers **50** MCP Tools, all called through `POST /mcp` (Strea
 |------|------|
 | `send_desktop_message` | Write a pushable message into a desktop user's inbox |
 
+::: tip send_desktop_message — the recipient is a **user identity**, not a node alias
+This is the one thing that is easy to get wrong, and it is the fundamental difference
+from `send_task`:
+
+- `send_task(alias=…)` goes to a **session/node** (something you can look up in the roster);
+- `send_desktop_message(to_user_id=… | to_username=…)` goes to a **logged-in user**, and is
+  pushed to their currently active Desktop / web clients.
+
+**A logged-in user does not necessarily have a corresponding session alias.** Passing an alias
+as the recipient — or the reverse — delivers to the wrong party, and **both calls return
+success**, because each argument is valid under its own meaning.
+
+```jsonc
+// Minimal call: supply either to_user_id or to_username
+{
+  "to_username": "alice",          // or "to_user_id": "u_9f2c1b7ae4d0"
+  "title": "Build finished",       // optional, <=200
+  "message": "v0.9.0-preview.43 is published to npm.",   // required, 1-10000
+  "severity": "success",           // info | success | warning | error, default info
+  "kind": "agent_message"          // default agent_message; clients use it to categorise
+}
+```
+
+Supply **at least one** of `to_user_id` / `to_username`; if both are given they are checked
+against each other and a mismatch is rejected. You normally do not pass `network_id`
+(single-network user tokens auto-resolve; an `ntok` stays bound to its own network).
+:::
+
 **SkillHub** · 4
 
 | Tool | What it does |


### PR DESCRIPTION
对着 /goal 的「agent 主动给 dashboard/客户端登录用户发消息」这一条。

## 先说一个查证结果：这条 goal 的**接口和测试已经落地了**

- 工具存在：`send_desktop_message`（`server/src/tools.ts:2308`），描述里已写明 *Targets user identity, not node alias*；
- 有测试：`server/src/desktop-message.test.ts`，21 处引用。

**缺的只是文档可用性。** 它在 `mcp-tools.md` 里此前**只有一行表格**：

```
| `send_desktop_message` | 向桌面用户 inbox 写一条可推送消息 |
```

没有参数、没有示例，也没提它和 `send_task` 的区别。

## 补的核心：一条错了**不会报错**的语义

```
send_task(alias=…)                              → 发给一个会话/节点
send_desktop_message(to_user_id|to_username=…)  → 发给一个登录用户
```

🔴 **一个登录用户不一定有对应的会话 alias。** 拿 alias 当收件人、或者反过来，都会发给**错误的对象**，而**两种情况接口都返回成功** —— 因为参数在各自的语义下都合法。这类「成功地做错事」**只能靠文档挡**，代码层面两边都是有效输入。

（这不是假想的失败模式：本项目自己的协作约定里就专门记着「某些登录用户没有对应的会话 alias，发错收件人会连续多轮无人收到」。）

## 参数逐条对着 schema 写，未臆造

全部来自 `server/src/tools.ts:2308-2319` 的 zod 定义：`title` ≤200 可选 / `message` 1–10000 必填 / `severity` 四值默认 `info` / `kind` 默认 `agent_message` / `to_user_id` 与 `to_username` 至少给一个、都给时做一致性校验 / `network_id` 通常不必传。

zh + en 同步。**`vitepress build` rc=0**（死链致命）、**`doc-symbol-anchors` rc=0**。