### PR TITLE
release(agent-network): 2.3.0-preview.71 —— 让 80 列折行的修复真正到 npm

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.70",
+  "version": "2.3.0-preview.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.70",
+      "version": "2.3.0-preview.71",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.70",
+  "version": "2.3.0-preview.71",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.70";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.71";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.54";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.70 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.71 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.70` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.71` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.70 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.71 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.70`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.71`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.71.md
+++ b/docs/tests/release-v2.3.0-preview.71.md
@@ -1,0 +1,47 @@
+# @sleep2agi/agent-network 2.3.0-preview.71
+
+## 为什么发这一版
+
+`.70` 里「创建能力」那几行**在 80 列终端会折行，且折点落在句子中间**。
+2026-08-30 由 `Mac打包牛` 在 macOS 真机（隔离前缀、只读、未连 hub）验收发现；
+随后逐个 kind 量出**另外两种情况也超宽**（`never-reported` 91 列、`ready-age-unknown`），
+那两种他手上没有 daemon 所以看不到。
+
+改后五种 kind 每一行 **≤ 71 显示列**，并加了常驻判据（按显示列算、含分母自证与正控），
+不再靠人去数。见 #1573。
+
+🔴 **这一版的存在本身就是 SOP §2.6 的例子**：修复合进 main ≠ 用户拿得到。
+`.70` 在 npm 上仍然吐 99 列的那一行，实测确认过。
+
+## Install
+
+新装（首次使用）：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.71
+anet --version
+```
+
+## Upgrade
+
+已经装过的：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.71
+anet --version        # 应显示 2.3.0-preview.71
+```
+
+验收（按 SOP §2.5 的四步，第 ④ 步不能省）：
+
+```bash
+npm view @sleep2agi/agent-network dist-tags.preview          # 2.3.0-preview.71
+npm view @sleep2agi/agent-network@2.3.0-preview.71 exports    # 含 ./daemon-capability-display
+# ③ npm pack + tar -tzf 列出该文件
+# ④ 解包后 import 跑一次,并量首行显示列数 <= 80
+```
+
+## 发布方式
+
+`release-gate (v0)` workflow_dispatch，`package=agent-network`、
+`version=2.3.0-preview.71`、`publish=true`。**只发 preview 通道**；
+promote 到 latest 需要 owner ACK，本次**不做**。


### PR DESCRIPTION
## 为什么

`.70` 里「创建能力」那几行**在 80 列终端折行，且折点落在句子中间**。#1573 已修 main。

**但修复合进 main ≠ 用户拿得到** —— 实测：

```
main 上           已是拆行后的形式
npm 上的 .70      首行仍然 99 列
```

🔴 **这正是我今天写进 SOP §2.6 的那一条，现在轮到它自己。**

## 这次按 SOP 走，三道门本地按原样判据模拟过

| | |
|---|---|
| `sync-pinned-versions.sh --apply` | package.json / lock / pair |
| **手工**（脚本不覆盖） | 两份 `getting-started.md` 的机器戳 + 人读表格行 |
| release notes | 含 gate 3 要求的 `## Install` / `## Upgrade`，且 Install 段含 `@2.3.0-preview.71` |

本地模拟结果：
```
gate3: ## Install ✓   ## Upgrade ✓   Install block has version ✓
gate4: rc=0（含 --verify-latest-from-npm）
```

**上一版我是在门跑起来之后才发现 gate 3 会红的**（release notes 缺 `## Install`），白跑了一整轮。这次在写 notes 的时候就按判据写。

## 内容

只有 #1573 一项：五种 kind 每一行 ≤ 71 显示列 + 常驻宽度判据（按显示列算、含分母自证与正控）。

来源是 `Mac打包牛` 的 **macOS 真机验收**（隔离前缀、只读、未连 hub），随后我逐个 kind 量出**另外两种也超宽**（`never-reported` 91 列、`ready-age-unknown`）—— 那两种他手上没有 daemon 所以看不到。