### PR TITLE
fix(agent-node): owner-schedule-control 的 lstat 类型用 Stats，别用重载联合 (#1536)

### DIFF
--- a/.github/scripts/check-agent-node-typecheck-ratchet.py
+++ b/.github/scripts/check-agent-node-typecheck-ratchet.py
@@ -45,7 +45,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASELINE = 86   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
+BASELINE = 82   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
                 # 环境须与 CI 一致:agent-node 下 npm install --no-save typescript@5.9.3 @types/node@20
 TS_VERSION = "5.9.3"
 TYPES_NODE_VERSION = "20"

--- a/agent-node/src/owner-schedule-control.ts
+++ b/agent-node/src/owner-schedule-control.ts
@@ -5,6 +5,7 @@ import {
   fstatSync,
   fsyncSync,
   lstatSync,
+  type Stats,
   openSync,
   readFileSync,
   rmSync,
@@ -67,7 +68,12 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function sameIdentity(a: ReturnType<typeof lstatSync>, b: ReturnType<typeof lstatSync>): boolean {
+// 🔴 类型用 `Stats` 而不是 `ReturnType<typeof lstatSync>`:后者是**重载的联合**,
+// 含 `throwIfNoEntry: false` 那个重载的 `Stats | undefined`。本文件所有调用点
+// 都是 `lstatSync(path)`(不带该选项),拿不到文件时**抛异常而不是返回 undefined**,
+// 所以 undefined 永远不在这里出现 —— 声明成联合只会让每个使用点都要多一次
+// 与现实无关的判空。(strict 下这行原本产生 4 条 TS18048。)
+function sameIdentity(a: Stats, b: Stats): boolean {
   return a.dev === b.dev && a.ino === b.ino;
 }
 
@@ -80,7 +86,7 @@ function assertPrivateDirectory(path: string): void {
 }
 
 function readJournal(path: string): Journal | null {
-  let before: ReturnType<typeof lstatSync>;
+  let before: Stats;
   try { before = lstatSync(path); } catch (error: any) {
     if (error?.code === "ENOENT") return null;
     throw error;


### PR DESCRIPTION
#1550 那道棘轮门落地后的第一次真实使用：拿它去找东西，而不是只让它守着。

## 改了什么

`sameIdentity(a, b)` 和 `let before` 都写成 `ReturnType<typeof lstatSync>`。**那是重载的联合**，含 `throwIfNoEntry: false` 那个重载的 `Stats | undefined`。

本文件所有调用点都是 `lstatSync(path)`（不带该选项），**拿不到文件时抛异常而不是返回 undefined** ⇒ undefined 永远不在这里出现。声明成联合的后果是：strict 下这一行产生 **4 条 TS18048**，而每一条要求的都是**与现实无关的判空**。

**不是运行时缺陷**（现状是类型比现实宽，不是代码会崩），是**声明与契约不符**。

## 验证

```
基线 86 → 改动后 82   （门自己打印 ::notice 要求下调，本 PR 一并调到 82）
bun test src/owner-schedule-control.test.ts → 6 pass / 0 fail / 42 expect()
行为零改动：只动类型注解 + 一行 import
```

## 🔴 我查过、确认**不是缺陷**因而没改的三条（写下来避免下一个人重查）

| 报错 | 结论 |
|---|---|
| `cli.ts sideThreadNodeRuntime is possibly null` | 整段在 `try/catch` 里，catch 写一个带 `reason:"runtime"` 的兜底快照 —— **不存在崩溃路径** |
| `DelegationCheckResult.reason` × 12 | 调用点是 `if (!check.exists) { … check.reason … }`，**判别联合收窄写得完全正确** |
| `Cannot find name 'Bun'` × 4 | **配置缺口**（兄弟包 `server` 用 `types:["bun-types"]`），不是代码问题；单独评估，本 PR 不碰 |

这三条是我这轮实际花掉的大部分时间。**结论是：这 86 条里绝大多数是严格性/注解噪音，不是潜伏缺陷** —— 也就是说这道棘轮门的价值是**前瞻的**（挡住新增），不是回溯的（挖出旧账）。这一点值得写明，免得有人期待它能自动找出 bug。