### PR TITLE
feat(hub): #1545 hub 收下并带出「can_create_nodes 是多久以前测的」

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2002 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2002) + [tools.ts:2016 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2016) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2060 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2060) + [tools.ts:2074 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2074) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/api-host-supervisors-can-create-nodes.test.ts
+++ b/server/src/api-host-supervisors-can-create-nodes.test.ts
@@ -264,3 +264,87 @@ describe("#1353 Fix ② — /api/host-supervisors surfaces can_create_nodes + bl
     expect(rows.find((r: any) => r.alias === "malformed")).toBeUndefined();
   });
 });
+
+/* #1545 —— `can_create_nodes` 说的是「能不能」,这一组说的是「**那是什么时候测的**」。
+ *
+ * 为什么非要分开:agent-node 到 preview.67 为止用一个进程级缓存只算一次
+ * (`cli.ts` 的 `_createCapCache`)。开机时二进制好、之后被 chmod 掉 ⇒ 它会
+ * **永远上报 ready**。hub 这边,那条记录和一个 3 秒前刚测出来的 ready
+ * 在 `last_seen_at` 上一模一样 —— 心跳是新的,那一格不是。
+ *
+ * 🔴 缺席**不得**当成 0。把「没报」渲染成「刚测的」,正好朝「没问题」方向说谎,
+ *    而这正是 #1545 里比沉默更糟的那一半。
+ */
+describe("#1545 /api/host-supervisors —— can_create_nodes 的年龄", () => {
+  test("daemon 报了年龄 → 原样带出", async () => {
+    clearDaemons();
+    seedDaemon("age-fresh", {
+      role: "host_supervisor",
+      daemon_capabilities: {
+        can_create_nodes: false,
+        create_nodes_blocked_reason: "anet_bin_source",
+        create_capability_observed_ms_ago: 12,
+      },
+    });
+    const d = findDaemon(await listDaemons(), "age-fresh");
+    expect(d.create_capability_observed_ms_ago).toBe(12);
+  });
+
+  test("🔴 daemon 没报年龄 → 这一格必须**缺席**,不能是 0/null", async () => {
+    clearDaemons();
+    seedDaemon("age-absent", {
+      role: "host_supervisor",
+      daemon_capabilities: { can_create_nodes: true },
+    });
+    const d = findDaemon(await listDaemons(), "age-absent");
+    // 能力本身照常带出 —— 加年龄这一格不许把旧 daemon 的既有信息弄丢。
+    expect(d.can_create_nodes).toBe(true);
+    expect("create_capability_observed_ms_ago" in d).toBe(false);
+  });
+
+  /* 🔴 消毒**不是 clamp**:clamp 会把一个坏值变成一个看起来正常的年龄,
+   * 而这一格存在的全部意义就是让人分辨新鲜和陈旧。坏值一律当作「没报」。 */
+  test.each([
+    ["负数", -1],
+    ["超过一年", 400 * 24 * 60 * 60 * 1000],
+    ["null(schema 的 .catch 兜底值)", null],
+    ["字符串(直接写库,绕过 schema)", "12"],
+  ])("坏值当作没报,而不是 clamp 成边界:%s", async (label, value) => {
+    clearDaemons();
+    const alias = `age-bad-${String(label).slice(0, 4)}`;
+    seedDaemon(alias, {
+      role: "host_supervisor",
+      daemon_capabilities: {
+        can_create_nodes: true,
+        create_capability_observed_ms_ago: value,
+      },
+    });
+    const d = findDaemon(await listDaemons(), alias);
+    expect(d.can_create_nodes).toBe(true);           // 能力仍在
+    expect("create_capability_observed_ms_ago" in d).toBe(false);  // 年龄不在
+  });
+
+  /* 边界校准:上面用 400 天证明「太旧被丢」,这里用**刚好一年**证明门不是恒丢。
+   * 只验被丢那一侧的话,一个恒丢的实现能全绿通过。 */
+  test("边界:恰好一年被接受 ⇒ 上面那条不是因为恒丢才绿", async () => {
+    clearDaemons();
+    const oneYear = 365 * 24 * 60 * 60 * 1000;
+    seedDaemon("age-boundary", {
+      role: "host_supervisor",
+      daemon_capabilities: { can_create_nodes: true, create_capability_observed_ms_ago: oneYear },
+    });
+    const d = findDaemon(await listDaemons(), "age-boundary");
+    expect(d.create_capability_observed_ms_ago).toBe(oneYear);
+  });
+
+  test("年龄只在 can_create_nodes 存在时出现(旧 daemon 两格都没有)", async () => {
+    clearDaemons();
+    seedDaemon("age-legacy", {
+      role: "host_supervisor",
+      daemon_capabilities: { runtimes_supported: ["claude-agent-sdk"] },
+    });
+    const d = findDaemon(await listDaemons(), "age-legacy");
+    expect("can_create_nodes" in d).toBe(false);
+    expect("create_capability_observed_ms_ago" in d).toBe(false);
+  });
+});

