### PR TITLE
feat(agent-node): #1545 daemon 每次上报重算「能不能建节点」并带上年龄

### DIFF
--- a/.github/scripts/check-agent-node-typecheck-ratchet.py
+++ b/.github/scripts/check-agent-node-typecheck-ratchet.py
@@ -45,7 +45,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASELINE = 82   # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
+BASELINE = 81   # 2026-08-30, #1545: 82 → 81。少掉的那一条是 config-apply.ts 的
+                # createCapability.reason 只声明了 "anet_bin_pin_unresolved",而调用方
+                # 传的是五类真实 code —— 把那个联合单一来源化(CreateNodesBlockedReason)
+                # 之后它自然消失了。
+                # 2026-08-30, origin/main, strict:true, src/**/*.ts (排除 *.test.ts);
                 # 环境须与 CI 一致:agent-node 下 npm install --no-save typescript@5.9.3 @types/node@20
 TS_VERSION = "5.9.3"
 TYPES_NODE_VERSION = "20"

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -130,6 +130,11 @@ import {
   type ConfigUpdate,
   type ConfigPatch,
 } from "./runtime/config-apply";
+import {
+  evaluateCreateCapability,
+  type CreateCapabilityLogState,
+  type DaemonCreateCapability,
+} from "./runtime/daemon-create-capability";
 import { DEFAULT_CODEX_MODEL, resolveCodexModel } from "./codex-model-default";
 import { resolveTelegramAccess, buildEmptyAllowlistWarn, loadTelegramAccess } from "./util/access-resolve";
 import {
@@ -181,36 +186,45 @@ import {
 // 只对 host_supervisor 算。普通节点返回 undefined ⇒ 快照里完全不出现这两个字段,
 // 行为与改动前逐字相同。
 //
-// 🔴 算一次就缓存:report_status 是心跳路径,而 loadAndVerifyAnetBin() 会做
-//    realpathSync + statSync + 读文件哈希。每次心跳都跑一遍是纯浪费。
-//    代价是 daemon 运行期间修好了 pin 也要重启才会反映 —— 可接受,
-//    因为修 pin 的正规做法(写 /etc/anet-daemon/path.conf)本来就伴随重启。
-type CreateBlockedReason =
-  | "anet_bin_identity" | "anet_bin_source" | "anet_bin_shape"
-  | "anet_bin_permission" | "anet_bin_unknown";
-let _createCapCache: { ok: boolean; reason?: CreateBlockedReason } | null | undefined;
-function daemonCreateCapability(): { ok: boolean; reason?: CreateBlockedReason } | undefined {
-  if (_createCapCache !== undefined) return _createCapCache ?? undefined;
-  if (fileConfig?.role !== "host_supervisor") { _createCapCache = null; return undefined; }
-  try {
+// ── #1545:这里原本「算一次就缓存」,现在改成每次上报重算。下面是为什么 ──
+//
+// 原注释的理由是:「心跳路径上跑 realpathSync + statSync + 读文件哈希是纯浪费;
+// 代价是运行期间修好了 pin 也要重启才反映 —— 可接受,因为修 pin 的正规做法
+// (写 /etc/anet-daemon/path.conf)本来就伴随重启。」
+//
+// 🔴 那个「代价」只说了**一半**,而没说的那一半朝「没问题」方向错:
+//    它论证的是「坏 → 好」要等重启(修 pin 伴随重启,可接受)。
+//    但 pin 也会在**运行期间由好变坏** —— 二进制被 `anet upgrade` / npm 重装换掉、
+//    被 chmod、包目录被移走。这些**都不伴随 daemon 重启**。
+//    于是 daemon 会**永远上报 can_create_nodes:true**,而 create 每次都失败。
+//    「说了但说的是开机那一刻的事」比沉默更糟:沉默至少不误导。
+//
+// 🔴 「纯浪费」这一半是量出来的,不是驳倒的 —— 量完发现它很小:
+//    realpath/stat 是微秒级;唯一重的是 sha256,本机实测 954,122 字节的
+//    read+SHA-256 **median 3.92ms**,按 3 分钟心跳 = 占空比 **0.0022%**。
+//    而且 `ANET_BIN_SHA256` **全仓没有任何代码或安装脚本会写**(readPathConf 里
+//    它是可选键),所以那一支在现场几乎从不进入。
+//    考虑过按 (abs, mtime, size) 缓存哈希 —— **否决**:那是拿一个供应链完整性
+//    校验去换 4ms,而能改写二进制的攻击者同样能改 mtime,缓存键正好被它要防的
+//    那个人控制。
+//
+// 🔴 仍然只对 host_supervisor 算。普通节点返回 undefined ⇒ 快照里完全不出现
+//    这几个字段,行为与改动前逐字相同。
+/** 只用于**日志去重**的状态(见 daemon-create-capability.ts 里的注释)。
+ *  🔴 它不参与任何判断 —— 上报的能力值每次都是现算的。 */
+const _createCapLogState: CreateCapabilityLogState = {};
+function daemonCreateCapability(): DaemonCreateCapability | undefined {
+  return evaluateCreateCapability({
+    role: fileConfig?.role,
     // 同步 require 而不是顶层 import:cli.ts 对 create-node-daemon 一直是按需加载的,
     // 保持一致,也避免非 daemon 节点为这一个函数拉进整个模块。
-    const mod = require("./runtime/create-node-daemon.js");
-    mod.loadAndVerifyAnetBin();
-    _createCapCache = { ok: true };
-  } catch (e) {
-    // 🔴 只报代码,**不报原始报错文本**。unsafePathHelp() 的消息里带完整机器路径,
-    //    而这个字段会一路走到 hub 和 Dashboard —— 一条「哪台机器的哪个路径缺什么」
-    //    本身就是一张地图。原文仍然进 daemon 自己的日志,那里是本地的。
-    // 🔴 从 Error 上读机器可读的类别。拿不到就用 anet_bin_unknown,
-    //    **不猜一个具体类别** —— 猜错会让人按错的方向去修
-    //    (「要 sudo 改系统配置」和「一行 chmod go-w」是完全不同的两件事)。
-    const code = (e as any)?.anetBinCode;
-    const known = ["anet_bin_identity","anet_bin_source","anet_bin_shape","anet_bin_permission"];
-    _createCapCache = { ok: false, reason: known.includes(code) ? code : "anet_bin_unknown" };
-  }
-  return _createCapCache;
+    probe: () => require("./runtime/create-node-daemon.js").probeAnetBinReadiness(),
+    now: () => Date.now(),
+    log,
+    logState: _createCapLogState,
+  });
 }
+
 const home = homedir();
 const peerReplyCapabilityCache = createPeerReplyCapabilityCache();
 

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -703,3 +703,77 @@ describe("#1353 create_nodes_blocked_reason —— 四类而不是一类", () =>
     expect(set.size).toBe(4);
   });
 });
