### PR TITLE
fix(cli): 非 claude-agent-sdk 节点上拒绝配置飞书通道 —— 那层工具拒绝在它们上面不触发 (#1259)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -10733,6 +10733,33 @@ Examples:
       attachChannel(storedProfile, "telegram");
     } else {
       // type === "feishu" — RFC-020 §3.1 / §5.1 (#179)
+      //
+      // 🔴 #1259 —— 飞书回合的工具拒绝层(RFC-020 §13 Layer B)**只实现为一个
+      //    `PreToolUse` hook**(agent-node/src/cli.ts 里 checkFeishuToolDeny 的
+      //    **唯一**调用点)，而 PreToolUse 是 claude-agent-sdk 的机制。
+      //    在 codex-sdk / codex-app-server / opencode-cli 节点上，那一层
+      //    **一次都不会被调用** —— 三类拒绝(触达密钥路径的工具、抽取密钥的
+      //    Bash 模式、飞书回合上的 commhub MCP 调用，最重是向任意 alias
+      //    横向 send_task)全部放行，而且**没有任何东西会报错或提示**。
+      //
+      //    所以在这里拒绝，而不是让它配上去之后看起来一切正常。
+      //    形状对齐本文件既有的 runtime 不匹配处理(见 `--copresence requires
+      //    runtime=codex-app-server`)——本仓对 runtime 不匹配的立场就是拒绝并说明。
+      //
+      // 🔴 缺省即 claude-agent-sdk：`agent-node/src/cli.ts` 的
+      //    `opts.runtime || process.env.RUNTIME || fileConfig.runtime || "claude-agent-sdk"`。
+      //    所以 undefined **必须放行** —— 把"没写"当成"不是 claude"会打死
+      //    每一个从来没设过 runtime 的节点。
+      const feishuRuntime = (storedProfile as any)?.runtime || (profile as any)?.runtime || "claude-agent-sdk";
+      if (feishuRuntime !== "claude-agent-sdk") {
+        console.error(`[anet] ❌ feishu 通道目前只支持 runtime=claude-agent-sdk(节点 "${nodeRef}" 是 runtime=${feishuRuntime})。`);
+        console.error(`[anet]    原因:飞书回合的工具拒绝层(RFC-020 §13 Layer B)实现为 claude-agent-sdk 的`);
+        console.error(`[anet]    PreToolUse hook。在其它 runtime 上它**一次都不会触发** —— 通道能配上、`);
+        console.error(`[anet]    看起来正常，但密钥路径工具 / 抽密钥的 Bash / 飞书回合上的 commhub 调用全部放行。`);
+        console.error(`[anet]    见 #1259。要在这个节点上用飞书，改用 claude-agent-sdk 运行时。`);
+        process.exit(1);
+      }
+
       let appId = opts["app-id"];
       let appSecret = opts["app-secret"];
       let allowOpenId = opts.allow;


### PR DESCRIPTION
## 问题：不是「没测过」，是**有一层安全控制不存在**

#1259 把 codex/opencode 记作「没拦，零测试」。静态追完那条链，要往前推一格：

```
agent-node/src/cli.ts:2548   PreToolUse: [{ hooks: [async (input) => {
agent-node/src/cli.ts:2560     checkFeishuToolDeny(...)   ← 全仓唯一调用点
opencode-cli 的 think() 入口(cli.ts:3261 起)  feishu/deny 命中 0 次
```

`PreToolUse` 是 **claude-agent-sdk 的机制**（该文件自己的注释：「by intercepting the LLM's PreToolUse hook」）。

⇒ 在 codex-sdk / codex-app-server / opencode-cli 节点上开飞书通道，**那一层一次都不会被调用**。它拦的三类 —— 触达密钥路径的工具、抽取密钥的 Bash 模式、**飞书回合上的 commhub MCP 调用（最重是向任意 alias 横向 `send_task`）** —— **全部放行，且没有任何东西会报错或提示**。通道配得上、看起来一切正常。

## 🔴 这不是「新加一道更严的门」

同一个文件里已有先例：

```ts
cli.ts:1139  if (profile.runtime !== "codex-app-server") {
cli.ts:1140    console.error(`[anet] ❌ --copresence requires runtime=codex-app-server …`)
               process.exit(1);
```

**本仓对 runtime 不匹配的既有立场就是拒绝并说明。** 我是对齐，不是收紧。

## 🔴 缺省必须放行，否则会打死每一个没设过 runtime 的节点

```
agent-node/src/cli.ts:519
  opts.runtime || process.env.RUNTIME || fileConfig.runtime || "claude-agent-sdk"
```

**`undefined` 就是 `claude-agent-sdk`。** 把「没写」当成「不是 claude」是这类守卫最容易犯的错（`undefined ≠ false`）。判定式写成 `(runtime || "claude-agent-sdk") !== …`。

## 判定覆盖（两侧都非空，否则这个检查什么也没测）

| | |
|---|---|
| **allow** (3) | `undefined` / `""` / `claude-agent-sdk` |
| **refuse** (5) | `claude-code-cli` / `codex-sdk` / `codex-app-server` / `opencode-cli` / `grok-build-cli` |

## 未做实测的说明

**没有在真实飞书通道上验证**，因为那要往生产 IM 发消息 —— 明令禁止。全部结论来自 `origin/main` 的静态判据：唯一调用点、hook 机制归属、其余入口 0 命中、默认值来源。**能验的验了，不能验的标明白。**

`tsc --noEmit` rc=0（用真 tsc，退出码没穿过管道）。