### PR TITLE
fix(cli): `anet status` 不再把「卡住/出错」显示成「在干活」 (#1548)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -35,6 +35,7 @@ import {
   type SessionInfo,
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
+import { classifySessionStatus } from "../src/session-status-class";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
@@ -11843,12 +11844,12 @@ async function statusCommand() {
     const sessions = statusRes.sessions || [];
     const tasks = tasksRes.tasks || [];
 
-    const classifyStatus = (s: any) => {
-      const raw = String(s?.status || "").toLowerCase();
-      if (raw === "offline") return "offline";
-      if (["working", "blocked", "error", "waiting_input", "running", "busy"].includes(raw)) return "working";
-      return "idle";
-    };
+    // 🔴 #1548 —— 分类逻辑抽到 ../src/session-status-class.ts 并加了测试。
+    //    原先这里把 `blocked` / `error` 折进 `working`,于是运维看到「N working」
+    //    时,其中可能有几个是**卡住**或**出错**的。而 #1548 已经证明 `blocked`
+    //    是一个**没有出口**的状态(只有 report_completion 能把它拉回 idle),
+    //    所以一个 agent 可以永远停在那里而被报成「在干活」。
+    const classifyStatus = (s: any) => classifySessionStatus(s?.status);
     const summary = statusRes.summary || sessions.reduce((acc: any, s: any) => {
       acc[classifyStatus(s)]++;
       acc.total++;
@@ -11856,12 +11857,29 @@ async function statusCommand() {
     }, { idle: 0, working: 0, offline: 0, total: 0 });
     const idle = sessions.filter((s: any) => classifyStatus(s) === "idle");
     const working = sessions.filter((s: any) => classifyStatus(s) === "working");
+    const attention = sessions.filter((s: any) => classifyStatus(s) === "attention");
     const offline = sessions.filter((s: any) => classifyStatus(s) === "offline");
 
     console.log(`\n  CommHub: ${hub}`);
-    console.log(`  Agents: ${summary.idle || 0} idle, ${summary.working || 0} working, ${summary.offline || 0} offline`);
+    // 🔴 attention 单独一格。折进 working 会让「需要人看一眼」消失在一个看起来
+    //    正常的数字里 —— 这正是 #1548 那一族问题:两种不同的事渲染成同一个词。
+    const attnCount = summary.attention ?? attention.length;
+    console.log(`  Agents: ${summary.idle || 0} idle, ${summary.working || 0} working`
+      + (attnCount > 0 ? `, ${attnCount} needs attention` : "")
+      + `, ${summary.offline || 0} offline`);
     console.log(`  SSE:    ${sseCount === null ? "unknown" : `${sseCount} connected`}`);
     console.log(`  Tasks:  ${tasks.length} recent\n`);
+
+    if (attention.length > 0) {
+      console.log("  Needs attention (blocked / error — not progressing):");
+      for (const s of attention) {
+        console.log(`    ${String(s.alias).padEnd(16)} ${String(s.status || "").padEnd(8)} ${(s.task || "").slice(0, 48)}`);
+      }
+      // 🔴 状态是**自报**的:它只在 agent 显式上报时才变。一个 `blocked` 可能是
+      //    3 秒前报的,也可能是三周前报的 —— 这里不假装知道哪一种。
+      console.log("    (状态由 agent 自报,不含活性成分;要确认它还在不在,发一条任务试试)");
+      console.log();
+    }
 
     if (working.length > 0) {
       console.log("  Working:");

--- a/agent-network/src/session-status-class.test.ts
+++ b/agent-network/src/session-status-class.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "bun:test";
+import { classifySessionStatus } from "./session-status-class";
+
+describe("#1548 anet status 不能把「卡住」显示成「在干活」", () => {
+  // 🔴 这一条是本次修的那个 bug 的红夹具:改之前 blocked/error 返回 "working"
+  test("blocked / error 归入 attention,不是 working", () => {
+    expect(classifySessionStatus("blocked")).toBe("attention");
+    expect(classifySessionStatus("error")).toBe("attention");
+  });
+
+  test("真正在推进的仍是 working", () => {
+    for (const s of ["working", "running", "busy", "waiting_input"]) {
+      expect(classifySessionStatus(s)).toBe("working");
+    }
+  });
+
+  test("offline 与 idle 不变", () => {
+    expect(classifySessionStatus("offline")).toBe("offline");
+    expect(classifySessionStatus("idle")).toBe("idle");
+    expect(classifySessionStatus("")).toBe("idle");
+    expect(classifySessionStatus(undefined)).toBe("idle");
+    expect(classifySessionStatus(null)).toBe("idle");
+  });
+
+  // 🔴 分母自证:四个类别都必须真的被产出。少一个,上面的断言可能在测一个
+  //    塌成两三类的实现而仍然全绿。
+  test("四个类别都被产出(否则这组断言覆盖不全)", () => {
+    const got = new Set(["idle", "working", "blocked", "offline"].map(classifySessionStatus));
+    expect(got).toEqual(new Set(["idle", "working", "attention", "offline"]));
+  });
+
+  // 正控:大小写与未知值不会被静默归错
+  test("大小写不敏感;未知值归 idle 而不是抛错", () => {
+    expect(classifySessionStatus("BLOCKED")).toBe("attention");
+    expect(classifySessionStatus("Working")).toBe("working");
+    expect(classifySessionStatus("some-new-state")).toBe("idle");
+  });
+});

--- a/agent-network/src/session-status-class.ts
+++ b/agent-network/src/session-status-class.ts
@@ -1,0 +1,26 @@
+/**
+ * `anet status` 的会话状态分类。
+ *
+ * 🔴 为什么单独成文件:原先它是 statusCommand 里的一个闭包,没有任何测试碰得到它 ——
+ *    而它决定了运维看到的那三个数字。一个把「卡住」算成「在干活」的分类器,
+ *    和一个正确的分类器,在输出上长得一模一样(都是一个数)。
+ *
+ * 🔴 改了什么:`blocked` / `error` 原先被折进 `working`。
+ *    它们的含义是**需要人看一眼**,不是**正在推进**。
+ *    运维看到「5 working」会认为一切正常,而其中可能有几个卡了很久 ——
+ *    #1548 已经证明 `blocked` 是一个**没有出口**的状态:
+ *    只有 report_completion 能把它拉回 idle,所以一个 agent 可以永远停在那里。
+ *
+ * `waiting_input` 保留在 working 里:它是一个**进行中的回合**在等人,
+ * 与 blocked/error 不同 —— 那是回合本身出了问题。
+ */
+export type SessionClass = "idle" | "working" | "attention" | "offline";
+
+export function classifySessionStatus(raw: unknown): SessionClass {
+  const s = String(raw ?? "").toLowerCase();
+  if (s === "offline") return "offline";
+  // 需要人看一眼的:卡住、出错。**不算 working。**
+  if (s === "blocked" || s === "error") return "attention";
+  if (["working", "waiting_input", "running", "busy"].includes(s)) return "working";
+  return "idle";
+}


### PR DESCRIPTION
## 问题

`statusCommand` 里的分类器把 `blocked` / `error` 折进 `working`：

```ts
if (["working", "blocked", "error", "waiting_input", "running", "busy"].includes(raw)) return "working";
```

⇒ 运维看到「N working」时，**其中可能有几个是卡住或出错的**。

而 #1548 已经证明 `blocked` 是一个**没有出口**的状态 —— 只有 `report_completion` 能把它拉回 idle（`server/src/tools.ts:904`），`stale-sweeper` 只按 `updated_at` 转 offline。**一个 agent 可以永远停在 blocked 而被报成「在干活」。**

今天实测过两个显示 `blocked` 的节点，**发任务都秒回** —— 状态是自报的，它只在 agent 显式上报时才变。

## 改动

- **分类抽到 `agent-network/src/session-status-class.ts` 并加测试。** 原先它是 `statusCommand` 里的一个**闭包，没有任何测试碰得到**，而它决定了运维看到的那三个数字。
- 新增 `attention` 类别（`blocked` / `error`）。**`waiting_input` 留在 working** —— 那是一个**进行中的回合**在等人，和回合本身出问题不是一回事。
- `anet status` 多一格 `N needs attention`，并单独列出 alias / status / task。
- 那一段下面明写：**状态由 agent 自报，不含活性成分** —— 一个 `blocked` 可能是 3 秒前报的，也可能是三周前报的，**这里不假装知道哪一种**。

## 测试

含 **分母自证**（四个类别都必须真的被产出 —— 否则断言可能在测一个塌成两三类的实现**而仍然全绿**）与正控（大小写、未知值不被静默归错）。

## 两向见证

```
把分类改回旧的折叠写法  → 3 条红（含分母自证那条）
改回                   → 5 pass / 0 fail / 15 expect()
```

`tsc --noEmit` rc=0（真 tsc，退出码没穿过管道）。