+
+/* #1545 —— 「能不能」旁边必须带上「**这是什么时候测的**」。
+ *
+ * 病灶:preview.67 及更早的 daemon 用 `_createCapCache` 在开机时算一次就永久缓存。
+ * 开机好、之后二进制被 `anet upgrade` 换掉或被 chmod ⇒ 它**永远上报 ready**,
+ * 而 create 每次都失败。在 hub 上,那条记录和一条 3 秒前刚测的 ready
+ * **在 last_seen_at 上完全一样** —— 心跳是新的,那一格不是。 */
+describe("#1545 buildConfigSnapshot —— can_create_nodes 的年龄", () => {
+  const cfg = { role: "host_supervisor" };
+
+  test("给了 probedAtMs → 换算成 create_capability_observed_ms_ago", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 1,
+      { ok: true, probedAtMs: 1_000_000 }, 1_000_042);
+    expect(s.daemon_capabilities.create_capability_observed_ms_ago).toBe(42);
+  });
+
+  test("刚测的 → 0(不是缺席)", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 1,
+      { ok: true, probedAtMs: 5_000 }, 5_000);
+    expect(s.daemon_capabilities.create_capability_observed_ms_ago).toBe(0);
+  });
+
+  /* 🔴 这条是整组的重点:**缺席和 0 必须是两件事**。
+   * 旧调用点不传 probedAtMs ⇒ 那一格必须不存在,而不是 0。
+   * 渲染成 0 等于替一个从不重算的旧 daemon 宣称"这是刚测的"。 */
+  test("🔴 没给 probedAtMs → 那一格**缺席**,绝不能是 0", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 1, { ok: true });
+    expect(s.daemon_capabilities.can_create_nodes).toBe(true);   // 能力仍在
+    expect("create_capability_observed_ms_ago" in s.daemon_capabilities).toBe(false);
+    expect(s.daemon_capabilities.create_capability_observed_ms_ago).not.toBe(0);
+  });
+
+  test("blocked 时同样带年龄(坏消息也要说是什么时候的)", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 1,
+      { ok: false, reason: "anet_bin_source", probedAtMs: 100 }, 100 + 180_000);
+    expect(s.daemon_capabilities.can_create_nodes).toBe(false);
+    expect(s.daemon_capabilities.create_nodes_blocked_reason).toBe("anet_bin_source");
+    expect(s.daemon_capabilities.create_capability_observed_ms_ago).toBe(180_000);
+  });
+
+  /* 时钟被 NTP 往回拨会让 now < probedAt。夹到 0 而不是让负数流出去:
+   * 负数会被 hub 读取侧的消毒整格丢掉(读的人退回「年龄未知」),
+   * 而回拨量级(通常 < 1s)远小于这一格要分辨的尺度(分钟 vs 周)。 */
+  test("时钟回拨 → 夹到 0,不让负数流到 hub", () => {
+    const s: any = buildConfigSnapshot(cfg, true, 1,
+      { ok: true, probedAtMs: 10_000 }, 9_000);
+    expect(s.daemon_capabilities.create_capability_observed_ms_ago).toBe(0);
+  });
+
+  test("probedAtMs 不是有限数 → 当作没给(缺席),不算出 NaN", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      const s: any = buildConfigSnapshot(cfg, true, 1,
+        { ok: true, probedAtMs: bad as number }, 1000);
+      expect("create_capability_observed_ms_ago" in s.daemon_capabilities).toBe(false);
+    }
+  });
+
+  test("🔴 加了年龄也不许夹带路径(沿用 #1353 的立场)", () => {
+    const blob = JSON.stringify(buildConfigSnapshot(cfg, true, 1,
+      { ok: false, reason: "anet_bin_permission", probedAtMs: 1 }, 2));
+    expect(blob).not.toContain("/");
+    expect(blob).not.toContain("\\");
+    // 正控:真会出现在上游 e.message 里的串必须含 "/",证明上面不是恒真
+    expect("chmod go-w '/home/x/anet.cjs'").toContain("/");
+  });
+
+  test("非 daemon 节点(不传能力参数)不受影响 —— 三格都不出现", () => {
+    const s: any = buildConfigSnapshot({ role: "member" }, true, 1);
+    const caps = s.daemon_capabilities ?? {};
+    expect("can_create_nodes" in caps).toBe(false);
+    expect("create_nodes_blocked_reason" in caps).toBe(false);
+    expect("create_capability_observed_ms_ago" in caps).toBe(false);
+  });
+});

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -414,13 +414,30 @@ export interface DaemonCapabilities {
    * 🔴 只报代码,**永远不报原始报错文本**。`unsafePathHelp()` 的消息里带
    *    完整的机器路径,而这个字段会一路走到 hub 和 Dashboard ——
    *    一条「哪台机器的哪个路径缺什么」本身就是一张地图。 */
-  create_nodes_blocked_reason?:
-    | "anet_bin_identity"     // 这个文件不是 anet 的 bin ⇒ 重装或 unset ANET_BIN_ABS
-    | "anet_bin_source"       // pin 从哪来 ⇒ 写 /etc/anet-daemon/path.conf（要 sudo）
-    | "anet_bin_shape"        // 路径形态 ⇒ 换成 realpath
-    | "anet_bin_permission"   // 权限 ⇒ 一行 chmod go-w
-    | "anet_bin_unknown";     // 拿不到类别时的兜底（见下）
+  /** #1353 + #1545 —— `can_create_nodes` 是**多久以前**测出来的(毫秒)。
+   *
+   * 🔴 缺席 ≠ 0。preview.67 及更早的 daemon 在**开机时算一次**就永久缓存,
+   *    它们不发这一格;把缺席渲染成 0 等于替它们宣称"这是刚测的",
+   *    正好朝「没问题」方向说谎。读的人必须能把
+   *    「刚测的」「很久以前测的」「不知道」分成三件事说。
+   *
+   * 为什么是时长不是时间戳:见 buildConfigSnapshot 里的赋值处注释(时钟偏移)。 */
+  create_capability_observed_ms_ago?: number;
+  create_nodes_blocked_reason?: CreateNodesBlockedReason;
 }
