### PR TITLE
fix(test): qa-rfc028 备份点必须早于第一次修改，并加 EXIT trap (#1541)

### DIFF
--- a/tests/qa-rfc028-provider-probe/run.sh
+++ b/tests/qa-rfc028-provider-probe/run.sh
@@ -65,6 +65,17 @@ cp /tmp/anet-mock-cert.pem /usr/local/share/ca-certificates/anet-mock.crt
 update-ca-certificates >/dev/null 2>&1
 ok "mock cert installed to system trust store (rejectUnauthorized stays真)"
 
+# 🔴 #1541 — 备份必须早于**第一次**修改。
+# 原先最早的备份点在 F 场景那里(暂存 DNS 攻击之前),也就是说它拍到的已经是
+# 「含下面这条 pin」的版本;两处 `cp /tmp/hosts.bak /etc/hosts` 恢复的自然也是含 pin 的状态。
+# ⇒ 一次 exit 0 的**成功**运行也会留下 `127.0.0.1 api.anthropic.com canary.internal`。
+# 容器内无害(销毁即消失),但直接在宿主上跑 run.sh 会永久留下。
+#
+# trap 里的 `|| true` 不能省:EXIT trap 里一个非零退出码会**覆盖脚本真实的退出码**,
+# 那会让整套断言的红绿变得不可读 —— 比它要修的污染严重得多。
+cp /etc/hosts /tmp/hosts.orig
+trap 'cp -f /tmp/hosts.orig /etc/hosts 2>/dev/null || true' EXIT
+
 # Pin DNS: api.anthropic.com → 127.0.0.1 in container's /etc/hosts
 if ! grep -q "api.anthropic.com" /etc/hosts; then
   echo "127.0.0.1 api.anthropic.com canary.internal" >> /etc/hosts


### PR DESCRIPTION
Closes #1541

## 病灶不是「恢复失败没判红」，是**恢复的目标状态本身就是错的**

```
:69/:70   echo "127.0.0.1 api.anthropic.com canary.internal" >> /etc/hosts   ← 第一次修改
...
F 场景    cp /etc/hosts /tmp/hosts.bak      ← 备份点在**它之后**
两处      cp /tmp/hosts.bak /etc/hosts      ← 于是恢复到「已含 pin」的状态
全脚本    trap 计数 = 0
```

⇒ **一次 exit 0 的成功运行也会留下那条 pin。** 补 `|| bad`（#1544 已合入）修不掉它 —— 那修的是「红不红」，这修的是「恢复得对不对」。

严重性：正规入口是 Dockerfile、容器销毁即消失，**只有直接在宿主 `bash run.sh` 才永久留下** ⇒ footgun。

## 修法

备份点提到任何修改之前 + EXIT trap 兜底。

🔴 **`|| true` 不能省**：EXIT trap 里一个非零退出码会**覆盖脚本真实的退出码**，那会让整套断言的红绿不可读 —— 比它要修的污染严重得多。

## 两向见证（Docker）

| 方向 | suite rc | `docker cp` 出的 /etc/hosts |
|---|---|---|
| 正向（完整跑） | **0**（PASS=51 FAIL=0 SKIP=0） | `api.anthropic.com` 命中 **0** |
| 反向（在 F override 之后、任何 restore 之前注入 `exit 1`） | **1**（真的失败了） | 命中 **0** |

**反向那一侧才是关键**：正向那侧，既有的 `:353` 恢复也会把它清干净 —— **「trap 生效」和「trap 是摆设」在正向上输出完全相同。**

## 🔴 未取得的一格，如实记录

我本想再跑一次「main 版本 + 同样注入」的对照（预期**非 0** 命中）。**DEV 根分区在那次构建时被撑满**，容器起不来（rc=125），**该对照没有数据**。

这个方向已有 通信测试马 的独立实测（main 上完整成功运行后容器内仍含那一行，稳定态残留恰好一行）。**我不拿它当我自己的观测**，在此标明来源。