### PR TITLE
chore(gate): agent-node 类型检查基线 87 → 86（棘轮自己要求的）

### DIFF
--- a/.github/scripts/check-agent-node-typecheck-ratchet.py
+++ b/.github/scripts/check-agent-node-typecheck-ratchet.py
@@ -45,7 +45,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASELINE = 87   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
+BASELINE = 86   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
                 # 环境须与 CI 一致:agent-node 下 npm install --no-save typescript@5.9.3 @types/node@20
 TS_VERSION = "5.9.3"
 TYPES_NODE_VERSION = "20"


### PR DESCRIPTION
#1550 的跟进。

#1549 去掉那条重复的 `grokVersion` 键之后，main 上实际是 **86** 条，而基线还写着 **87** —— **棘轮比现实松了 1**，也就是有人再引入一条新错误也不会被拦下。

这是门按设计工作：它在 `count < BASELINE` 时打印

```
::notice::type errors dropped to 86 (baseline 87). Please lower BASELINE to 86 so the ratchet keeps its grip.
```

本 PR 就是照做。

## 两向见证（干净工作树 + CI 同款环境）

```
npm install --no-save typescript@5.9.3 @types/node@20
基线 86      86 errors → rc=0
注入 1 条    87 errors → rc=1  「rose to 87, above the baseline of 86」
还原         86 errors → rc=0
--selftest   PASS
```

## 🔴 顺带记一次翻车，因为它正好证明这道门的硬化是承重的

我试着加 `@types/bun` 想消掉 4 条 `TS2868`，量出 **「86 → 0」**。

**那是假的**：`npm install --no-save @types/bun@latest` 把本地 typescript 二进制清掉了。三项判据都指向根本没跑——`tsc rc=127` / **检查到的文件数 0** / **注入一条故意的类型错误仍然是 0**。

拿这道门去跑那个坏环境，它明确拒绝并打印该敲的命令：

```
::error::…/node_modules/.bin/tsc not found — this gate measures, it does not install.
::error::Failing closed: without types, tsc aborts on TS2688 and reports ~1 error,
         which would look like a near-perfect result.
```

所以 **bun-types 这件事本 PR 不做** —— 要做得在一个能证明自己跑起来了的环境里重新评估。