### PR TITLE
release(agent-network): 2.3.0-preview.72 —— 两处「看错状态」的修复到 npm

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.71",
+  "version": "2.3.0-preview.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.71",
+      "version": "2.3.0-preview.72",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.71",
+  "version": "2.3.0-preview.72",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.71";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.72";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.54";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.71 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.72 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.71` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.72` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.71 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.72 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.71`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.72`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.72.md
+++ b/docs/tests/release-v2.3.0-preview.72.md
@@ -1,0 +1,47 @@
+# @sleep2agi/agent-network 2.3.0-preview.72
+
+## 内容：两处会让人**看错状态**的修复
+
+| PR | 修的是什么 |
+|---|---|
+| #1575 | **非 claude-agent-sdk 节点上拒绝配置飞书通道** —— 飞书回合的工具拒绝层（RFC-020 §13 Layer B）只实现为 claude-agent-sdk 的 `PreToolUse` hook，在 codex/opencode 上**一次都不会触发**。此前通道配得上、看起来正常，而密钥路径工具 / 抽密钥的 Bash / 飞书回合上的 commhub 横向 `send_task` **全部放行**。 |
+| #1577 | **`anet status` 不再把「卡住/出错」显示成「在干活」** —— 分类器把 `blocked` / `error` 折进 `working`，运维看到的「N working」里可能有卡住的。而 `blocked` 是一个**没有出口**的状态（只有 `report_completion` 能拉回 idle）。 |
+
+**两者是同一个形状**：一件"需要人看一眼"的事，被渲染成了"一切正常"。
+
+## Install
+
+新装（首次使用）：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.72
+anet --version
+```
+
+## Upgrade
+
+已经装过的：
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.72
+anet --version        # 应显示 2.3.0-preview.72
+anet status           # 现在会多一格 "N needs attention"（如果有 blocked/error 的话）
+```
+
+验收按 SOP §2.5 四步（第 ④ 步不能省 —— tar 列得出文件不等于它跑得对）：
+
+```bash
+npm view @sleep2agi/agent-network dist-tags.preview           # 2.3.0-preview.72
+npm view @sleep2agi/agent-network@2.3.0-preview.72 exports    # 含 ./daemon-capability-display
+# ③ npm pack + tar -tzf 列出该文件
+# ④ 解包后 import 跑一次
+```
+
+🔴 **部署 anet.sh 必须在发包与验收之后**（SOP §2.6 的顺序）。这个 bump 一合入，
+main 上的上手指南就指向 `.72` —— 而它此刻还不存在。
+
+## 发布方式
+
+`release-gate (v0)` workflow_dispatch，`package=agent-network`、
+`version=2.3.0-preview.72`、`publish=true`。**只发 preview**；
+promote 到 latest 需要 owner ACK，本次**不做**。


### PR DESCRIPTION
把两处**会让人看错状态**的修复批量发一版（不是各发一次 —— 今天我已经因为在发版排队期间开 PR 把队列堵到 48，没必要付两次 CI 代价）。

| PR | 修的是什么 |
|---|---|
| **#1575** | 非 claude-agent-sdk 节点上**拒绝**配置飞书通道 —— 那层工具拒绝（RFC-020 §13 Layer B）只实现为 claude-agent-sdk 的 `PreToolUse` hook，在 codex/opencode 上**一次都不会触发**。此前通道配得上、看起来正常，而**密钥路径工具 / 抽密钥的 Bash / 飞书回合上的 commhub 横向 `send_task` 全部放行**。 |
| **#1577** | `anet status` 不再把 `blocked`/`error` 显示成 `working` —— 运维看到的「N working」里可能有卡住的，而 `blocked` 是一个**没有出口**的状态。 |

**两者是同一个形状**：一件「需要人看一眼」的事，被渲染成了「一切正常」。

## 门已本地按原样判据模拟

```
gate3: ## Install ✓  ## Upgrade ✓  Install block has @2.3.0-preview.72 ✓
gate4: rc=0（含 --verify-latest-from-npm）
```

## 🔴 合入后的顺序

按 SOP §2.6：**bump 合入 → 发包 → 四步验收 → 最后才部署 anet.sh**。这个 bump 一合入，main 上的上手指南就指向 `.72`，而它此刻还不存在。