### PR TITLE
ci(deploy): anet.sh 部署后按内容验收一次（先只报不拦）

### DIFF
--- a/.github/workflows/deploy-anet-sh.yml
+++ b/.github/workflows/deploy-anet-sh.yml
@@ -78,3 +78,30 @@ jobs:
             exit 1
           }
           echo "✅ deployed docs-site → anet.sh (prebuilt confirmed)"
+
+      # 🔴 「部署成功」不等于「内容上线了」。上面那条 prebuilt 断言证明的是
+      #    **没有走远端构建**(成本红线),它对「这次改的那句话到底在不在线上」
+      #    一个字都没说。2026-08-30 手工部署时实测过两种假象:
+      #      · 部署确实成功,drift 门却报「落后」——(a) 在带未提交改动的检出上跑门,
+      #        (b) 指纹选中了代码围栏里的行、被语法高亮拆成多个 span 永远匹配不上(#1552 已修);
+      #      · 反过来,`deploy rc=0` 也从不保证被改的页面真的换了内容。
+      #    ⇒ 唯一能回答这个问题的是**按内容比对**,所以在这里跑 drift 门。
+      #
+      #    先 continue-on-error(只报不拦):这一步依赖 CDN 传播,新加的判据在证明自己
+      #    稳定之前不该拦住一次**已经完成**的部署。稳定几天后再去掉 continue-on-error。
+      - name: verify by content (report-only)
+        if: steps.guard.outputs.skip == 'false'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          # CDN 传播:重试而不是一次定生死。间隔递增,总计约 45s。
+          for wait in 5 10 30; do
+            sleep "$wait"
+            out=$(python3 .github/scripts/check-docs-site-drift.py 2>&1) && rc=0 || rc=$?
+            printf '%s\n' "$out"
+            [ "$rc" -eq 0 ] && { echo "✅ live site matches main"; exit 0; }
+            echo "— 第 ${wait}s 这轮未通过,可能仍在 CDN 传播,重试…"
+          done
+          echo "::warning::部署已完成,但内容比对在约 45s 内没有通过。"
+          echo "::warning::这一步目前只报不拦。请人工确认:改动是否真的出现在 https://anet.sh 上。"
+          exit 1


### PR DESCRIPTION
## 现有流程止步于「prebuilt confirmed」

那条断言证明的是**没有走远端构建**（#1163 成本红线）—— 它对「**这次改的那句话到底在不在线上**」一个字都没说。

## 两种假象我今天都实测到了

| 方向 | 表现 |
|---|---|
| 部署成功、门却说落后 | (a) 在**带未提交改动的检出**上跑门（报的 N 恰好等于 `git status --porcelain docs-site \| wc -l`）；(b) 指纹选中**代码围栏里的行**，被语法高亮拆成多个 `<span>`，永远匹配不上（#1552 已修） |
| 部署成功、内容却没换 | `deploy rc=0` 从不保证被改的页面真的更新了 |

⇒ **唯一能回答这个问题的是按内容比对。**

## 实现

部署成功后跑 `check-docs-site-drift.py`，CDN 传播用**递增重试**（5s/10s/30s，约 45s）而不是一次定生死。

## 🔴 为什么先 `continue-on-error: true`

这一步依赖 CDN 传播。**一条新加的判据在证明自己稳定之前，不该拦住一次已经完成的部署** —— 「部署失败」和「部署成功但验收还没追上」是两件事，不能让后者看起来像前者。稳定几天后再去掉。

（这和我对 `agent-node-typecheck` 门的态度一致：先跑、先观察，稳了再设为必需。）

## 说明

该 workflow 目前 gated 在 `VERCEL_TOKEN`，未设置时整个 job 优雅跳过 ⇒ **本改动在 token 设上之前不会执行**。但那正是把它准备好的时候：token 一设，第一次自动部署就带内容验收，而不是等出事之后再补。

`workflow-structure` rc=0 / `action-pins` rc=0 / YAML 解析通过（5 steps）