### PR TITLE
feat(pkg): #1545 把 describeCapability 作为子路径导出,供 Dashboard 复用

### DIFF
--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/src/client.js",
       "types": "./dist/client.d.ts"
+    },
+    "./daemon-capability-display": {
+      "import": "./dist/src/daemon-capability-display.js",
+      "types": "./dist/src/daemon-capability-display.d.ts"
     }
   },
   "bin": {
@@ -20,7 +24,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test:feishu-bridge": "bun tests/feishu-bridge-ackplaceholder.test.ts",
-    "build": "bun build src/client.ts --outdir dist/src --target node --minify && bun build bin/cli.ts --outdir dist/bin --target node --minify --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' && bun build src/node-server.ts --outdir dist/src --target node --minify && bun build src/im/feishu/worker.ts --outdir dist/src/im/feishu --target node --minify --external @larksuiteoapi/node-sdk && tsc --emitDeclarationOnly --declaration --outDir dist && npx javascript-obfuscator dist/bin/cli.js --output dist/bin/cli.js --compact true --string-array true --string-array-encoding base64 && npx javascript-obfuscator dist/src/client.js --output dist/src/client.js --compact true --string-array true && npx javascript-obfuscator dist/src/node-server.js --output dist/src/node-server.js --compact true --string-array true && cp bin/anet.cjs dist/bin/anet.cjs",
+    "build": "bun build src/client.ts --outdir dist/src --target node --minify && bun build src/daemon-capability-display.ts --outdir dist/src --target browser --minify && bun build bin/cli.ts --outdir dist/bin --target node --minify --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' && bun build src/node-server.ts --outdir dist/src --target node --minify && bun build src/im/feishu/worker.ts --outdir dist/src/im/feishu --target node --minify --external @larksuiteoapi/node-sdk && tsc --emitDeclarationOnly --declaration --outDir dist && npx javascript-obfuscator dist/bin/cli.js --output dist/bin/cli.js --compact true --string-array true --string-array-encoding base64 && npx javascript-obfuscator dist/src/client.js --output dist/src/client.js --compact true --string-array true && npx javascript-obfuscator dist/src/node-server.js --output dist/src/node-server.js --compact true --string-array true && cp bin/anet.cjs dist/bin/anet.cjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/agent-network/src/daemon-capability-display.test.ts
+++ b/agent-network/src/daemon-capability-display.test.ts
@@ -148,3 +148,55 @@ describe("#1545 修法命令 —— 必须能整行粘贴", () => {
     expect(fixOf("anet_bin_permission").command).toContain("command -v anet");
   });
 });
