### PR TITLE
fix(release): release notes 补 `## Install` / `## Upgrade`（gate 3 硬要求）

### DIFF
--- a/docs/tests/release-v2.3.0-preview.70.md
+++ b/docs/tests/release-v2.3.0-preview.70.md
@@ -31,6 +31,33 @@ npm view @sleep2agi/agent-network@2.3.0-preview.69 exports
 `doc-symbol-pins` 支持字面量锚并因此捞出一处 85 行的真实漂移（#1566）、
 `check-docs-site-drift` 不再把代码围栏里的行当指纹（#1552）。
 
+## Install
+
+新装（首次使用）：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.70
+anet --version
+```
+
+## Upgrade
+
+已经装过的：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.70
+anet --version        # 应显示 2.3.0-preview.70
+```
+
+🔴 **升级完请顺手核一条**，因为这一版存在的全部理由就是那个子路径导出：
+
+```bash
+npm view @sleep2agi/agent-network@2.3.0-preview.70 exports
+# 期望含 "./daemon-capability-display"
+```
+
+`.69` 正是「发布成功、但要的东西不在里面」—— 它的 `exports` 只有 `"."`。
+
 ## 发布方式
 
 `release-gate (v0)` workflow_dispatch，`package=agent-network`、


### PR DESCRIPTION
`release-gate` 的 **gate 3** 断言三件事，我写 `docs/tests/release-v2.3.0-preview.70.md` 时**一条都没满足**：

```
^## Install\b   存在
^## Upgrade\b   存在
Install 段落里必须出现 @<被发的版本>
```

workflow 里记着这道门的来历：

> v0.10.2 shipped without `## Install` and new users had no install path.
> v0.10.7 had stale `@version` in Install section.

**两次都是发出去之后、新用户没有安装路径才发现的。**

🔴 **我是在门跑之前读了它的断言才发现的，不是等它红。** 当时 `build tarball` 已 success、四道门在排队 —— 如果不读，这次发版会在 gate 3 上红，然后要重新走一遍完整流程。

本地按 gate 3 的**原样判据**模拟过（包括它那段取 Install 区块的 awk）：

```
## Install    present
## Upgrade    present
Install block mentions @2.3.0-preview.70  ✓
```