### PR TITLE
fix(cli): 创建能力那几行塞进 80 列，并把宽度做成常驻判据

### DIFF
--- a/agent-network/src/daemon-capability-display.test.ts
+++ b/agent-network/src/daemon-capability-display.test.ts
@@ -200,3 +200,45 @@ describe("#1545 跨仓共享的前提(Dashboard 在浏览器里 import 这个模
     expect(self.split("\n").filter(l => /^\s*import\s|require\s*\(/.test(l)).length).toBeGreaterThan(0);
   });
 });
+
+/* 🔴 2026-08-30 macOS 真机验收(Mac打包牛)发现:合成的首行约 99 列,80 列终端折行,
+ * 而折点落在句子中间。本模块其余细节本来就各占一行 —— 那一句是唯一的例外。
+ * 这条测试把"每一行都要能塞进 80 列"变成常驻判据,而不是靠人再去数一次。
+ * 宽度按**显示列**算:CJK 占 2 列,不是按字符数(按字符数会漏掉正好是这一类问题)。 */
+function displayWidth(s: string): number {
+  let n = 0;
+  for (const ch of s) n += /[\u2E80-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFFEF]/.test(ch) ? 2 : 1;
+  return n;
+}
+
+describe("#1545 输出宽度 —— 每一行都要塞进 80 列", () => {
+  const NOW = 1_760_000_000_000;
+  const iso = (ms: number) => new Date(ms).toISOString();
+  const rows: Array<[string, any]> = [
+    ["blocked",             { can_create_nodes: false, create_nodes_blocked_reason: "anet_bin_permission", create_capability_observed_ms_ago: 0, last_seen_at: iso(NOW - 3000) }],
+    ["blocked-age-unknown", { can_create_nodes: false, create_nodes_blocked_reason: "anet_bin_permission" }],
+    ["ready",               { can_create_nodes: true, create_capability_observed_ms_ago: 0, last_seen_at: iso(NOW - 3000) }],
+    ["ready-age-unknown",   { can_create_nodes: true }],
+    ["never-reported",      {}],
+  ];
+
+  // 🔴 分母自证:这 5 行必须真的产出 5 个**不同**的 kind。
+  //    少一个,下面的宽度检查会不知不觉少覆盖一种情况而仍然全绿。
+  test("五种情况确实产出五个不同的 kind", () => {
+    const kinds = new Set(rows.map(([, r]) => describeCapability(r, NOW).kind));
+    expect(kinds.size).toBe(5);
+  });
+
+  test.each(rows)("%s 的每一行都 <= 80 显示列", (_name, row) => {
+    const lines = describeCapability(row as any, NOW).line.split("\n");
+    expect(lines.length).toBeGreaterThan(0);
+    for (const L of lines) expect(displayWidth(L)).toBeLessThanOrEqual(80);
+  });
+
+  // 正控:证明 displayWidth 不是恒返回小值 —— 一个恒 0 的实现能让上面全绿。
+  test("displayWidth 把 CJK 算成 2 列(否则上面的检查是空的)", () => {
+    expect(displayWidth("abcd")).toBe(4);
+    expect(displayWidth("中文")).toBe(4);
+    expect(displayWidth("中a")).toBe(3);
+  });
+});

--- a/agent-network/src/daemon-capability-display.ts
+++ b/agent-network/src/daemon-capability-display.ts
@@ -127,7 +127,8 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
   if (typeof row.can_create_nodes !== "boolean") {
     return {
       kind: "never-reported",
-      line: "创建能力:未知 —— 这台 daemon 没报过这一格(agent-node 版本早于 preview.55)。升级它才能看到。",
+      line: ("创建能力:未知 —— 这台 daemon 没报过这一格。\n" +
+        "    (agent-node 版本早于 preview.55;升级它才能看到)"),
     };
   }
 
@@ -146,7 +147,8 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
         // 🔴 这句必须说清「不知道什么时候测的」**以及为什么**。
         //    preview.67 及更早的 daemon 在开机时算一次就永久缓存 —— 也就是说
         //    这个 ready 可能是几周前的事,而二进制早被换掉了。
