### PR TITLE
release(agent-network): 2.3.0-preview.70 —— 让子路径导出真正到 npm

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.69",
+  "version": "2.3.0-preview.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.69",
+      "version": "2.3.0-preview.70",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.69",
+  "version": "2.3.0-preview.70",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.69";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.70";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.54";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.69 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.70 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.69` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.70` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.69 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.70 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.69`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.70`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.70.md
+++ b/docs/tests/release-v2.3.0-preview.70.md
@@ -1,0 +1,49 @@
+# @sleep2agi/agent-network 2.3.0-preview.70
+
+## 为什么发这一版
+
+`.69` 已在 npm（2026-08-30T03:42Z）。**它的 `exports` 里只有 `"."`** ——
+`./daemon-capability-display` 子路径导出是 #1568 合入的，晚于 `.69` 出包。
+
+```
+npm view @sleep2agi/agent-network@2.3.0-preview.69 exports
+→ { ".": { import: "./dist/src/client.js", types: "./dist/client.d.ts" } }
+```
+
+⇒ Dashboard 复用 `describeCapability` 这条路**在 `.69` 上走不通**，必须发 `.70`。
+
+🔴 **注意这里有一个会骗人的对照**：`.69` 之前 `agent-network/package.json` 里写的也是
+`2.3.0-preview.69`，与 npm 上的版本号**逐字相同** —— 只看版本号会得出「已经发过了」。
+**判据必须是产物内容**（这里比的是 `exports` 键），不是版本号。
+
+## 这一版包含什么（#1545 一条完整的链）
+
+| PR | 内容 |
+|---|---|
+| #1555 | `probeAnetBinReadiness` —— 把 anet_bin 判定变成不抛异常、可被问出来的值 |
+| #1558 | hub 收下并带出 `create_capability_observed_ms_ago`（那一格是**多久以前**测的） |
+| #1560 | daemon 拆掉进程级缓存，**每次上报重算**并带年龄 |
+| #1565 | `anet daemon list` 说出「这台 daemon 现在能不能建节点」，五种情况五句不同的话 |
+| #1567 | 文档改掉与工具**相反**的那句话（原文说 `anet daemon list` 只读本机配置） |
+| #1568 | 子路径导出 `./daemon-capability-display`，供 Dashboard 复用**同一份判据** |
+
+另含本轮的工程质量改动：agent-node 首次拥有类型检查棘轮（#1550，基线 86 → 81）、
+`doc-symbol-pins` 支持字面量锚并因此捞出一处 85 行的真实漂移（#1566）、
+`check-docs-site-drift` 不再把代码围栏里的行当指纹（#1552）。
+
+## 发布方式
+
+`release-gate (v0)` workflow_dispatch，`package=agent-network`、
+`version=2.3.0-preview.70`、`publish=true`。**四道门全绿才发**，且**只发 preview 通道**。
+promote 到 latest 需要 owner ACK，本次**不做**。
+
+## 验收判据（发完必须自己核，别只看 workflow 绿）
+
+```bash
+npm view @sleep2agi/agent-network dist-tags.preview        # 期望 2.3.0-preview.70
+npm view @sleep2agi/agent-network@2.3.0-preview.70 exports # 期望含 ./daemon-capability-display
+```
+
+🔴 **第二条不能省**：workflow 绿说明「发布这个动作成功了」，
+而这一版存在的全部理由是**那个子路径导出真的在包里**。
+两者不是一回事 —— `.69` 就是「发布成功、但要的东西不在里面」。


### PR DESCRIPTION
## 为什么

`.69` 已在 npm（03:42Z），但**它的 `exports` 里只有 `"."`** —— `./daemon-capability-display` 是 #1568 合入的，**晚于 `.69` 出包**：

```
npm view @sleep2agi/agent-network@2.3.0-preview.69 exports
→ { ".": { import: "./dist/src/client.js", types: "./dist/client.d.ts" } }
```

⇒ Dashboard 复用 `describeCapability`（方案 A，产物影响已实测 +3,034 B、浏览器 chunk 里 0 个 node/bun 导入、正控 46 个）**在 `.69` 上走不通**。

🔴 **一个会骗人的对照**：`.69` 之前 `package.json` 写的也是 `2.3.0-preview.69`，与 npm 上**逐字相同** —— 只看版本号会得出「已经发过了」。**判据必须是产物内容**（这里比 `exports` 键）。

## 改动

- `sync-pinned-versions.sh --apply`：package.json / package-lock.json / opencode-agent-node-pair.ts
- **手工**（脚本不覆盖，是记录在案的发版坑）：两份 `getting-started.md` 的**机器戳 + 人读表格行**
- 新增 `docs/tests/release-v2.3.0-preview.70.md`（`release.yml:429` 会读它当 release notes）

## 🔴 改数字之前先验了它附带的断言

那张表的行不只是版本号，它带着一句断言：「生成密码的 `server/src/auth.ts` 自 `.49` 起零提交，逻辑逐字未变」。

```
git log --since=2026-08-27T02:25Z -- server/src/auth.ts  → 0 条（最后一次 2026-08-12）
```

断言仍成立，所以只改版本号是安全的。**否则就是把一个过期断言原样搬到新版本上。**

## 门

`check-doc-version-claims` rc=0（「每一条被标记的版本断言都指着正在发的那个版本」）、`home-path-baseline` rc=0、`doc-symbol-pins --doc-root docs-site` rc=0。

## 合入后

用 `release-gate (v0)` 发 **preview 通道**（`publish=true`，四道门全绿才发）。**promote 到 latest 需要 owner ACK，本次不做。**