### PR TITLE
「Install Grok Build CLI」—— 但它已经装了（真机踩到）

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3505,8 +3505,12 @@ async function processWithGrok(
     const { execFileSync } = await import("child_process");
     const version = execFileSync("grok", ["--version"], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
     debug(`[grok] ${version}`);
-  } catch {
-    throw new Error("grok CLI not found. Install Grok Build CLI and run `grok --version` before starting this node.");
+  } catch (e: any) {
+    // 2026-08-30 —— 这里原来一句话吞掉全部失败:「not found. Install Grok Build CLI」。
+    // 真机上 grok 装着(官方位置 ~/.grok/bin),缺的只是 daemon 的 PATH ——
+    // 照那句话重装十遍也不会好。见 ./runtime/grok-preflight。
+    const { grokPreflightMessage } = await import("./runtime/grok-preflight");
+    throw new Error(grokPreflightMessage(e || {}, String(process.env.PATH || "")));
   }
 
   const { runGrokAcpTurn } = await import("./runtime/grok-build-acp/runtime");

--- a/agent-node/src/runtime/grok-preflight.test.ts
+++ b/agent-node/src/runtime/grok-preflight.test.ts
@@ -1,0 +1,71 @@
+/* 2026-08-30 —— 这句报错在真机上把人指错了方向。
+ *
+ * Mac mini,daemon 建的 grok-build-acp 节点,用户收到的原话是
+ * 「grok CLI not found. Install Grok Build CLI」——
+ * 而那台机器上 grok 就装在官方位置 `~/.grok/bin/grok`。
+ * 真因是 daemon 的 PATH 没有它,子节点又继承 daemon 的 PATH。
+ */
+import { describe, expect, test } from "bun:test";
+import { grokPreflightMessage } from "./grok-preflight.js";
+
+const PATH_SAMPLE = "/opt/homebrew/bin:/usr/bin:/bin";
+
+describe("🔴 grok 预检:三种失败必须说成三句不同的话", () => {
+  const CASES = [
+    { code: "ENOENT" },
+    { code: "EACCES" },
+    { status: 1, stderr: "boom" },
+  ];
+
+  test("三种各说各的", () => {
+    const out = CASES.map(c => grokPreflightMessage(c, PATH_SAMPLE));
+    expect(new Set(out).size).toBe(CASES.length);
+  });
+
+  /* 🔴 本体:找不到 ≠ 没装。修复前这句话是「Install Grok Build CLI」。 */
+  test("🔴 ENOENT 明说「不等于没装」,并指向 PATH 而不是重装", () => {
+    const s = grokPreflightMessage({ code: "ENOENT" }, PATH_SAMPLE);
+    expect(s).toContain("不在 PATH 上");
+    /* 断言串里不带 ** 之类的标记符 —— 第一版就是把星号放错了位置而假红。 */
+    expect(s.replace(/\*/g, "")).toContain("不等于没装");
+    expect(s).not.toContain("Install Grok Build CLI");
+    expect(s).toContain("~/.grok/bin");
+  });
+
+  /* 🔴 真机上就是这一条把人坑了:在自己 shell 里 export 完全无效。 */
+  test("🔴 ENOENT 必须点出 daemon 子节点继承 daemon 的 PATH", () => {
+    const s = grokPreflightMessage({ code: "ENOENT" }, PATH_SAMPLE);
+    expect(s).toContain("daemon");
+    expect(s).toContain("继承");
+  });
+
+  /* 「PATH 里没有」不把 PATH 印出来,等于没说。 */
+  test("🔴 ENOENT 回显当前 PATH", () => {
+    expect(grokPreflightMessage({ code: "ENOENT" }, PATH_SAMPLE)).toContain(PATH_SAMPLE);
+  });
+
+  /* 🔴 GROK_BINARY 只有 grok-build-cli 那条路读,ACP 从没读过它。
+   * 建议一个本运行时无效的开关 = 把这条报错的毛病换个方向再犯一次。 */
+  test("🔴 任何一种都不许建议 GROK_BINARY(ACP 不读它)", () => {
+    for (const c of CASES) {
+      expect(grokPreflightMessage(c, PATH_SAMPLE)).not.toContain("GROK_BINARY");
+    }
+  });
+
+  test("EACCES 说的是权限,不是找不到", () => {
+    const s = grokPreflightMessage({ code: "EACCES" }, PATH_SAMPLE);
+    expect(s).toContain("chmod +x");
+    expect(s).not.toContain("不在 PATH 上");
+  });
+
+  test("非 ENOENT/EACCES:说清是 grok 自己起不来,并带上它的 stderr", () => {
+    const s = grokPreflightMessage({ status: 127, stderr: "libfoo missing" }, PATH_SAMPLE);
+    expect(s).toContain("exit 127");
+    expect(s).toContain("libfoo missing");
+    expect(s).toContain("不是找不到");
+  });
+
+  test("🔴 分母自证:确实覆盖了 3 种失败形状", () => {
+    expect(CASES.length).toBe(3);
+  });
+});

--- a/agent-node/src/runtime/grok-preflight.ts
+++ b/agent-node/src/runtime/grok-preflight.ts
@@ -1,0 +1,61 @@
+/* grok ACP 预检失败时说什么。
+ *
+ * 2026-08-30 起因(真机):Mac mini 上用 daemon 建了一个 grok-build-acp 节点,
+ * 它给用户回的是:
+ *
+ *     grok 错误: grok CLI not found. Install Grok Build CLI and run
+ *     `grok --version` before starting this node.
+ *
+ * 而那台机器上 grok **装着**,就在官方安装器放它的地方(`~/.grok/bin/grok`,
+ * 见 docs/grok-build-cli-preview.md:安装器自己打印 "installed to …/.grok/bin/grok")。
+ * 真正的原因是 daemon 的 PATH 里没有 `~/.grok/bin`,而 **daemon 建出来的子节点
+ * 继承 daemon 的 PATH**。照那句话去重装,装十遍也不会好。
+ *
+ * 🔴 这条不是新知识 —— grok-copresence/runtime.ts 里已经写着同一条实测:
+ *    「grok 装在 ~/.grok/bin,而 PTY 的受控 env 里没有它」。那条路修好了,
+ *    ACP 这条预检没跟上。
+ *
+ * 🔴 这里**不能**建议 `GROK_BINARY`:那个覆盖只有 grok-build-cli 那条路读
+ *    (cli.ts 的 processWithGrokCli),grok-build-acp 从头到尾没读过它。
+ *    建议一个在本运行时无效的开关,等于把这条报错的毛病换个方向再犯一次。
+ */
+
+/** execFile 抛出来的东西里,我们真正用得上的那几格。 */
+export type GrokPreflightError = {
+  readonly code?: string;
+  readonly status?: number | null;
+  readonly stderr?: string;
+};
+
+const HINT_INSTALL = "没装的话按 docs/grok-build-cli-preview.md 装";
+
+/** 把预检失败翻译成一句**说得出下一步**的话。`pathEnv` 原样回显 —— 
+ *  「PATH 里没有」这种话,不把 PATH 印出来等于没说。 */
+export function grokPreflightMessage(e: GrokPreflightError, pathEnv: string): string {
+  const path = pathEnv || "(空)";
+  if (e.code === "ENOENT") {
+    return [
+      "grok CLI 不在 PATH 上 —— 这**不等于**没装。",
+      "  grok 的官方安装位置是 ~/.grok/bin/grok,而它默认不在登录 PATH 里。",
+      "  先看装没装:  ls -l ~/.grok/bin/grok",
+      '  装了就加进去:  export PATH="$HOME/.grok/bin:$PATH"',
+      "  🔴 这个节点若是 daemon 建的:子节点继承 **daemon 的** PATH,",
+      "     在你自己的 shell 里 export 没用 —— 要改 daemon 的启动环境再重启 daemon。",
+      `  ${HINT_INSTALL}。`,
+      `  当前 PATH: ${path}`,
+    ].join("\n");
+  }
+  if (e.code === "EACCES") {
+    return [
+      "grok CLI 找到了,但不可执行(EACCES)。",
+      '  chmod +x "$(command -v grok)"',
+      `  当前 PATH: ${path}`,
+    ].join("\n");
+  }
+  const tail = (e.stderr || "").trim().slice(0, 200);
+  return [
+    `grok CLI 在,但 \`grok --version\` 没跑成功${typeof e.status === "number" ? `(exit ${e.status})` : ""}。`,
+    "  这不是找不到,是它自己起不来 —— 先手动跑一次 `grok --version` 看它说什么。",
+    ...(tail ? [`  它的 stderr: ${tail}`] : []),
+  ].join("\n");
+}


### PR DESCRIPTION
## 真机现象

Mac mini 上用 daemon 建了一个 `grok-build-acp` 节点。用户发消息，节点回的是：

```
grok 错误: grok CLI not found. Install Grok Build CLI and run `grok --version` before starting this node.
```

**而那台机器上 grok 装着**，就在官方安装器放它的地方：

```
$ ls -l ~/.grok/bin/grok
… -> ../downloads/grok-1.0.13-macos-aarch64
$ PATH="$HOME/.grok/bin:$PATH" grok --version
grok 1.0.13 (5e9a58528b76)
```

`docs/grok-build-cli-preview.md` 里安装器自己打印的就是 `installed to …/.grok/bin/grok`。

真因：**daemon 的 PATH 里没有 `~/.grok/bin`，而 daemon 建出来的子节点继承 daemon 的 PATH。** 照那句话去重装，装十遍也不会好。

## 一个 catch 吞掉三件事

```ts
} catch {
  throw new Error("grok CLI not found. Install Grok Build CLI …");
}
```

| 实际失败 | 该怎么修 | 以前说的 |
|---|---|---|
| `ENOENT`（不在 PATH） | 把 `~/.grok/bin` 加进 PATH | 「没装，去装」 |
| `EACCES`（不可执行） | `chmod +x` | 「没装，去装」 |
| 非零退出（grok 在，自己起不来） | 看它的 stderr | 「没装，去装」 |

改成按 errno 分三种，每种说出下一步，并**回显当前 PATH** ——「PATH 里没有」不把 PATH 印出来等于没说。

ENOENT 那条还专门点出真机上坑住人的那一点：

> 🔴 这个节点若是 daemon 建的：子节点继承 **daemon 的** PATH，在你自己的 shell 里 export 没用 —— 要改 daemon 的启动环境再重启 daemon。

## 🔴 为什么不建议 `GROK_BINARY`

这是我写这条消息时差点自己犯的错。`GROK_BINARY` **只有 `grok-build-cli` 那条路读**（`cli.ts` 的 `processWithGrokCli`）；`grok-build-acp` 从头到尾没读过它 —— `acp/runtime.ts` 只透传 `opts.binary`，不查环境变量。

**建议一个在本运行时无效的开关，等于把这条报错的毛病换个方向再犯一次。** 所以专门有一条测试钉住「任何一种都不许提 `GROK_BINARY`」。

## 🔴 这条实测不是新知识

`grok-copresence/runtime.ts` 里早就写着同一句：

> 实测(macOS,Apple M4):grok 装在 `~/.grok/bin`,而 PTY 的受控 env 里没有它

**那条路修好了，ACP 这条预检没跟上。**

## 测试

8 条，**两向见证**：把消息改回原来那句 → **8 条里 6 条红**，另 2 条（不许提 `GROK_BINARY`、分母自证）本就不该由这个变异区分。

其中一条我自己先踩了一次：断言串里写了 `不**等于**没装`，星号位置和源码 `**不等于**没装` 差一格，假红一次。已改成先 `replace(/\*/g,"")` 再断言 —— **校验串里不该带标记符**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)