-        line: "创建能力:可用,但**不知道是什么时候测的** —— 该 daemon 版本在开机时算一次就不再重测。重启它、或升级到会带年龄的版本。",
+        line: ("创建能力:可用\n" +
+        "    ⚠ 不知道是什么时候测的 —— 该版本开机只算一次。重启它,或升级。"),
       };
     }
     return { kind: "ready", ageMs, line: `创建能力:可用(${formatAge(ageMs)}测)` };
@@ -159,7 +161,8 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
     explain: `未知原因代码 ${reason} —— 本 CLI 可能比那台机器的 anet 旧,升级本机 anet 或看它的 daemon 日志`,
     command: null,
   };
-  const where = "完整原文(含真实路径)只在那台机器的 daemon 日志里 —— 它带机器路径,按设计不上报。";
+  // 实测 83 列,80 列终端会折一下;拆成两句,每句都在 80 以内。
+  const where = "完整原文只在那台机器的 daemon 日志里。\n    (它带真实机器路径,按设计不上报)";
   const body = [
     `    原因:${fix.explain}`,
     fix.command ? `    修法(可整行粘贴):${fix.command}` : "    修法:没有单条命令能修,见上。",
@@ -168,7 +171,11 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
   if (ageMs === undefined) {
     return {
       kind: "blocked-age-unknown",
-      line: `创建能力:**不可用**(${reason}),但**不知道是什么时候测的** —— 该 daemon 版本开机只算一次。\n${body}`,
+      // 🔴 首行只放「状态 + 原因码」,把「不知道什么时候测的」挪到缩进行。
+      //    2026-08-30 macOS 真机验收(Mac打包牛)实测:合成一行约 **99 列**,
+      //    80 列终端会折行,而折点落在句子中间。本模块其余细节本来就各占一行,
+      //    这一句原先是唯一的例外。
+      line: `创建能力:**不可用**(${reason})\n    ⚠ 不知道是什么时候测的 —— 该 daemon 版本开机只算一次,之后不再重测。\n${body}`,
       fix,
     };
   }


### PR DESCRIPTION
## 来源：macOS 真机验收

`Mac打包牛` 在隔离前缀（不动全局 anet、不连 hub、不建节点）验今天新发的 `.70`，报回一个容器里验不出来的问题：

> 第 1 句「创建能力:**不可用**…开机只算一次。」约 **99 列**，80 列 Terminal 会折成两行

**本模块其余细节本来就各占一行 —— 那一句是唯一的例外。** 折点落在句子中间。

## 🔴 我量之后发现真机验收漏了两种情况

他机器上**没有 daemon**，所以只看到 `blocked` 那一支。我逐个 kind 量：

| kind | 改前最宽 |
|---|---|
| blocked-age-unknown | **99** |
| never-reported | **91** |
| ready-age-unknown | 超 80 |
| blocked / ready | ≤80 |

**真机验收覆盖的是「他机器当时的状态」，不是全部分支。** 两者都需要 —— 他发现了容器验不出的问题，我发现了他手上没有的状态。

改后：**所有五种 kind 的每一行 ≤ 71 列**。

## 常驻判据（不靠人再数一次）

- 五种 kind 每一行 ≤ 80 **显示列**（CJK 算 2 列 —— **按字符数会正好漏掉这类问题**）
- 🔴 **分母自证**：那 5 行必须真的产出 **5 个不同的 kind**；少一个，宽度检查会少覆盖一种情况**而仍然全绿**
- 🔴 **正控**：`displayWidth("中文")==4` —— 一个恒返回 0 的实现能让宽度检查全绿

## 两向见证

```
还原源码改动、只留新测   → 5 条红（blocked / blocked-age-unknown / ready-age-unknown / never-reported …）
改回                    → 34 pass / 0 fail / 93 expect()
```

## 顺带：一个我查过、不是 bug 的观察

我第一次测时 `{can_create_nodes:true, create_capability_observed_ms_ago:0}` 返回的是 `ready-age-unknown` 而不是 `ready`。**不是缺陷** —— 年龄是 `(now − last_seen_at) + observed_ms_ago`，我的测试行**没有 `last_seen_at`**，所以算不出年龄、正确地退回 age-unknown。补上之后就是 `ready`。**是我的夹具不完整，不是代码。**