### PR TITLE
fix(gate): doc-symbol-pins 多处匹配时列出全部候选，别给一个会被照抄的单一行号 (#1561)

### DIFF
--- a/scripts/check-doc-symbol-pins.py
+++ b/scripts/check-doc-symbol-pins.py
@@ -153,11 +153,26 @@ def judge(doc: Path, repo: Path, anchor: str, rel: str, n: int,
         judged = True
         if any(abs(w - n) <= WINDOW for w in where):
             break
-        near = min(where, key=lambda w: abs(w - n))
-        findings.append(
-            f"  🔴 {doc.relative_to(repo)}  锚文本点名 `{sym}`，钉在 {rel}#L{n}，"
-            f"但那一行是:\n       {lines[n - 1].strip()[:100]}\n"
-            f"       `{sym}` 现在在第 {near} 行（共 {len(where)} 处）")
+        head = (f"  🔴 {doc.relative_to(repo)}  锚文本点名 `{sym}`，钉在 {rel}#L{n}，"
+                f"但那一行是:\n       {lines[n - 1].strip()[:100]}")
+        if len(where) == 1:
+            findings.append(f"{head}\n       `{sym}` 只出现一处，在第 {where[0]} 行:\n"
+                            f"         {where[0]:>5}  {lines[where[0] - 1].strip()[:96]}")
+        else:
+            # 🔴 多处匹配时**不给单一答案**。此前这里打印
+            #    `min(where, key=|w-n|)`(离原 pin 最近的那处),而"最近"经常是
+            #    **该符号上方的一句注释** —— 注释里自然会提到它。
+            #    照着那个数字改 pin,门**会变绿**,而文档从此指着一句注释。
+            #    2026-08-30 实测:`send_ack` 的注释在 2072、真正的工具注册在 2074,
+            #    两者相距 2 行,谁"更近"完全取决于原 pin 落在哪 —— 而它们的含义天差地别。
+            #    ⇒ 列出全部候选**并带上行内容**,把消歧交回给人。
+            #      只给几个数字是不够的:人还是会挑第一个。
+            body = "\n".join(f"         {w:>5}  {lines[w - 1].strip()[:96]}" for w in where)
+            findings.append(
+                f"{head}\n       `{sym}` 在该文件出现 {len(where)} 处，"
+                f"本门**不替你判断**该钉哪一处:\n{body}\n"
+                f"       ⚠ 别直接抄第一个数字 —— 其中很可能有**提到该符号的注释行**。"
+                f"钉到注释上门一样会绿，而文档从此指向一个不相干的位置。")
         break
     return judged
 


### PR DESCRIPTION
Closes #1561

## 问题

漂移时这道门原先打印 `min(where, key=|w-n|)` —— 离原 pin **最近**的那一处。而「最近」经常是**该符号上方的一句注释**（注释里自然会提到它）。

实测 `send_ack` 在 `server/src/tools.ts` 出现 3 处：

```
2072  // ── V2: send_ack (不入 inbox，仅更新状态) ──      ← 注释
2074      "send_ack",                                    ← 真正的工具注册
2084      console.log(… → send_ack → task …)
```

**两者相距 2 行**，谁「更近」完全取决于原 pin 落在哪 —— 而含义天差地别。照着那个数字改 pin，**门会变绿**，而文档从此指着一句注释。

## 🔴 这不是假设

#1558 的作者就撞到了，而**我当时给他的修法建议正是「按门打印的数字改」**。是他自己去核了 `origin/main` 上逐字为 `    "send_ack",` 的那一行、再按 diffstat 偏移换算，才没有钉到注释上。

**一个红把人引向假绿，比直接的假绿更难防** —— 读的人此刻正处在「门红了想赶紧修绿」的状态，**最不适合做消歧的时刻**。

## 改法

多处匹配时**不给单一答案**，列出全部候选**并带上行内容**。只给几个数字不够 —— 人还是会挑第一个，**带行内容是关键**。单处匹配时仍直接给出那一处（也带内容）。

本文件既有注释已经修过同族的另一半（子串 → 词边界，因为 `createNetwork` 会命中 `createNetworkTokenForNode`），并写着「**一个会被照抄的错行号，比不给提示更糟**」。本 PR 把同一条原则推到多处匹配的情形。

## 两向见证

```
main 内容                    SYMBOL-PIN: OK   漂移 0   rc=0
故意把 send_ack pin 改到 L1500  SYMBOL-PIN: RED  漂移 1   rc=1
                             输出列出 2072/2074/2084 三行**及其内容**，
                             并警告「别直接抄第一个数字」
还原                          rc=0
```

## 更正我在 #1561 里的一处描述

我在 issue 里写「门打印的是**该词最早出现处**」—— **不准确**。实际是 `min(where, key=|w-n|)`，**离原 pin 最近的那一处**。结论不变（打印的可能是注释、照抄会假绿），但机制描述我更正在此。