+
+/** #1353 —— `can_create_nodes === false` 时的原因代码。
+ *
+ * 🔴 #1545:这个联合**只在这里定义一处**。此前 `agent-node/src/cli.ts` 里另有一份
+ *    同样的 `CreateBlockedReason`,两份会各自漂移 —— 而漂移的表现是「daemon 报了个
+ *    hub enum 里没有的值」,那会被 zod 静默丢掉(daemon_capabilities 非 strict),
+ *    现场看起来像"daemon 明明发了、hub 上没有"。 */
+export type CreateNodesBlockedReason =
+  | "anet_bin_identity"     // 这个文件不是 anet 的 bin ⇒ 重装或 unset ANET_BIN_ABS
+  | "anet_bin_source"       // pin 从哪来 ⇒ 写 /etc/anet-daemon/path.conf（要 sudo）
+  | "anet_bin_shape"        // 路径形态 ⇒ 换成 realpath
+  | "anet_bin_permission"   // 权限 ⇒ 一行 chmod go-w
+  | "anet_bin_unknown";     // 拿不到类别时的兜底（见下）
 
 export interface MaskedSnapshot {
   model?: string | null;
@@ -480,7 +497,17 @@ export function buildConfigSnapshot(
    *
    * `undefined` = 调用方没算(非 daemon 节点,或旧调用点)⇒ 不上报这两格,
    * 与改动前的行为逐字相同。 */
-  createCapability?: { ok: boolean; reason?: "anet_bin_pin_unresolved" },
+  createCapability?: {
+    ok: boolean;
+    /** 兼容:.40 及更早的调用点传 "anet_bin_pin_unresolved"(hub enum 仍收它)。 */
+    reason?: CreateNodesBlockedReason | "anet_bin_pin_unresolved";
+    /** #1545 —— 这次判断是什么时候做出来的(调用方的 `Date.now()`)。
+     *  给了就换算成 `create_capability_observed_ms_ago` 一起上报;
+     *  没给就**不上报那一格**(读的人据此说「年龄未知」)。 */
+    probedAtMs?: number;
+  },
+  /** #1545 测试注入点:默认取 `Date.now()`。**只为可测,不改语义。** */
+  nowMs: number = Date.now(),
 ): MaskedSnapshot {
   const out: MaskedSnapshot = {
     model: typeof fileConfig?.model === "string" ? fileConfig.model : null,
@@ -526,6 +553,23 @@ export function buildConfigSnapshot(
   // 这样旧 hub 和旧调用点的行为逐字不变。
   if (createCapability) {
     caps.can_create_nodes = createCapability.ok;
+    // #1545 —— 「能不能」旁边必须带上「**这是什么时候测的**」。
+    //
+    // 🔴 上报时长而不是绝对时间戳:这个值来自本机的钟,而 hub 拿它去和自己的钟
+    //    比较。时钟偏移下,绝对时间戳算出的年龄既可能"永远新鲜"也可能"来自 1970",
+    //    **错的方向不可预测**。时长对偏移免疫 —— hub 用自己的钟在收到时换算成绝对时间。
+    //
+    // 🔴 `Math.max(0, …)`:系统时钟可能被 NTP 往回拨,那会算出负数年龄。
+    //    夹到 0 是**朝"更旧"方向保守**的那一侧吗?不是 —— 0 表示"刚测的",
+    //    是朝"更新鲜"错。之所以仍然这么写,是因为负数会被 hub 的消毒直接丢掉
+    //    (读取侧对 `rawAge >= 0` 有断言),那等于**整格消失**、读的人退回"年龄未知";
+    //    而时钟回拨的量级(NTP 单次校正通常 < 1s)远小于这一格要分辨的尺度
+    //    (分钟 vs 周)。两害相权,保住这一格。
+    if (typeof createCapability.probedAtMs === "number"
+        && Number.isFinite(createCapability.probedAtMs)) {
+      caps.create_capability_observed_ms_ago =
+        Math.max(0, nowMs - createCapability.probedAtMs);
+    }
     if (!createCapability.ok && createCapability.reason) {
       caps.create_nodes_blocked_reason = createCapability.reason;
     }

--- a/agent-node/src/runtime/daemon-create-capability.test.ts
+++ b/agent-node/src/runtime/daemon-create-capability.test.ts
@@ -12,11 +12,11 @@ import {
   type CreateCapabilityLogState,
 } from "./daemon-create-capability.js";
 
-const READY: AnetBinProbeResult = { state: "ready", abs: "/home/vansin/.nvm/versions/node/v24.19.0/lib/node_modules/@sleep2agi/agent-network/dist/bin/cli.js" };
+const READY: AnetBinProbeResult = { state: "ready", abs: "/home/user/.nvm/versions/node/v24/lib/node_modules/@sleep2agi/agent-network/dist/bin/cli.js" };
 const BLOCKED: AnetBinProbeResult = {
   state: "blocked",
   code: "anet_bin_permission",
-  detail: "anet_bin_unsafe_path: group/other-writable. Fix: chmod go-w /home/vansin/.nvm/versions/node/v24.19.0/lib/node_modules/@sleep2agi/agent-network/dist/bin/anet.cjs",
+  detail: "anet_bin_unsafe_path: group/other-writable. Fix: chmod go-w /home/user/.nvm/versions/node/v24/lib/node_modules/@sleep2agi/agent-network/dist/bin/anet.cjs",
 };
 
 function harness(probeResults: AnetBinProbeResult[], opts: { role?: unknown; times?: number[] } = {}) {
@@ -81,9 +81,16 @@ describe("#1545 evaluateCreateCapability —— detail 不得离开本机", () =
     const blob = JSON.stringify(h.run());
     expect(blob).not.toContain("/");
     expect(blob).not.toContain("chmod");
-    expect(blob).not.toContain("vansin");
-    // 正控:detail 本身确实含路径 —— 证明上面三条不是恒真
-    expect(BLOCKED.state === "blocked" && BLOCKED.detail).toContain("/");
+    // 🔴 断言的是**夹具里真实存在的那些片段**。此前这里写的是 not.toContain("vansin"),
+    //    而夹具改成占位符 /home/user/ 之后那条就恒真了 ——
+    //    一条"永远成立"的泄露断言,和"没有泄露"长得一模一样。
+    expect(blob).not.toContain("node_modules");
+    expect(blob).not.toContain(".nvm");
+    // 正控:上面四条不是恒真 —— detail 里这四样确实都在
+    const detail = BLOCKED.state === "blocked" ? BLOCKED.detail : "";
+    for (const frag of ["/", "chmod", "node_modules", ".nvm"]) {
+      expect(detail).toContain(frag);
+    }
   });
 
   test("detail 仍然进本机日志(信息没有被丢掉,只是不上网)", () => {

--- a/agent-node/src/runtime/daemon-create-capability.test.ts
+++ b/agent-node/src/runtime/daemon-create-capability.test.ts
@@ -1,0 +1,153 @@
+// #1545 —— `evaluateCreateCapability` 的合同。
+//
+// 这个文件存在的直接原因:被测逻辑原先长在 `cli.ts` 里,而**全仓没有任何测试
+// import cli.ts**(它是 9000 行的可执行脚本,顶层就在跑)。本次改动的核心是
+// 把「开机算一次、永久缓存」改成「每次上报重算」—— 一个没有测试的缓存移除,
+// 和「我以为我移除了」在代码里长得一模一样。
+
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateCreateCapability,
+  type AnetBinProbeResult,
+  type CreateCapabilityLogState,
+} from "./daemon-create-capability.js";
+
+const READY: AnetBinProbeResult = { state: "ready", abs: "/home/vansin/.nvm/versions/node/v24.19.0/lib/node_modules/@sleep2agi/agent-network/dist/bin/cli.js" };
+const BLOCKED: AnetBinProbeResult = {
+  state: "blocked",
+  code: "anet_bin_permission",
+  detail: "anet_bin_unsafe_path: group/other-writable. Fix: chmod go-w /home/vansin/.nvm/versions/node/v24.19.0/lib/node_modules/@sleep2agi/agent-network/dist/bin/anet.cjs",
+};
+
+function harness(probeResults: AnetBinProbeResult[], opts: { role?: unknown; times?: number[] } = {}) {
+  const logs: string[] = [];
+  const logState: CreateCapabilityLogState = {};
+  let probeCalls = 0;
+  let tick = 0;
+  const times = opts.times ?? [];
+  const run = () => evaluateCreateCapability({
+    role: "role" in opts ? opts.role : "host_supervisor",
+    probe: () => {
+      const r = probeResults[Math.min(probeCalls, probeResults.length - 1)];
+      probeCalls += 1;
+      return r;
+    },
+    now: () => times[Math.min(tick++, times.length - 1)] ?? 1_000,
+    log: (m) => { logs.push(m); },
+    logState,
+  });
+  return { run, logs, probeCalls: () => probeCalls };
+}
+
+describe("#1545 evaluateCreateCapability —— 每次上报都重算", () => {
+  /* 🔴 这是整个 PR 的核心断言。原实现有 `_createCapCache`,第二次调用直接返回
+   * 缓存;若有人把它加回来,这条会红,而**其它每一条仍然会绿** ——
+   * 因为返回值的形状完全一样,只有"探了几次"能分辨。 */
+  test("🔴 连续三次调用 → 探针被调用三次(缓存真的没了)", () => {
+    const h = harness([READY]);
+    h.run(); h.run(); h.run();
+    expect(h.probeCalls()).toBe(3);
+  });
+
+  /* 反向锚:上面那条如果只是因为 harness 每次都新建对象才绿,就什么也没测。
+   * 这条证明同一个 harness 的状态确实跨调用共享(日志去重就靠它)。 */
+  test("反向锚:同一个 harness 的状态跨调用共享 ⇒ 上面数的是真的重复探测", () => {
+    const h = harness([READY]);
+    h.run(); h.run(); h.run();
+    expect(h.logs.length).toBe(1);   // 状态没变,只打一次
+  });
+
+  test("pin 在运行期间由好变坏 → 立刻反映(这是缓存版做不到的那一半)", () => {
+    const h = harness([READY, BLOCKED]);
+    expect(h.run()?.ok).toBe(true);
+    const second = h.run();
+    expect(second?.ok).toBe(false);
+    expect(second?.reason).toBe("anet_bin_permission");
+  });
+
+  test("pin 在运行期间由坏变好 → 同样立刻反映", () => {
+    const h = harness([BLOCKED, READY]);
+    expect(h.run()?.ok).toBe(false);
+    expect(h.run()?.ok).toBe(true);
+  });
+});
+
+describe("#1545 evaluateCreateCapability —— detail 不得离开本机", () => {
+  /* 🔴 unsafePathHelp() 的消息里带完整机器路径(实测形如
+   * /home/<用户名>/.nvm/versions/node/vXX/...)⇒ 带用户名。返回值会一路走到
+   * hub 和 Dashboard,而「哪台机器的哪个路径缺什么」本身就是一张地图。 */
+  test("🔴 返回值里不含 detail、不含任何路径", () => {
+    const h = harness([BLOCKED]);
+    const blob = JSON.stringify(h.run());
+    expect(blob).not.toContain("/");
+    expect(blob).not.toContain("chmod");
+    expect(blob).not.toContain("vansin");
+    // 正控:detail 本身确实含路径 —— 证明上面三条不是恒真
+    expect(BLOCKED.state === "blocked" && BLOCKED.detail).toContain("/");
+  });
+
+  test("detail 仍然进本机日志(信息没有被丢掉,只是不上网)", () => {
+    const h = harness([BLOCKED]);
+    h.run();
+    expect(h.logs.join("\n")).toContain("chmod go-w");
+  });
+});
+
+describe("#1545 evaluateCreateCapability —— 日志只在状态变化时打", () => {
+  /* 改成每 3 分钟重算之后,无条件打印 = 每天 480 行同一句话,
+   * 会把真正的变化淹掉。而变化恰恰是唯一值得记的事件。 */
+  test("状态不变 → 只打一次", () => {
+    const h = harness([BLOCKED]);
+    h.run(); h.run(); h.run();
+    expect(h.logs.length).toBe(1);
+  });
+
+  test("blocked → ready → blocked:三次变化打三条", () => {
+    const h = harness([BLOCKED, READY, BLOCKED]);
+    h.run(); h.run(); h.run();
+    expect(h.logs.length).toBe(3);
+  });
+
+  test("换了一类原因也算变化(修错方向的代价很大,值得记一条)", () => {
+    const other: AnetBinProbeResult = { state: "blocked", code: "anet_bin_source", detail: "d" };
+    const h = harness([BLOCKED, other]);
+    h.run(); h.run();
+    expect(h.logs.length).toBe(2);
+  });
+});
+
+describe("#1545 evaluateCreateCapability —— 边界", () => {
+  test("非 host_supervisor → undefined,且探针一次都不调用", () => {
+    const h = harness([READY], { role: "member" });
+    expect(h.run()).toBeUndefined();
+    expect(h.probeCalls()).toBe(0);
+  });
+
+  test("role 缺失 → 同样 undefined(不猜)", () => {
+    const h = harness([READY], { role: undefined });
+    expect(h.run()).toBeUndefined();
+    expect(h.probeCalls()).toBe(0);
+  });
+
+  test("probedAtMs 取自注入的 now(),不是常量 0", () => {
+    const h = harness([READY], { times: [1_700_000_000_000] });
+    expect(h.run()?.probedAtMs).toBe(1_700_000_000_000);
+  });
+
+  /* 🔴 时间点在**探测之前**取。探测本身要几毫秒(sha256),
+   * 若在之后取,报出去的年龄会把探测耗时算成"更新鲜"。 */
+  test("probedAtMs 在探测之前取样", () => {
+    const seen: number[] = [];
+    let t = 100;
+    const r = evaluateCreateCapability({
+      role: "host_supervisor",
+      probe: () => { seen.push(t); t += 50; return READY; },
+      now: () => { const v = t; t += 1; return v; },
+      log: () => {},
+      logState: {},
+    });
+    // now() 先跑(100),探针在那之后看到 101 —— 顺序反过来的话 probedAtMs 会是 151
+    expect(r?.probedAtMs).toBe(100);
+    expect(seen[0]).toBe(101);
+  });
+});

--- a/agent-node/src/runtime/daemon-create-capability.ts
+++ b/agent-node/src/runtime/daemon-create-capability.ts
@@ -1,0 +1,75 @@
+// #1545 —— 「这台 daemon 现在能不能创建节点」的求值,以及它**是什么时候求的**。
+//
+// 从 cli.ts 抽出来的原因很实际:cli.ts 是一个 9000 行的可执行脚本,顶层就在跑,
+// **全仓没有任何测试 import 它**。而本次改动的核心恰恰在那里 ——
+// 把「开机算一次、永久缓存」改成「每次上报重算」。一个没有测试的缓存移除,
+// 和「我以为我移除了」在代码里长得一模一样(#1545 本身就是这类问题的集合)。
+//
+// 抽出来之后,下面三件事都能被钉住:
+//   ① 连续调用**必须**每次都重新探测(缓存真的没了);
+//   ② `detail` **不进返回值**(它带机器路径,会一路走到 Dashboard);
+//   ③ 日志只在状态变化时打(每 3 分钟一次的心跳,无条件打印等于每天 480 行同一句话)。
+
+import type { CreateNodesBlockedReason } from "./config-apply.js";
+
+/** create-node-daemon.ts 的 `probeAnetBinReadiness` 的返回形状。
+ *  这里**只声明所需的那部分**,不 import 那个模块 —— cli.ts 对它一直是按需
+ *  `require` 的(非 daemon 节点不该为这一个函数拉进整个模块),保持同一策略。 */
+export type AnetBinProbeResult =
+  | { readonly state: "ready"; readonly abs: string }
+  | { readonly state: "blocked"; readonly code: CreateNodesBlockedReason; readonly detail: string };
+
+export type DaemonCreateCapability = {
+  readonly ok: boolean;
+  readonly reason?: CreateNodesBlockedReason;
+  /** 这次判断是**什么时候**做出来的(本机 `Date.now()`)。
+   *
+   *  🔴 传时间点而不是直接传 0:如果将来有人重新引入缓存,这个数会**自己变大**,
+   *     上报出去的年龄仍然是真的。传 0 的话,缓存一回来它就开始说谎,
+   *     而且没有任何东西会红。 */
+  readonly probedAtMs: number;
+};
+
+/** 只用于**日志去重**的状态。
+ *  🔴 它不参与任何判断 —— 返回的能力值每次都是现算的。
+ *     一个"只用来决定打不打日志"的变量,绝不能悄悄变成判据来源。 */
+export type CreateCapabilityLogState = { last?: "ready" | CreateNodesBlockedReason };
+
+export function evaluateCreateCapability(deps: {
+  /** 节点 config.json 里的 role。非 host_supervisor 一律返回 undefined。 */
+  readonly role: unknown;
+  /** 注入的探针(生产里是 create-node-daemon.ts 的 `probeAnetBinReadiness`)。 */
+  readonly probe: () => AnetBinProbeResult;
+  readonly now: () => number;
+  readonly log: (msg: string) => void;
+  readonly logState: CreateCapabilityLogState;
+}): DaemonCreateCapability | undefined {
+  // 只对 host_supervisor 算。普通节点返回 undefined ⇒ 快照里完全不出现这几个字段,
+  // 行为与 #1353 逐字相同。
+  if (deps.role !== "host_supervisor") return undefined;
+
+  const probedAtMs = deps.now();
+  const probe = deps.probe();
+
+  if (probe.state === "ready") {
+    if (deps.logState.last !== "ready") {
+      deps.log("[anet-daemon] #1545 create capability: ready (anet bin pin verified)");
+      deps.logState.last = "ready";
+    }
+    return { ok: true, probedAtMs };
+  }
+
+  // 🔴 只报代码,**不报 probe.detail**。unsafePathHelp() 的消息里带完整机器路径
+  //    (实测形如 /home/<用户名>/.nvm/versions/node/vXX/lib/node_modules/…),
+  //    而返回值会一路走到 hub 和 Dashboard —— 一条「哪台机器的哪个路径缺什么」
+  //    本身就是一张地图。原文只进 daemon 自己的日志,那里是本地的。
+  //    **脱敏后上报也不行**:脱掉家目录后既仍是地图(node 版本、目录布局),
+  //    又不足以定位。取舍是显式做的 —— code 全网可见,detail 只在本机。
+  if (deps.logState.last !== probe.code) {
+    deps.log(`[anet-daemon] #1545 create capability blocked: ${probe.code} — ${probe.detail}`);
+    deps.logState.last = probe.code;
+  }
+  // 分类由探针给出,这里**不再有第二份 known 白名单**
+  // (它原先在 cli.ts 里,和 create-node-daemon.ts 的分类是两份会各自漂移的判据)。
+  return { ok: false, reason: probe.code, probedAtMs };
+}


### PR DESCRIPTION
## 这是 #1545 的第二个病灶

第一个是「**没有人读**」(`can_create_nodes` 走到 hub API 就停下,`agent-network/`、
`dashboard/` 全仓 0 命中)。这个 PR 补第二个:**那一格是开机时算的,之后再没测过。**

`agent-node/src/cli.ts` 的 `daemonCreateCapability()`:

```ts
if (_createCapCache !== undefined) return _createCapCache ?? undefined;
```

| 开机那一刻 | 之后发生了什么 | daemon 永远上报 |
|---|---|---|
| pin 坏 | 运维写好了 `/etc/anet-daemon/path.conf` | `blocked` ❌ |
| pin 好 | 二进制被 `anet upgrade` / npm 重装换掉、被 `chmod`、包目录被移走 | **`ready`** ❌❌ |

第二行**朝「没问题」方向说谎**,比 #1545 抱怨的沉默更糟。而在 hub 上,那条记录和
一条 3 秒前刚测的 `ready` **在 `last_seen_at` 上完全一样** —— 心跳是新的,那一格不是。

## 我在推翻一条写着理由的注释,所以逐条答它

原注释:「算一次就缓存……代价是运行期间修好了 pin 也要重启才反映 —— 可接受,
因为修 pin 的正规做法(写 `/etc/anet-daemon/path.conf`)本来就伴随重启。」

**🔴 那个「代价」只说了一半。** 它论证的是「坏 → 好」要等重启,那半确实可接受。
但 pin 也会在运行期间**由好变坏**,而那些路径**都不伴随 daemon 重启**。
没说的那一半正好朝「没问题」方向错。

**🔴 「纯浪费」这一半我是量的,不是驳的** —— 量完发现它很小:
- `realpath`/`stat`:微秒级
- 唯一重的是 sha256:实测 **954,122 字节 read+SHA-256 median 3.92ms**(20 次,min 3.62/max 4.87)
- 按 3 分钟心跳 ⇒ 占空比 **0.0022%**
- 而且 `ANET_BIN_SHA256` **全仓没有任何代码或安装脚本会写**(`readPathConf` 里它是可选键,
  `docs-site/docs/deploy/daemon.md` 一个字没提)⇒ 那一支在现场几乎从不进入

按 `(abs, mtime, size)` 缓存哈希的方案**否决**:那是拿一个供应链完整性校验去换 4ms,
而**能改写二进制的攻击者同样能改 mtime** —— 缓存键正好被它要防的那个人控制。

## 为什么抽成独立模块(不是为了整洁)

逻辑原先长在 `cli.ts` 里,而 **全仓没有任何测试 `import` cli.ts**(9000 行、顶层就在跑)。
**一个没有测试的缓存移除,和「我以为我移除了」在代码里长得一模一样** ——
而这正是 #1545 这一类问题的形状。抽出 `runtime/daemon-create-capability.ts`
(纯函数 + 依赖注入)之后,下面这些才钉得住。

## 见证

| 变异 | 红 |
|---|---|
| **M1** 把缓存加回来 | 「连续三次调用 → 探针调三次」等 10 条 |
| **M2** 把 `detail` 塞进返回值 | 「返回值里不含 detail、不含任何路径」 |
| **M3** 日志去重失效 | 「状态不变 → 只打一次」 |

🔴 M1 我用的是 `globalThis` 级缓存,**污染面比一个忠实的模块内缓存更大**,所以红了 10 条 ——
真正钉住这条性质的是第一条。这里说清楚,免得把"红了一片"读成"覆盖很广"。

还有两条容易被忽略的:
- **反向锚**:同一 harness 的状态确实跨调用共享 —— 否则「探了三次」可能只是因为每次都
  新建对象,那条就什么也没测。
- `probedAtMs` 在**探测之前**取样(探测本身要几毫秒,取反了会把耗时算成"更新鲜"),有专门一条测顺序。

快照层另有 8 条(`config-apply.test.ts`),含两向变异:M-恒0 红 2 条、M-恒不发 红 4 条。
🔴 M-恒0 **没有**红掉「缺席」那条 —— 因为「缺席」测的是不传 `probedAtMs`,外层 `if` 仍在。核过才这么写。

## 年龄怎么传

`daemonCreateCapability()` 返回 **`probedAtMs`(时间点)**,由 `buildConfigSnapshot`
换算成 `create_capability_observed_ms_ago` 上报。

🔴 **传时间点而不是直接传 0**:将来若有人重新引入缓存,这个数会**自己变大**,上报的年龄
仍然是真的;传 0 的话,缓存一回来它就开始说谎,**而且没有任何东西会红**。
🔴 **缺席 ≠ 0**:旧 daemon 不发这一格,把缺席渲染成 0 等于替它们宣称"这是刚测的"。

## 顺带清掉一处同义副本(以及棘轮 82 → 81)

`CreateBlockedReason` 原先在 `cli.ts` 和 `config-apply.ts` **各有一份同样的取值表**。
两份一旦漂开,daemon 会报出一个 hub enum 里没有的值 —— 而 `daemon_capabilities` 非 strict
⇒ 被 zod **静默丢掉**,现场表现为「daemon 明明发了、hub 上没有」。现在只定义一处。

🔴 这也是**类型棘轮 82 → 81** 的来源:原 `createCapability.reason` 只声明了
`"anet_bin_pin_unresolved"`,而调用方传的是五类真实 code。单一来源化后那条错误消失,
基线已按门自己的要求下调。(基线是在 rebase 到最新 main 之后重算的 —— 我第一次算出的
是 85,那是基于旧 main;#1557 合入后 main 是 82。)

## 其它保持不变

- `detail` **只进本机日志**,不上报(原文形如 `/home/<用户名>/.nvm/.../anet.cjs`,带用户名;
  脱敏后既仍是地图又不足以定位 —— 取舍显式做:code 全网可见,detail 只在本机)
- 日志**只在状态变化时**打(每 3 分钟重算,无条件打印 = 每天 480 行同一句话,会淹掉真正的变化)
- 非 `host_supervisor` 节点:返回 `undefined`,探针一次都不调用,快照里三格都不出现

## 门

3 个测试文件 **190 pass / 0 fail**;
`typecheck-ratchet`(81==81)/ `test-file-coverage` / `test-suite-registration` /
`doc-symbol-anchors` / `doc-symbol-pins`(两个 doc-root)/ `doc-source-pins` → **全 rc=0**。

依赖 #1558(hub 收这一格)先合,否则新字段会被 zod 静默丢弃。

Refs #1545
