### PR TITLE
feat(agent-node): #1545 PR1 把 anet_bin 判定变成可以被问出来的值(不抛异常的 readiness 探针)

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -4,6 +4,7 @@ import {
   buildAnetArgsDaemon,
   minimalEnv,
   loadAndVerifyAnetBin,
+  probeAnetBinReadiness,
   ensureGlobalAnetConfig,
   reconcilePendingCreateRequestsOnConnect,
   resolveChildHome,
@@ -991,5 +992,112 @@ describe("RFC-027 BLOCKER-1 — childrenMap key shape matches hub canonical node
     expect(snap[0].alias).toBe("alias-xyz");
     expect(snap[0].pid).toBe(12345);
     _resetChildrenMapForTest();
+  });
+});
+
+/* #1545 PR1 —— 探针必须**两向都被见证**:blocked 那侧本来就有 6 条 toThrow 在守,
+ * 真正没人守的是「ready 时它确实说 ready」。只验 blocked 一侧的话,一个恒返回
+ * blocked 的实现能全绿通过 —— 而那正是 #1545 里最坏的形态:一个永远说"不行"
+ * 的探针和一个永远沉默的 daemon,对用户是同一件事。 */
+describe("#1545 probeAnetBinReadiness —— 不抛异常地回答「现在能不能起节点」", () => {
+  const FIXTURE_DIR = "/tmp/anet-probe-test-fixtures";
+
+  function setup(name: string, body = "fake-binary-bytes"): string {
+    const binDir = join(FIXTURE_DIR, `${name}-pkg`, "dist", "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(FIXTURE_DIR, `${name}-pkg`, "package.json"), JSON.stringify({
+      name: "@sleep2agi/agent-network",
+      bin: { anet: "dist/bin/anet.cjs" },
+    }));
+    const p = join(binDir, "anet.cjs");
+    writeFileSync(p, body, { mode: 0o755 });
+    return p;
+  }
+  function cleanup() {
+    try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+
+  // ── 方向一:ready。这条是本 PR 唯一新增的**正向**见证。
+  test("READY: 合法 pin 下返回 state=ready 且带出解析到的绝对路径", () => {
+    cleanup();
+    const p = setup("ready");
+    const got = probeAnetBinReadiness({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    }, "linux");
+    expect(got.state).toBe("ready");
+    expect(got).toEqual({ state: "ready", abs: p });
+    cleanup();
+  });
+
+  // ── 方向二:blocked,且**类别要说对**。#1545 的痛点不是"有没有报错",
+  //    是报错指错方向(source 让人去建 /etc/…,permission 只要一行 chmod)。
+  test("BLOCKED: env 兜底未显式开启 → code=anet_bin_source,detail 里带得出修法", () => {
+    cleanup();
+    const p = setup("blocked-source");
+    const got = probeAnetBinReadiness({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    }, "linux");
+    expect(got.state).toBe("blocked");
+    if (got.state !== "blocked") throw new Error("unreachable");
+    expect(got.code).toBe("anet_bin_source");
+    expect(got.detail).toContain("ANET_DAEMON_ALLOW_ENV_BIN=1");
+    expect(got.detail).toContain("Fix:");
+    cleanup();
+  });
+
+  test("BLOCKED: 完全没有 ANET_BIN_ABS —— 探针照样返回值而不是抛", () => {
+    const got = probeAnetBinReadiness({ ANET_DAEMON_PATH_CONF: "/nonexistent" }, "linux");
+    expect(got.state).toBe("blocked");
+    if (got.state !== "blocked") throw new Error("unreachable");
+    expect(got.detail).toContain("anet_bin_unsafe_path");
+  });
+
+  /* 🔴 这条不是补齐分类,是**把一个真实的空白钉住**:sha256 不匹配那条抛的是裸
+   * Error、没挂 anetBinCode。所以它只能是 unclassified。哪天有人给它挂上类别,
+   * 这条会红 —— 那正是应该有人来读一眼的时刻(而不是让显示层默默替它选一类)。 */
+  test("BLOCKED: sha256 不匹配 → 目前无类别可挂,如实报 anet_bin_unclassified", () => {
+    cleanup();
+    const p = setup("hash-mismatch", "actual-bytes");
+    const got = probeAnetBinReadiness({
+      ANET_BIN_ABS: p,
+      ANET_BIN_SHA256: createHash("sha256").update("different-bytes").digest("hex"),
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    }, "linux");
+    expect(got.state).toBe("blocked");
+    if (got.state !== "blocked") throw new Error("unreachable");
+    expect(got.code).toBe("anet_bin_unclassified");
+    expect(got.detail).toContain("sha256 mismatch");
+    cleanup();
+  });
+
+  /* 🔴 判据只有一个作者 —— 这条直接断言这件事,而不是断言两边"看起来一致":
+   * 同一份 env 喂给两者,「探针说 blocked」必须**恰好**等于「解析器抛了」。
+   * 有了它,以后任何人想给探针加一条自己的判断,都会在这里撞红。 */
+  test("PARITY: probe 的 blocked ⟺ loadAndVerifyAnetBin 抛异常(同一份 env)", () => {
+    cleanup();
+    const ok = setup("parity-ok");
+    const cases: Array<NodeJS.ProcessEnv> = [
+      { ANET_BIN_ABS: ok, ANET_DAEMON_ALLOW_ENV_BIN: "1", ANET_DAEMON_PATH_CONF: "/nonexistent" },
+      { ANET_BIN_ABS: ok, ANET_DAEMON_PATH_CONF: "/nonexistent" },
+      { ANET_DAEMON_PATH_CONF: "/nonexistent" },
+      { ANET_BIN_ABS: "/definitely/not/here/anet.cjs", ANET_DAEMON_ALLOW_ENV_BIN: "1", ANET_DAEMON_PATH_CONF: "/nonexistent" },
+    ];
+    let readyCount = 0;
+    let blockedCount = 0;
+    for (const env of cases) {
+      let threw = false;
+      try { loadAndVerifyAnetBin(env, "linux"); } catch { threw = true; }
+      const probed = probeAnetBinReadiness(env, "linux");
+      expect(probed.state === "blocked").toBe(threw);
+      if (probed.state === "ready") readyCount += 1; else blockedCount += 1;
+    }
+    // 分母自证:这组用例**两侧都有**。全 blocked 的话上面那个等式恒成立、什么也没测。
+    expect(readyCount).toBe(1);
+    expect(blockedCount).toBe(3);
+    cleanup();
   });
 });