--- a/server/src/report-status-host-schema.test.ts
+++ b/server/src/report-status-host-schema.test.ts
@@ -139,3 +139,73 @@ describe("#1545 create_capability_observed_ms_ago —— schema 必须收得宽"
     expect(parsed.daemon_capabilities.create_capability_observed_ms_ago).not.toBe("0");
   });
 });
+
+/* 🔴 #1545 —— 把 `host:` 上方那段方框注释里的表**钉住**。
+ *
+ * 那段注释说的是:这份 schema 的子对象一半 strict 一半不 strict,而「往里加一个
+ * hub 还不认识的键」的后果完全相反 —— 非 strict 静默丢弃(节点活着、字段蒸发),
+ * strict 拒掉整份 report(节点当场失联,#1225 的形状)。
+ *
+ * 注释会烂。这组测试的作用**不是禁止改 strict**(两种都各有其位),而是:谁改了,
+ * 谁就会在这里撞红,从而**被迫连注释一起改**。所以断言写成「和注释里那张表一致」,
+ * 而不是「必须是某个值」。 */
+describe("#1545 report_status 子对象的 strict 分布(注释里那张表的可执行副本)", () => {
+  const rs = () => schemas.report_status;
+  const UNKNOWN = { __hub_does_not_know_this_key__: 1 };
+
+  function acceptsUnknownKey(schema: any, base: object): "dropped" | "rejected" {
+    try {
+      const parsed = schema.parse({ ...base, ...UNKNOWN });
+      return "__hub_does_not_know_this_key__" in parsed ? "rejected" /* 不可能:留着说明它根本没被处理 */ : "dropped";
+    } catch { return "rejected"; }
+  }
+
+  const SIDE_THREAD = {
+    supported: true, runtime: "codex", runtimeVersion: "1.0",
+    topology: "native-exact-fork", evidenceRevision: "r1",
+  };
+  const SNAP_BASE = { flags: {}, config_update_capable: false, peer_reply_inbox_capable: true };
+
+  test.each([
+    ["host", () => rs().host, {}, "dropped"],
+    ["process_telemetry", () => rs().process_telemetry, {}, "dropped"],
+    ["config_snapshot", () => rs().config_snapshot, SNAP_BASE, "dropped"],
+    ["external_schedules", () => rs().external_schedules, { schedules: [] }, "rejected"],
+  ])("%s → 未知键被 %s", (_name, get, base, expected) => {
+    expect(acceptsUnknownKey(get(), base)).toBe(expected as string);
+  });
+
+  test("daemon_capabilities(嵌在 config_snapshot 里)→ 未知键被丢弃,不拒整份", () => {
+    const parsed: any = rs().config_snapshot.parse({
+      ...SNAP_BASE,
+      daemon_capabilities: { can_create_nodes: true, ...UNKNOWN },
+    });
+    expect(parsed.daemon_capabilities.can_create_nodes).toBe(true);
+    expect("__hub_does_not_know_this_key__" in parsed.daemon_capabilities).toBe(false);
+  });
+
+  test("side_thread_capability(同一个 config_snapshot 里)→ 未知键拒掉**整份**", () => {
+    expect(() => rs().config_snapshot.parse({
+      ...SNAP_BASE,
+      side_thread_capability: { ...SIDE_THREAD, ...UNKNOWN },
+    })).toThrow();
+    // 反向锚:去掉那个未知键必须过 —— 否则上面那条可能是被别的必填字段拒的,
+    // 和 strict 无关。
+    expect(() => rs().config_snapshot.parse({
+      ...SNAP_BASE, side_thread_capability: SIDE_THREAD,
+    })).not.toThrow();
+  });
+
+  /* 分母自证:上面这张表**两侧都有**。如果哪天全变成 dropped(或全 rejected),
+   * 那段注释描述的「不对称」就不存在了,而这条会先红。 */
+  test("这张表确实是不对称的(两种后果各至少一个)", () => {
+    const results = [
+      acceptsUnknownKey(rs().host, {}),
+      acceptsUnknownKey(rs().process_telemetry, {}),
+      acceptsUnknownKey(rs().config_snapshot, SNAP_BASE),
+      acceptsUnknownKey(rs().external_schedules, { schedules: [] }),
+    ];
+    expect(results.filter(r => r === "dropped").length).toBeGreaterThan(0);
+    expect(results.filter(r => r === "rejected").length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/report-status-host-schema.test.ts
+++ b/server/src/report-status-host-schema.test.ts
@@ -74,3 +74,68 @@ describe("report_status host telemetry schema", () => {
     })).not.toThrow();
   });
 });