+
+/* 🔴 #1545 —— 这个模块是**跨仓共享**的:Dashboard(另一个仓)通过
+ * `@sleep2agi/agent-network/daemon-capability-display` 子路径导入它,在**浏览器里**跑。
+ *
+ * 共享的不是文案,是**判据**:年龄算法 `(now − last_seen_at) + observed_ms_ago`,
+ * 和 code →(explain, command)映射。两边各写一份就会分叉,而
+ * 「CLI 说 ready、Dashboard 说 blocked」比两边都沉默更难查。
+ *
+ * 下面这组钉的是**让共享成立的那几个前提**。它们平时不会有人想起来,
+ * 而破坏它们的改动看起来都完全正常(加一个 import、给 build 加一条混淆)。 */
+describe("#1545 跨仓共享的前提(Dashboard 在浏览器里 import 这个模块)", () => {
+  const pkg = require("../package.json");
+  const SUBPATH = "./daemon-capability-display";
+
+  test("package.json 暴露了这个子路径(Node 会按 exports 拦掉未声明的子路径)", () => {
+    expect(pkg.exports[SUBPATH]).toBeTruthy();
+    expect(pkg.exports[SUBPATH].import).toBe("./dist/src/daemon-capability-display.js");
+    expect(pkg.exports[SUBPATH].types).toBe("./dist/src/daemon-capability-display.d.ts");
+  });
+
+  test("build 里有对应的独立入口(否则 exports 指向一个不存在的文件)", () => {
+    expect(pkg.scripts.build).toContain("bun build src/daemon-capability-display.ts");
+  });
+
+  /* 🔴 它**不能**被混淆。同 build 里 client.js / cli.js / node-server.js 走
+   * javascript-obfuscator --string-array;把一个给别的仓读的纯格式化函数塞进那条链,
+   * 拿到的是一份连报错都难读的依赖。 */
+  test("它不在 javascript-obfuscator 的目标列表里", () => {
+    const targets = [...String(pkg.scripts.build).matchAll(/javascript-obfuscator (\S+)/g)].map(m => m[1]);
+    expect(targets.length).toBeGreaterThan(0);          // 分母自证:确实抓到了目标列表
+    expect(targets).not.toContain("dist/src/daemon-capability-display.js");
+    // 正控:那三个确实在列 —— 证明上一条不是因为正则没匹配到东西才绿
+    expect(targets).toContain("dist/src/client.js");
+  });
+
+  /* 🔴 最要紧的一条:这个模块**一个 import 都不能有**。
+   * 它要在浏览器里跑;一旦有人加了 `node:fs` / `node:crypto`,
+   * Dashboard 的构建**未必会报错**(打包器可能把它 external 掉),
+   * 而是**运行时才炸** —— 那种错误离这行改动很远,几乎不可能被联想回来。 */
+  test("🔴 源文件没有任何 import / require(它要在浏览器里跑)", () => {
+    const src = require("node:fs").readFileSync(
+      new URL("./daemon-capability-display.ts", import.meta.url), "utf-8") as string;
+    const offenders = src.split("\n")
+      .map((l, i) => [i + 1, l] as const)
+      .filter(([, l]) => /^\s*import\s|require\s*\(/.test(l));
+    expect(offenders).toEqual([]);
+    // 正控:同一个模式在**本测试文件**上必须命中(它有 import),证明不是恒空
+    const self = require("node:fs").readFileSync(
+      new URL("./daemon-capability-display.test.ts", import.meta.url), "utf-8") as string;
+    expect(self.split("\n").filter(l => /^\s*import\s|require\s*\(/.test(l)).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Dashboard(另一个仓)要显示同一格「这台 daemon 能不能建节点」。**共享的不是文案,
是判据** —— 年龄算法 `(now − last_seen_at) + observed_ms_ago`,和
code →(explain, command)映射(拿不到类别时 `command: null` 不硬凑)。
两边各写一份就会分叉,而「CLI 说 ready、Dashboard 说 blocked」比两边都沉默更难查。

在此之前**做不到**,三处挡着,都是量出来的:
  ① exports 只有 "."           ⇒ Node 按 exports 拦掉子路径导入
  ② client.js 走 obfuscator     ⇒ re-export 出去的是一份混淆产物
  ③ Dashboard 对本包零依赖      ⇒ 这是新建一条跨仓耦合,不是加一行 import

## 产物实测(合并前的前置条件,不是推论)

用真 tarball 装进 Dashboard、改 HostSupervisorPicker 真 import、跑生产构建:

  客户端 chunk  1,901,843 → 1,904,877 bytes   **+3,034 B(+2.96 KB,+0.160%)**
  chunk 数      35 → 35(没有新增 chunk)
  node:/bun: 前缀导入(.next/static/chunks)   **0**

🔴 两个自证,缺一不可:
- **正控**:同一个 grep 模式在 `.next/server` 上命中 **46 个文件** ——
  所以 static/chunks 的「0」是真的没有,不是模式写错了恒空。
- **分母自证**:新代码确实出现在浏览器 chunk 里(`创建能力` 命中 3 次)——
  否则「体积没涨」可能只是因为它被 tree-shake 掉了,那测的是"什么都没发生"。

产物 2,989 B,不混淆,带 .d.ts;`bun build --target browser`;
源模块 **import 数 = 0**,结构上就拉不进 node 内建。

## 三条让共享成立的前提,已钉住(4 条测试)

  子路径出现在 exports        M3 拿掉它            → 红
  build 有对应独立入口
  不在 obfuscator 目标列表     M2 把它加进混淆目标  → 红
  源文件 0 个 import/require   M1 加一个 node: 导入 → 红

🔴 最后那条最要紧:加了 `node:fs` 之后 **Dashboard 的构建未必会报错**
   (打包器可能 external 掉),而是**运行时才炸** —— 那种错误离这行改动很远,
   几乎不可能被联想回来。所以用测试挡在这一侧。
两条正控:obfuscator 目标列表确实抓到了东西(client.js 在列);
"0 个 import" 那条的同一模式在本测试文件上必须命中。

## 版本偏移

新 daemon 报一个旧 Dashboard 不认识的 code 时,走「未知原因代码 X」+ `command: null`,
**不套用任何一条已知修法**(已有测试 `anet_bin_from_the_future`)。
偏移时它朝「我不知道」退,不朝「猜一个」退。

Refs #1545

---

## 完整测量记录(供复核)

构建配置两次完全相同,只差 `npm install <tarball>` + 组件里一个 import 和一处渲染。

```
基线   .next/static/chunks   1,901,843 B / 35 files
之后   .next/static/chunks   1,904,877 B / 35 files
增量                          +3,034 B  (+2.96 KB, +0.160%)

grep -rlE '"(node|bun):' .next/static/chunks   → 0 个文件
grep -rlE '"(node|bun):' .next/server          → 46 个文件   ← 正控
grep -c '创建能力' .next/static/chunks/1jr-*.js  → 3          ← 分母自证
```

子路径导入在**真安装的 tarball** 上验过(不是靠 tsconfig paths):
```
子路径导入 OK, 导出: describeCapability,formatAge
创建能力:**不可用**(anet_bin_permission,3s 前测)
```

## 顺带更正我自己一处证据

我此前说过「`agent-network/` 和 `dashboard/` **全仓 0 命中**」。
**结论对,证据错**:agent-network 这个仓里**根本没有 `dashboard/` 目录**,
那半个 grep 匹配的是一个不存在的路径,所以它必然返回 0 ——
我把「路径不存在」读成了「没有人读」。

在**真的 Dashboard 仓**里重新量过:`can_create_nodes` / `create_nodes_blocked_reason`
命中 **0**(它确实只用 `/api/host-supervisors` 列 daemon,不看这两格)。
结论站得住,但它此前是**靠巧合站住的**。

好消息是那条代理路由 `app/api/anet/host-supervisors/route.ts` 把 `daemons` **原样透传**
(没有字段白名单),所以新字段能到组件,不会在中间再被静默丢一次。

Refs #1545