--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -1058,7 +1058,7 @@ describe("#1545 probeAnetBinReadiness —— 不抛异常地回答「现在能�
   /* 🔴 这条不是补齐分类,是**把一个真实的空白钉住**:sha256 不匹配那条抛的是裸
    * Error、没挂 anetBinCode。所以它只能是 unclassified。哪天有人给它挂上类别,
    * 这条会红 —— 那正是应该有人来读一眼的时刻(而不是让显示层默默替它选一类)。 */
-  test("BLOCKED: sha256 不匹配 → 目前无类别可挂,如实报 anet_bin_unclassified", () => {
+  test("BLOCKED: sha256 不匹配 → 目前无类别可挂,如实报 anet_bin_unknown", () => {
     cleanup();
     const p = setup("hash-mismatch", "actual-bytes");
     const got = probeAnetBinReadiness({
@@ -1069,7 +1069,7 @@ describe("#1545 probeAnetBinReadiness —— 不抛异常地回答「现在能�
     }, "linux");
     expect(got.state).toBe("blocked");
     if (got.state !== "blocked") throw new Error("unreachable");
-    expect(got.code).toBe("anet_bin_unclassified");
+    expect(got.code).toBe("anet_bin_unknown");
     expect(got.detail).toContain("sha256 mismatch");
     cleanup();
   });

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -909,3 +909,48 @@ export async function handleCreateNodeDoorbell(
     request_id, status: "started", child_pid: childPid,
   }).catch((e: any) => deps.warn(`[create-node] ack failed: ${e?.message || e}`));
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * #1545 PR1 —— 把「能不能起节点」变成一个**可以被问、且会回答**的值。
+ *
+ * 现状:上面那个解析器只有一种表达方式 —— 抛异常。守护进程启动时它抛,进程就退;
+ * 但**没有任何命令能在不引发那次退出的前提下问出同一个判断**,于是 daemon 显示
+ * 在线、`node create` 却必失败,而中间每一层都没有话说(#1545 的 B 路)。
+ *
+ * 🔴 这里**不重写解析逻辑,只把 throw 翻译成 return**。
+ *    理由:判据只能有一个作者。如果探针自己再判一遍,两份判据就会各自漂移 ——
+ *    到那时「探针说 ready、create 仍然失败」会比现在的沉默更难查,因为它看起来
+ *    像已经检查过了。(这是对 problem statement 里「抽出不抛异常的核心」的一处
+ *    收窄:包一层比拆开更小、且**逐字不变是构造性的**,不需要靠测试去证明。)
+ *
+ * 🔴 `code` 允许 `anet_bin_unclassified`,不是占位:`loadAndVerifyAnetBin` 里
+ *    **sha256 mismatch 那条抛的是裸 Error、没有挂 anetBinCode**。把它硬塞进上面
+ *    四类中的任何一类都是编的 —— 未归类就说未归类,别让显示层替它选一个方向。
+ *
+ * 🔴 这里**没有 unknown 态**。unknown 的含义是「daemon 根本没上报过这一格」,
+ *    那是传输/显示层的状态(PR2/PR4),探针跑到了就一定有答案。 */
+export type AnetBinReadiness =
+  | { readonly state: "ready"; readonly abs: string }
+  | {
+      readonly state: "blocked";
+      readonly code: AnetBinFailureCode | "anet_bin_unclassified";
+      /** 人读的整句,含解析器给出的 `Fix: …` 那半 —— 不另存一份副本,
+       *  否则修法会有两处、而只有一处会被改。 */
+      readonly detail: string;
+    };
+
+export function probeAnetBinReadiness(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): AnetBinReadiness {
+  try {
+    return { state: "ready", abs: loadAndVerifyAnetBin(env, platform) };
+  } catch (error) {
+    const code = (error as AnetBinError | null)?.anetBinCode;
+    return {
+      state: "blocked",
+      code: code ?? "anet_bin_unclassified",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -923,9 +923,14 @@ export async function handleCreateNodeDoorbell(
  *    像已经检查过了。(这是对 problem statement 里「抽出不抛异常的核心」的一处
  *    收窄:包一层比拆开更小、且**逐字不变是构造性的**,不需要靠测试去证明。)
  *
- * 🔴 `code` 允许 `anet_bin_unclassified`,不是占位:`loadAndVerifyAnetBin` 里
- *    **sha256 mismatch 那条抛的是裸 Error、没有挂 anetBinCode**。把它硬塞进上面
- *    四类中的任何一类都是编的 —— 未归类就说未归类,别让显示层替它选一个方向。
+ * 🔴 `code` 的第五个取值**沿用 `anet_bin_unknown`,不新造名字**。#1353 已经在
+ *    `config-apply.ts` 的 `create_nodes_blocked_reason` 里定义了它(「拿不到类别时
+ *    的兜底」),hub 的 zod enum(`server/src/tools.ts`)也已经收这个值。
+ *    我一度想叫 `anet_bin_unclassified` —— 那是**造同义副本**:两个名字同一个含义,
+ *    以后只会有一个被改到。
+ *    它不是占位:`loadAndVerifyAnetBin` 里 **sha256 mismatch 那条抛的是裸 Error、
+ *    没有挂 anetBinCode**(同文件其余 8 个 throw 点都走 `unsafePathHelp`),
+ *    所以确实无类别可挂。把它硬塞进四类中任何一类都是编的。
  *
  * 🔴 这里**没有 unknown 态**。unknown 的含义是「daemon 根本没上报过这一格」,
  *    那是传输/显示层的状态(PR2/PR4),探针跑到了就一定有答案。 */
@@ -933,7 +938,7 @@ export type AnetBinReadiness =
   | { readonly state: "ready"; readonly abs: string }
   | {
       readonly state: "blocked";
-      readonly code: AnetBinFailureCode | "anet_bin_unclassified";
+      readonly code: AnetBinFailureCode | "anet_bin_unknown";
       /** 人读的整句,含解析器给出的 `Fix: …` 那半 —— 不另存一份副本,
        *  否则修法会有两处、而只有一处会被改。 */
       readonly detail: string;
@@ -949,7 +954,7 @@ export function probeAnetBinReadiness(
     const code = (error as AnetBinError | null)?.anetBinCode;
     return {
       state: "blocked",
-      code: code ?? "anet_bin_unclassified",
+      code: code ?? "anet_bin_unknown",
       detail: error instanceof Error ? error.message : String(error),
     };
   }


### PR DESCRIPTION
## 这一层解决 #1545 的哪一格

B 路(agent-node 侧)第一块。#1545 的形状是:daemon 在线、`node create` 必失败、
**中间每一层都没有话说**。原因在 agent-node 里是结构性的 ——「能不能起节点」这个
判断只有一种表达方式:`loadAndVerifyAnetBin` 抛异常、守护进程退出。
**想问它,就得引发那次退出。** 于是没有任何命令能在不弄死 daemon 的前提下问出答案。

本 PR 只做一件事:给它加一个**返回值形态**。

```ts
probeAnetBinReadiness(env, platform):
  | { state: "ready";   abs: string }
  | { state: "blocked"; code: AnetBinFailureCode | "anet_bin_unclassified"; detail: string }
```

## 三个设计决定,都请顺手复核

**① 包一层,不拆解析器。** problem statement 里我写的是「抽出不抛异常的核心」,
实际做成了 try/catch 翻译。收窄的理由:**判据只能有一个作者**。探针若自己再判一遍,
两份判据会各自漂移 —— 到那天「探针说 ready、create 仍然失败」比现在的沉默更难查,
因为它**看起来像已经检查过了**。而且这样一来「行为逐字不变」是构造性的:
解析器和那 6 条 `toThrow(/anet_bin_unsafe_path.../)` **一行未动**,不需要测试去证明。

**② 多一个 `anet_bin_unclassified`,不是占位。**
`loadAndVerifyAnetBin` 里 sha256 mismatch 那条抛的是**裸 `Error`、没挂 `anetBinCode`**
(create-node-daemon.ts,`if (pin.sha256)` 那段)。把它硬塞进现有四类中的任何一类
都是编的 —— 而 08-28 的翻车正是这个形状:`anet_bin_source` 和 `anet_bin_permission`
盖成同一句话,让人跑去建 `/etc/anet-daemon/path.conf`,实际只要一行 `chmod`。
**未归类就说未归类,别让显示层替它选一个方向。** 有专门一条测试钉住它,
哪天有人给 sha256 那条挂上类别,这条会红 —— 那正是该有人读一眼的时刻。

**③ 这里没有 `unknown` 态。** `unknown` 的含义是「daemon 根本没上报过这一格」,
那是传输/显示层的状态(PR2 hub 字段 / PR4 CLI),**探针跑到了就一定有答案**。
(应你在派工里的要求:readiness 的取值域最终不止 ready/blocked 两态 ——
但第三态属于上面那两层,不该在这里造。)

## 见证:两向,缺一不可

| 变异 | 红的 | 绿的 |
|---|---|---|
| **M1 恒 blocked**(拿掉 ready 分支) | `READY` + `PARITY` | 3 条 `BLOCKED` 全绿 |
| **M2 恒 ready**(吞掉异常) | 3 条 `BLOCKED` + `PARITY`(共 4 条) | — |
| 还原 | — | **72 pass / 0 fail** |

🔴 **只验 blocked 一侧的话 M1 会全绿活下来。** blocked 那侧本来就有 6 条 `toThrow` 在守,
真正没人守的是「ready 时它确实说 ready」;而一个永远说"不行"的探针,
和一个永远沉默的 daemon,**对用户是同一件事**。

`PARITY` 那条直接断言 ①:同一份 env 下,「probe 说 blocked」**恰好**等于「解析器抛了」。
它自己带分母自证(ready 1 / blocked 3)—— 用例集若全是 blocked,那个等式恒成立、
什么也没测。

## 门

- `bun test src/runtime/create-node-daemon.test.ts` → 72 pass / 0 fail(新增 5 条)
- `check-agent-node-typecheck-ratchet.py`(#1550)→ **86 errors == baseline 86**,新增代码 0 增量
  (这道门还不在 main 的必需检查里,所以单独跑过并记在这里)
- `check-doc-symbol-anchors` / `check-test-file-coverage` / `check-test-suite-registration` → rc=0

## 不在本 PR 里

PR2 hub 侧 readiness 字段(顶层、optional **且** nullable)、PR3 daemon 在上报时重算并带
`observed_at`、PR4 CLI 显示。本 PR **没有任何调用点** —— 探针加了但还没人问它,
这是有意的:一次只动一层。

Refs #1545
