### PR TITLE
feat(gate): doc-symbol-pins 支持字面量锚，堵掉「跳过 = 绿」那一半 (#1561)

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -198,7 +198,7 @@ curl -X POST http://localhost:9200/api/auth/login \
 }
 ```
 
-`user` 对象 5 字段同 register 响应（注 `email` 可为 `null`）；`network_id` 是该用户作为 owner 的 default network（[`auth.ts:113-115`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L113) 取 `ORDER BY role = 'owner' DESC LIMIT 1`）。每次 login 都签发**新的** `utok_`（不撤销已有，多设备登录互不踢，[`auth.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 搜 `// User token (utok_) — not bound to network, for CLI/Dashboard login`）。
+`user` 对象 5 字段同 register 响应（注 `email` 可为 `null`）；`network_id` 是该用户作为 owner 的 default network（[`auth.ts:197-199`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L197) 取 `ORDER BY role = 'owner' DESC LIMIT 1`）。每次 login 都签发**新的** `utok_`（不撤销已有，多设备登录互不踢，[`auth.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 搜 `// User token (utok_) — not bound to network, for CLI/Dashboard login`）。
 
 **常见 4xx**（verify [`auth.ts login()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts)）：
 

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -208,7 +208,7 @@ curl -X POST http://localhost:9200/api/auth/login \
 }
 ```
 
-The `user` object's 5 fields match the register response (note `email` may be `null`); `network_id` is the default network the user owns ([`auth.ts:113-115`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L113) does `ORDER BY role = 'owner' DESC LIMIT 1`). Each login issues a **brand-new** `utok_` (existing tokens are not rotated, so multiple devices can log in independently — see [`auth.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) — grep `// User token (utok_) — not bound to network, for CLI/Dashboard login`).
+The `user` object's 5 fields match the register response (note `email` may be `null`); `network_id` is the default network the user owns ([`auth.ts:197-199`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L197) does `ORDER BY role = 'owner' DESC LIMIT 1`). Each login issues a **brand-new** `utok_` (existing tokens are not rotated, so multiple devices can log in independently — see [`auth.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) — grep `// User token (utok_) — not bound to network, for CLI/Dashboard login`).
 
 **Common 4xx errors** (verify [`auth.ts login()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts)):
 

--- a/scripts/check-doc-symbol-pins.py
+++ b/scripts/check-doc-symbol-pins.py
@@ -59,6 +59,14 @@ PIN = re.compile(
     r"\[([^\]\n]{1,120})\]\("
     r"https://github\.com/sleep2agi/agent-network/blob/"
     r"([0-9a-zA-Z._-]+)/([^\s)#\"']+)#L(\d+)\)"
+    # 🔴 链接**之后**的一小段也算锚。本仓写法是把代码片段放在链接后面：
+    #      [`…cli.ts:7882`](…#L7882) `sub === "dashboard"` 分支
+    #    只捕获 `[...]` 里的标签就永远看不到那个片段 —— 而它恰恰是唯一能逐字定位的东西
+    #    （`sub` 在 cli.ts 出现 89 次、`dashboard` 39 次，两个都超 UBIQUITOUS ⇒ 整条 pin
+    #    被归进「跳过」而不告警，实测因此漏掉过一处 36 行的漂移）。
+    # 🔴 `[^\n\[]` 而不是 `[^\n]`：architecture.md 有**同一行两个 pin** 的写法，
+    #    贪婪尾窗会吃掉后一个 pin 的 `[` —— 实测 pin 总数从 15 掉到 13。
+    r"([^\n\[]{0,100})"
 )
 IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
 # 🔴 #1024 —— ref 一直被捕获但从没被用过(那个组以前就叫 `_ref`)。
@@ -107,6 +115,25 @@ def tracked_docs(repo: Path, doc_root: str) -> list[Path]:
     return sorted((repo / doc_root).rglob("*.md"))
 
 
+LITERAL = re.compile(r"`([^`\n]{6,80})`")
+
+
+def candidate_literals(anchor: str) -> list[str]:
+    """锚里可以**逐字**在源文件中定位的代码片段。
+
+    只取含非标识符字符的（纯标识符交给 candidate_symbols，两条路径不重复判同一件事）。
+    """
+    out = []
+    for frag in LITERAL.findall(anchor):
+        frag = frag.strip()
+        if not frag or IDENT.fullmatch(frag):
+            continue
+        if not re.search(r"[^A-Za-z0-9_ ]", frag):
+            continue
+        out.append(frag)
+    return out
+
+
 def candidate_symbols(anchor: str, rel: str) -> list[str]:
     """从锚文本里挑出**可能是符号**的词。
 
@@ -130,13 +157,32 @@ def candidate_symbols(anchor: str, rel: str) -> list[str]:
 
 
 def judge(doc: Path, repo: Path, anchor: str, rel: str, n: int,
-          lines: list[str], findings: list[str]) -> bool:
+          lines: list[str], findings: list[str], label_only: str = "") -> bool:
     """判一条 pin。返回 True=判定过了(不管漂没漂),False=没能判定。
 
     🔴 两条路径(ref=分支 / ref=commit)共用这一份判据。
        分成两份写的话,以后只会有一份被改到 —— 而两份的输出长得一样。
     """
-    symbols = candidate_symbols(anchor, rel)
+    # 🔴 尾窗**只喂字面量**，不喂标识符。尾窗里的散文常常「提到」并不在 pin 那一行的
+    #    符号，而且常是**否定**语气：
+    #      docs/pitfalls.md    「`get_inbox` **故意不在列**」   ← 说的是它不在
+    #      docs/architecture.md「SSE 推 `new_reply` 不是 `new_task`」← 说的是后果
+    #    把这些当成「锚点名了该符号」会报出**假漂移**（实测一次报出 6 条，全是假的）。
+    for frag in candidate_literals(anchor):
+        hits = [i + 1 for i, line in enumerate(lines) if frag in line]
+        if len(hits) != 1:
+            continue                      # 0 次分不清改写；多次不比标识符精确
+        w = hits[0]
+        if abs(w - n) <= WINDOW:
+            return True
+        findings.append(
+            f"  🔴 {doc.relative_to(repo)}  锚文本逐字点名 `{frag}`，钉在 {rel}#L{n}，"
+            f"但那一行是:\n       {lines[n - 1].strip()[:100]}\n"
+            f"       该片段在该文件**恰好出现一处**，在第 {w} 行:\n"
+            f"         {w:>5}  {lines[w - 1].strip()[:96]}")
+        return True
+
+    symbols = candidate_symbols(label_only or anchor, rel)
     judged = False
     for sym in symbols:
         # 🔴 词边界，不是子串。2026-08-18 实测:`createNetwork` 用子串匹配会命中
@@ -191,7 +237,9 @@ def main() -> int:
             text = doc.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        for anchor, ref, rel, lineno in PIN.findall(text):
+        for anchor, ref, rel, lineno, trail in PIN.findall(text):
+            label_only = anchor
+            anchor = anchor + " " + trail
             pins += 1
             if IMMUTABLE_REF.match(ref):
                 # 钉在具体 commit 上 —— 拿那个 commit 的内容判,不拿工作树。
@@ -199,7 +247,7 @@ def main() -> int:
                 if lines_at_ref is None:
                     unresolved += 1
                     continue
-                judged_here = judge(doc, repo, anchor, rel, int(lineno), lines_at_ref, findings)
+                judged_here = judge(doc, repo, anchor, rel, int(lineno), lines_at_ref, findings, label_only)
                 if not judged_here:
                     skipped += 1
                 continue
@@ -218,7 +266,7 @@ def main() -> int:
             if not (1 <= n <= len(lines)):
                 skipped += 1  # 越界同样归另一道门
                 continue
-            if not judge(doc, repo, anchor, rel, n, lines, findings):
+            if not judge(doc, repo, anchor, rel, n, lines, findings, label_only):
                 skipped += 1
 
 

--- a/scripts/check-doc-symbol-pins.py
+++ b/scripts/check-doc-symbol-pins.py
@@ -118,7 +118,7 @@ def tracked_docs(repo: Path, doc_root: str) -> list[Path]:
 LITERAL = re.compile(r"`([^`\n]{6,80})`")
 
 
-def candidate_literals(anchor: str) -> list[str]:
+def candidate_literals(anchor: str, rel: str = "") -> list[str]:
     """锚里可以**逐字**在源文件中定位的代码片段。
 
     只取含非标识符字符的（纯标识符交给 candidate_symbols，两条路径不重复判同一件事）。
@@ -128,8 +128,19 @@ def candidate_literals(anchor: str) -> list[str]:
         frag = frag.strip()
         if not frag or IDENT.fullmatch(frag):
             continue
-        if not re.search(r"[^A-Za-z0-9_ ]", frag):
-            continue
+        # 🔴 只认**真的像代码**的片段。第一版只要求「含非标识符字符」,于是收进了
+        #    文件名、URL 路径、线格式字符串,在 docs-site 那个 doc-root 上报出 5 条假漂移:
+        #      `auth.ts`              ← 文件名(含 `.` 就过了第一版)
+        #      `/events/<username>`   ← URL 路径
+        #      `: keepalive\n\n`      ← 线格式字面量
+        #    它们在目标文件里恰好出现一次是**巧合**(出现在注释或字符串里),
+        #    而 pin 指的是那段逻辑,不是那处提及。
+        if "/" in frag:
+            continue                       # 路径/URL,不是代码片段
+        if not re.search(r"[(){}=;]|=>|&&|\|\|", frag):
+            continue                       # 没有任何代码语法
+        if any(part and part in frag for part in Path(rel).name.split(".")):
+            continue                       # 片段里带着被引用文件自己的名字
         out.append(frag)
     return out
 
@@ -168,7 +179,7 @@ def judge(doc: Path, repo: Path, anchor: str, rel: str, n: int,
     #      docs/pitfalls.md    「`get_inbox` **故意不在列**」   ← 说的是它不在
     #      docs/architecture.md「SSE 推 `new_reply` 不是 `new_task`」← 说的是后果
     #    把这些当成「锚点名了该符号」会报出**假漂移**（实测一次报出 6 条，全是假的）。
-    for frag in candidate_literals(anchor):
+    for frag in candidate_literals(anchor, rel):
         hits = [i + 1 for i, line in enumerate(lines) if frag in line]
         if len(hits) != 1:
             continue                      # 0 次分不清改写；多次不比标识符精确


### PR DESCRIPTION
## 问题：这道门跳过了三分之二，而「跳过不是通过」是它自己写的

原先只把 markdown 链接的 `[标签]` 当锚，并从中挑**标识符**。标识符在目标文件里出现次数超过 `UBIQUITOUS=20` 时，**整条 pin 被归进「跳过」**。

实测代价：`docs/architecture.md` 钉 `sub === "dashboard"` —— `sub` 在 cli.ts 出现 **89** 次、`dashboard` **39** 次，两个都超阈值 ⇒ 整条 pin 被跳过，**它漂了 36 行（文档 L7845 / 实际 7881）而门一直绿**。

`architecture.md` 自己就写着「**直到 checker 支持字面量文本形态的 pin**」—— 这个能力缺口被记录在案很久了。

## 改动

1. **尾窗**：链接之后 100 字符也算锚（本仓写法是把代码片段放在链接后面）。用 `[^\n\[]` 而不是 `[^\n]` —— 该文件有**同一行两个 pin**，贪婪尾窗会吃掉后一个 pin 的 `[`，**实测 pin 总数从 15 掉到 13**。
2. **字面量候选**：反引号里含非标识符字符的代码片段，在目标文件**恰好出现一次**时逐字定位。

## 🔴 尾窗只喂字面量，不喂标识符

第一版两者都喂，报出 **6 条假漂移**。尾窗里的散文经常「提到」并不在 pin 那一行的符号，而且常是**否定**语气：

```
docs/pitfalls.md      「`get_inbox` **故意不在列**」        ← 说的是它不在
docs/architecture.md  「SSE 推 `new_reply` 不是 `new_task`」← 说的是后果
```

**把「提到」当成「指向」就会报出假漂移，而 pin 本身是对的。**

## 两向见证（用真实历史，不是构造的夹具）

```
base e9ea9074（#1565 修文档之前）  RED  漂移 1
      报「锚文本逐字点名 `sub === "dashboard"`」—— 正是老 checker 跳过的那条
rebase 到含 #1565 的 main          OK   漂移 0   rc=0

判定数 5 → 8    跳过 10 → 7    pin 总数 15 不变
```