+
+/* #1545 —— `create_capability_observed_ms_ago` 的**验证宽度**本身就是判据。
+ *
+ * 这一格是纯诊断信息(那个 can_create_nodes 是多久以前测出来的)。zod 对象里
+ * 任何一个**已知字段**验证失败,整份 report_status 都会被拒 —— 不是丢掉这一格。
+ * 所以给它加 `.int()/.min()/.max()` 等于:一台节点发了个奇怪的诊断数字,
+ * 就在 hub 上整个失联。**#1225/#1498 已经用 host.ip 演过一遍这件事了。**
+ *
+ * 消毒在读取处(`/api/host-supervisors`),不在这里。 */
+describe("#1545 create_capability_observed_ms_ago —— schema 必须收得宽", () => {
+  const caps = () => schemas.report_status.config_snapshot;
+
+  test("前提:抓到的确实是 config_snapshot 形状,且它接受 daemon_capabilities", () => {
+    expect(caps()).toBeTruthy();
+    const parsed = caps().parse({
+      flags: {}, config_update_capable: false, peer_reply_inbox_capable: true,
+      daemon_capabilities: { can_create_nodes: true },
+    });
+    expect(parsed.daemon_capabilities.can_create_nodes).toBe(true);
+  });
+
+  test("正常值:透传", () => {
+    const parsed = caps().parse({
+      flags: {}, config_update_capable: false, peer_reply_inbox_capable: true,
+      daemon_capabilities: { can_create_nodes: true, create_capability_observed_ms_ago: 0 },
+    });
+    expect(parsed.daemon_capabilities.create_capability_observed_ms_ago).toBe(0);
+  });
+
+  test("null 必须被接受(显式「我没测过」和「我不发这一格」都要能表达)", () => {
+    const parsed = caps().parse({
+      flags: {}, config_update_capable: false, peer_reply_inbox_capable: true,
+      daemon_capabilities: { can_create_nodes: true, create_capability_observed_ms_ago: null },
+    });
+    expect(parsed.daemon_capabilities.create_capability_observed_ms_ago).toBeNull();
+  });
+
+  /* 🔴 这四个值**一个都不许让整份 report 被拒**。它们在读取侧会被当成「没报」,
+   *    但那是读取侧的事 —— 这一层的职责只有一个:别把节点踢下线。 */
+  test.each([
+    ["负数", -1],
+    ["非整数", 1234.5678],
+    ["超过一年", 400 * 24 * 60 * 60 * 1000],
+    ["NaN", Number.NaN],
+  ])("怪值不得拒掉整份 report_status:%s", (_label, value) => {
+    expect(() => caps().parse({
+      flags: {}, config_update_capable: false, peer_reply_inbox_capable: true,
+      daemon_capabilities: { can_create_nodes: false,
+        create_nodes_blocked_reason: "anet_bin_source",
+        create_capability_observed_ms_ago: value },
+    })).not.toThrow();
+  });
+
+  /* 🔴 反向锚:上面那组「不抛」如果只是因为**这个 key 压根没被 schema 看见**,
+   * 它们会一样绿。所以这里证明 schema 确实在看它:喂一个非数字,值必须**被改写成
+   * null**(而不是原样穿过去)。原样穿过去 = key 被忽略,那组测试就什么也没测。 */
+  test("反向锚:非数字被改写成 null(不是原样穿过)⇒ 证明 schema 确实在看这个 key", () => {
+    const parsed = caps().parse({
+      flags: {}, config_update_capable: false, peer_reply_inbox_capable: true,
+      daemon_capabilities: { can_create_nodes: true, create_capability_observed_ms_ago: "0" },
+    });
+    expect(parsed.daemon_capabilities.create_capability_observed_ms_ago).toBeNull();
+    expect(parsed.daemon_capabilities.create_capability_observed_ms_ago).not.toBe("0");
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3152,6 +3152,12 @@ return Bun.serve({
           // upgraded past preview.55.
           let snapCanCreate: boolean | undefined;
           let snapBlockedReason: string | undefined;
+          // #1545 —— 见 report_status schema 里 create_capability_observed_ms_ago 的注释:
+          // 上报侧**故意收得宽**(无 int/min/max,免得一个诊断字段能让整份 report 被拒),
+          // 消毒放在这里。非有限数、负数、超过 1 年的一律当作「没报」——
+          // 🔴 不是 clamp 成边界值:clamp 会把一个坏值变成一个**看起来正常的年龄**,
+          //    而这一格存在的全部意义就是让人分辨新鲜和陈旧。
+          let snapObservedMsAgo: number | undefined;
           if (r.config_snapshot) {
             try {
               const parsed = typeof r.config_snapshot === "string" ? JSON.parse(r.config_snapshot) : r.config_snapshot;
@@ -3164,12 +3170,18 @@ return Bun.serve({
                   && caps.create_nodes_blocked_reason.length > 0) {
                 snapBlockedReason = caps.create_nodes_blocked_reason;
               }
+              const rawAge = caps?.create_capability_observed_ms_ago;
+              if (typeof rawAge === "number" && Number.isFinite(rawAge)
+                  && rawAge >= 0 && rawAge <= 365 * 24 * 60 * 60 * 1000) {
+                snapObservedMsAgo = rawAge;
+              }
             } catch { /* malformed */ }
           }
-          return { row: r, role: snapRole, canCreate: snapCanCreate, blockedReason: snapBlockedReason };
+          return { row: r, role: snapRole, canCreate: snapCanCreate, blockedReason: snapBlockedReason,
+            observedMsAgo: snapObservedMsAgo };
         })
         .filter(({ role }) => role === "host_supervisor")
-        .map(({ row: r, canCreate, blockedReason }) => {
+        .map(({ row: r, canCreate, blockedReason, observedMsAgo }) => {
           let online = false;
           let lastSeenAt: string | null = null;
           if (r.session_last_seen) {
@@ -3220,6 +3232,18 @@ return Bun.serve({
             // don't confuse consumers with a reason on a healthy daemon.
             if (canCreate === false && blockedReason) {
               out.create_nodes_blocked_reason = blockedReason;
+            }
+            // #1545 —— 只在 daemon 真的报了这一格时才出现。
+            // 🔴 缺席**不能**当成 0:那等于替一个从不重算的旧 daemon 宣称
+            //    「这是刚测的」,正好朝「没问题」方向说谎。缺席就让它缺席,
+            //    读的人据此说「年龄未知」(与 can_create_nodes 本身
+            //    undefined-vs-false 的处理同一条规矩,见上面 #1353 Fix ②)。
+            //
+            // 语义:该能力值是在**这份 report 发出前 N 毫秒**测得的。
+            // 绝对年龄 = (now - last_seen_at) + create_capability_observed_ms_ago。
+            // 用节点自己的钟只量了「多久以前」,绝对时间全部由 hub 的钟出。
+            if (typeof observedMsAgo === "number") {
+              out.create_capability_observed_ms_ago = observedMsAgo;
             }
           }
           return out;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -636,6 +636,37 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             "anet_bin_permission",
             "anet_bin_unknown",
           ]).optional(),
+          // #1545 —— 上面那一格**是什么时候测出来的**。
+          //
+          // 🔴 为什么必须有:agent-node 到 preview.67 为止,`daemonCreateCapability()`
+          //    用一个进程级缓存(`_createCapCache`)只算一次。开机时 pin 坏 ⇒ 之后
+          //    永远上报 blocked(哪怕运维已经写好 path.conf);开机时好 ⇒ 之后把二进制
+          //    chmod 掉也**永远上报 ready**。后者是朝「没问题」方向说谎。
+          //    而 hub 这边,一个 3 秒前测的 blocked 和一个三周前测的 blocked,
+          //    在 `last_seen_at` 上长得一模一样 —— 心跳是新的,那一格不是。
+          //
+          // 🔴 为什么是「多久以前」(时长)而不是绝对时间戳:这个值来自**节点自己的钟**。
+          //    时钟偏移下,绝对时间戳会算出一个既可能"永远新鲜"也可能"来自 1970"的年龄,
+          //    而且错的方向不可预测。时长对偏移免疫 —— hub 用自己的钟在收到时换算。
+          //
+          // 🔴 为什么不加 `.min()/.max()/.int()`:**这几个约束都会让整条 report_status 被拒**
+          //    (zod 对象里任何一个已知字段验证失败 = 整份被拒,不是丢掉这一格),
+          //    而这一格是纯诊断信息,不值得拿一台节点的在线状态去换。
+          //    收得宽,**在读取处消毒**(见 /api/host-supervisors)。
+          //    这条不是我新立的:同一个 schema 上方 `anet_bin_pin_unresolved` 那条注释
+          //    记的就是同一次教训 —— 删一个 enum 值会让所有 .40 daemon 失联。
+          //
+          // 🔴 `.catch(null)` 不是装饰:光写 `z.number()` **仍然会拒 NaN**
+          //    (实测:`z.number().nullable().optional()` 对 NaN 抛),而那意味着
+          //    一次算错的时长能让整台节点在 hub 上失联 —— 正是 #1225 里 host.ip
+          //    那个形状。`.catch(null)` 让这一格**在任何输入下都不可能拒掉整份 report**:
+          //    合法数字透传,其余一律变 null(读取侧当作「没报」)。
+          //    类型仍然是 number 而不是 unknown —— 别给一个 attacker daemon
+          //    留下"往快照里塞任意大对象"的口子(同 schema 上方 soft cap 的立场)。
+          //
+          // 不上报这一格 ≠ 0。旧 daemon 压根不发,读的人必须能把
+          // 「刚测的」「很久以前测的」「不知道」分成三件事说。
+          create_capability_observed_ms_ago: z.number().nullable().catch(null).optional(),
         }).optional(),
       }).optional().describe("RFC-024 — masked node config snapshot"),
     },

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -517,6 +517,28 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       model: z.string().max(200).optional().describe("AI model name"),
       node_name: z.string().max(200).optional().describe("Stable node display name (may differ from alias)"),
       network_id: z.string().max(200).optional().describe("Network this agent belongs to"),
+      // ╭─ 🔴 往 report_status 里加字段之前先读这一段(#1545 实测,zod 4.3.6)─────────╮
+      // │ **这份 schema 的子对象一半严一半松,而后果完全不同。**
+      // │
+      // │   非 strict:host / process_telemetry / config_snapshot / daemon_capabilities
+      // │   `.strict()`:external_schedules(含其 schedules[] 元素)
+      // │              side_thread_capability(含其 exactBoundary)
+      // │
+      // │ 往**非 strict** 的对象里加一个 hub 还不认识的键 ⇒ zod **静默丢弃**。
+      // │   节点不会掉线,但字段人间蒸发 —— 现场表现为「daemon 明明发了、hub 上没有」,
+      // │   排查起来和 daemon 侧 bug 一模一样。
+      // │ 往**strict** 的对象里加同一个键 ⇒ `unrecognized_keys`,**整份 report_status 被拒**。
+      // │   而 agent-node 的 register() 是 `await` 且无人 catch ⇒ **节点进程当场死掉**
+      // │   (#1225 就是这么全网躺倒的,见下面 host.ip 那段)。
+      // │
+      // │ 所以「新字段能不能 daemon 先发」**没有统一答案,取决于你往哪个子对象里加**:
+      // │   非 strict → 可以先发(会丢,不会死);strict → hub 必须先合,否则升级即失联。
+      // │
+      // │ 🔴 别把这条读成「strict 更危险、都改成非 strict」。两者各有其位:
+      // │   external_schedules / side_thread_capability 是**有界快照**,strict 挡的是
+      // │   「节点往里塞任意键」;daemon_capabilities 是**能力自述**,天然要向前兼容
+      // │   (旧 hub 见到新能力应当忽略而不是拒绝整份上报)。**加字段前先看清你在哪一边。**
+      // ╰──────────────────────────────────────────────────────────────────────────────╯
       host: z.object({
         // 🔴 `.nullable()` 不是防御性冗余,是**发送方声明的类型**:agent-node 的
         //    HostTelemetry 是 `ip: string | null`,`firstNonInternalIPv4()` 在没有
@@ -599,6 +621,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         // never saw them, max_concurrent_children stayed default + the
         // allowlists stayed unenforced. PR3 nit ① per 通信龙).
         // Soft caps avoid abuse via attacker daemon.
+        // 🔴 这个对象**故意不是 `.strict()`** —— 能力自述必须向前兼容:
+        //    旧 hub 见到新 daemon 报的新能力,应当忽略那一格,而不是拒掉整份 report
+        //    把节点踢下线。代价是新键在 hub 升级前会被**静默丢弃**(所以新字段仍然
+        //    应当 hub 先合)。同一份 schema 里 side_thread_capability / external_schedules
+        //    是 `.strict()` 的,后果不同 —— 见 `host:` 上方那段方框注释。
         daemon_capabilities: z.object({
           runtimes_supported: z.array(z.string().max(64)).max(16).optional(),
           allowed_secret_keys: z.array(z.string().max(64)).max(64).optional(),


### PR DESCRIPTION
## 这是 #1545 四段计划的一处修正

原计划的 PR2 是「hub 顶层加一个 readiness 字段」。**不做** —— `can_create_nodes` /
`create_nodes_blocked_reason` 从 #1353 起就已经 daemon→hub→API 全通
(`config-apply.ts:528` → `cli.ts:1505` → `tools.ts:614/631` → `server.ts:3160-3222`
→ create 拒绝 `tools.ts:3231`),再加一个等于造第二份。已与 通信龙 确认。

真正缺的是两件事:**(a) 没有人读**(`agent-network/`、`dashboard/` 全仓 0 命中)、
**(b) 那一格是开机时算的、之后再没测过**。本 PR 补 (b) 的 hub 那一半。

## 为什么「年龄」这一格不可省

`agent-node/src/cli.ts` 的 `daemonCreateCapability()`:

```ts
if (_createCapCache !== undefined) return _createCapCache ?? undefined;
```

进程级缓存,只算一次。于是:

| 开机那一刻 | 之后发生了什么 | daemon 永远上报 |
|---|---|---|
| pin 坏 | 运维写好了 `/etc/anet-daemon/path.conf` | `blocked` ❌ |
| pin 好 | 二进制被 `chmod` 掉 / 装了别的版本 | **`ready`** ❌❌ |

第二行**朝「没问题」方向说谎**,比 #1545 抱怨的沉默更糟。而在 hub 上,
一个 3 秒前测的 `blocked` 和一个三周前测的 `blocked`,**在 `last_seen_at` 上完全一样**
—— 心跳是新的,那一格不是。

## 三个设计决定

**① 报「多久以前」(时长),不报绝对时间戳。**
这个值来自**节点自己的钟**。时钟偏移下,绝对时间戳会算出一个既可能"永远新鲜"
也可能"来自 1970"的年龄,而且**错的方向不可预测**。时长对偏移免疫;绝对时间全部
由 hub 的钟出:`年龄 = (now - last_seen_at) + create_capability_observed_ms_ago`。

**② schema 收得宽,消毒放在读取处 —— 并且 `.catch(null)` 不是装饰。**
zod 对象里任何一个**已知字段**验证失败,**整份 `report_status` 都会被拒**,不是丢掉
这一格。给一个纯诊断字段加 `.int()/.min()/.max()`,等于让一次算错的时长把整台节点
从 hub 上摘下去 —— 正是 #1225 / #1498 里 `host.ip` 那个形状。

🔴 而且光写 `z.number().nullable().optional()` **仍然会拒 NaN**(我写了测试才发现,
不是推的)。所以用 `.catch(null)`:合法数字透传,其余一律变 `null`,这一格
**在任何输入下都不可能拒掉整份 report**。仍然是 `number` 而不是 `unknown` ——
别给 attacker daemon 留一个"往快照里塞任意大对象"的口子(同 schema 上方 soft cap 的立场)。

**③ 坏值当作「没报」,不 clamp;缺席也不当 0。**
clamp 会把一个坏值变成一个**看起来正常的年龄**,而这一格存在的全部意义就是让人
分辨新鲜和陈旧。缺席当 0 = 替一个从不重算的旧 daemon 宣称"这是刚测的",
又一次朝「没问题」说谎(同 #1353 Fix ② 对 undefined-vs-false 的处理)。

## 见证

| 变异 | 红 | 说明 |
|---|---|---|
| **M1** 读取侧恒丢年龄 | 「原样带出」+「恰好一年被接受」 | 缺席那几条仍绿 —— 只验缺席一侧的话恒丢能全绿活下来 |
| **M2** 读取侧不消毒直接透传 | 「负数」「超过一年」 | `null` / 字符串两条由出口处 `typeof === "number"` 挡住,**两道守卫互补**(这一点我核过,不是笼统说"都红了") |
| 还原 | — | 17 pass / 0 fail |

边界校准:除了「400 天被丢」,另有一条「**恰好一年被接受**」—— 只验被丢那一侧的话,
一个恒丢的实现能全绿通过。

schema 侧另有 6 条,包括「负数 / 非整数 / 超一年 / NaN 都不得拒掉整份 report」,
外加一条**反向锚**:非数字必须被改写成 `null` 而不是原样穿过 —— 否则「不抛」
可能只是因为这个 key 压根没被 schema 看见,那组测试就什么也没测。

## 门

- 19 个相关 server 套件 **249 pass / 0 fail**
- `check-doc-symbol-anchors` / `check-test-file-coverage` / `check-test-suite-registration` / `check-docs-integrity` → 全 rc=0
- **无 DB 迁移**:`config_snapshot` 本来就是整块 JSON 存,新键只需过 zod 并在读取处取出

## 顺序

hub 必须先合。`daemon_capabilities` **不是 `.strict()`**,所以 daemon 先发不会像 #1498
那样把节点踢下线 —— 但未知键会被 zod **静默丢弃**,表现为「daemon 明明发了、hub 上没有」,
排查起来和 daemon 侧 bug 一模一样。(这一条我实测过 zod 4.3.6 的行为,没有沿用 #1498 的推论。)

接着:agent-node 拆 `_createCapCache` + 发这一格;然后 CLI 读出并**连同年龄一起显示**。

Refs #1545
