### PR TITLE
RELEASE-SOP 教的发版动作，正是规则明令禁止的那一个

### DIFF
--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -292,20 +292,33 @@ git commit -m "chore(release): @sleep2agi/agent-node 2.3.2-preview.0"
 > Conventional Commits：`chore(release): ...` 或 `release: ...`。
 > 不加 `Co-Authored-By` 类 footer（OSS rule，见仓库 commit history）。
 
-### Step 6：publish preview
+### Step 6：publish preview —— 走 GitHub Actions，**不在本机发**
+
+🔴 **本机不发包。** 这是 Vincent 2026-08-27 定的规则：发版一律走 GitHub Actions，
+本机只开发。规则的来历就是当天的事故 —— `latest` 被一次本机手工 `npm publish`
+（漏了 `--tag preview`）顶掉。一条命令，没有门，没有回退窗口。
 
 ```bash
-cd agent-node
-npm publish --tag preview
+gh workflow run release.yml \
+  -f package=agent-node \
+  -f version=2.3.2-preview.0 \
+  -f publish=true \
+  --ref main
 ```
 
-> 默认就是 `--tag preview`，**永远不要直接 `--tag latest`**。
+- **四道门全绿才会 publish**（`release.yml` 的 `if:` 里逐个断言 success）；
+  任一门红 → `publish` job 直接 skipped，不会发出半成品。
+- 这条工作流**只发 preview 通道，永不发 latest**（见它 `publish` input 自己的描述）。
+- `--ref main`：对外产物一律从 main 出（同日定的第二条规则）；其它分支只做测试验证。
+
+> 本文档早先在这一步写的是 `cd agent-node && npm publish --tag preview`。
+> **那条指令现在是违规的**，已删除 —— 它正是上面那起事故的动作形状。
 
 ### Step 7：等待窗口 ≥ 30 分钟 + owner explicit ACK
 
 两阶段发版规则（release-preview-first，见 [CONTRIBUTING.md §Release process](../CONTRIBUTING.md)）：
 
-- 第一阶段：`npm publish --tag preview` 后，**至少 30 分钟**真实环境烟测
+- 第一阶段：`release.yml`（`publish=true`）发到 preview 通道后，**至少 30 分钟**真实环境烟测
 - 第二阶段：owner 或 lead **显式 ACK** 后才能升 latest
 - 30 分钟内发现 bug：发新 preview 覆盖，不要急着 dist-tag latest
 
@@ -314,10 +327,21 @@ npm publish --tag preview
 ### Step 8：升 latest（owner ACK 之后）
 
 ```bash
-npm dist-tag add @sleep2agi/agent-node@2.3.2-preview.0 latest
-# verify
+gh workflow run promote-latest.yml \
+  -f package=agent-node \
+  -f version=2.3.2-preview.0 \
+  -f must_contain='<只有这个版本才有的符号或字符串>' \
+  -f ack=true \
+  --ref main
+# verify（升完之后核一遍，别只看 workflow 绿）
 npm view @sleep2agi/agent-node dist-tags
 ```
+
+🔴 `must_contain` 不是走形式：它防的是**把 latest 推到一个不含目标改动的旧版本** ——
+这种事故发出去以后，光看版本号看不出来。填一个只有目标版本才有的符号/字符串。
+
+🔴 `ack=true` 的语义是「owner/lead 的显式 ACK」。**你不能替 owner 勾这一格。**
+本机 `npm dist-tag add` 同样属于「本机发包」，一并禁掉。
 
 ### Step 9：通知通信文档马同步 release docs
 

--- a/docs/release/versioning-and-compatibility.md
+++ b/docs/release/versioning-and-compatibility.md
@@ -65,7 +65,9 @@ dashboard 跟 commhub 的 REST 契约（C3）要版本约束——纳入本文�
 
 ## 7. Release SOP（复用现成）
 
-- fresh clone main → 各包 `bun install` → `npm version <精确版> --no-git-tag-version` → `npm publish --tag preview`（prepublishOnly 自动 build）
+- 发版走 `gh workflow run release.yml -f package=<pkg> -f version=<精确版> -f publish=true --ref main`
+  （🔴 **本机不发包**，Vincent 2026-08-27 定；四门全绿才 publish，且只发 preview 通道）
+  权威步骤见 [RELEASE-SOP](../RELEASE-SOP.md)
 - 验：dist 关键串在 + `grep -c 'Bun\.' dist` = 0
 - **npm publish 顺序** = **server → agent-node → agent-network**（被依赖的先发；矩阵新行也按这条顺序试）
 - 每 preview 带一句 changelog；latest 严格两阶段（preview 亲测 + 30min 窗口）

--- a/docs/tests/release-gate-playbook.md
+++ b/docs/tests/release-gate-playbook.md
@@ -154,7 +154,7 @@ p.expect(r"选择 runtime"); p.sendline("")  # default
 
 ## 5. Per-preview workflow
 
-1. SDK马/通信牛/N站马 push commit + `npm publish @preview`
+1. SDK马/通信牛/N站马 push commit + 跑 `release.yml`（`publish=true`）发 preview —— 🔴 本机不发包，见 [RELEASE-SOP](../RELEASE-SOP.md)
 2. **PRE-build curl HEAD verify**: `curl -sI .../<pkg>-<ver>.tgz` returns 200 (catch dist-tag-flip-but-tarball-404 per [v0.9.0 Round 5](https://github.com/sleep2agi/agent-network/issues/126#issuecomment-4458336023))
 3. Run A1+A2+B1+B2+C1 = preview ship gate (~5min)
 4. Paste verdict into release PR / issue comment (table with case + verdict + evidence)


### PR DESCRIPTION
## 问题

`docs/RELEASE-SOP.md` Step 6：

```bash
cd agent-node
npm publish --tag preview
```

而 `CLAUDE.md` 里 Vincent **2026-08-27 定的规则**是：

> **发版一律走 GitHub Actions**（本机只开发不发包）

而且这条规则**不是预防性的**，它的来历就是当天的事故：

> 当日教训：latest 曾被一次本地手工 `npm publish` 未带 `--tag preview` 顶上去

**所以照这份 SOP 一步步做，做的正是那条规则要禁的动作。** Step 8 的 `npm dist-tag add … latest` 同理。

一份权威 SOP 和一条硬规则互相矛盾时，人会照 SOP 做 —— 因为 SOP 是有步骤号、能照着敲的那一份。

## 改法

换成两条**真实存在**的 workflow（每个 input 名都对着各自的 yml 核过，没有一个是我编的）：

| Step | 命令 |
|---|---|
| 6 发 preview | `gh workflow run release.yml -f package= -f version= -f publish=true --ref main` |
| 8 升 latest | `gh workflow run promote-latest.yml -f package= -f version= -f must_contain= -f ack=true --ref main` |

并补上 SOP 原来没写的两件事：

- **四门全绿才 publish**（`release.yml` 的 `if:` 逐个断言 success）；任一门红 → `publish` job skipped，**不会发出半成品**。原文的本机 `npm publish` 没有这层保护。
- `must_contain` 防的是**把 latest 推到一个不含目标改动的旧版本** —— 这种事故发出去以后，光看版本号看不出来。`ack=true` 是 owner 的显式 ACK，**不能替 owner 勾**。

## 同义副本

全仓找了一遍还有哪里在教人本机发包，改了另外两处**指导性**的：

- `docs/release/versioning-and-compatibility.md` §7
- `docs/tests/release-gate-playbook.md` §5

## 🔴 刻意没改的

`evolution-log.md`、`docs/tests/release-v*.md`、research 笔记、RFC 里的历史行 —— 那些是**记录**，记的是当时确实那么做的事。把记录改写成现行规则会让历史失真，而且下次有人查"这个版本当初怎么发的"会得到错的答案。

判据是那句话**在教人现在怎么做，还是在记当时发生了什么**。

## 门

`check-docs-integrity` / `check-docs-site-orphans` / `check-doc-symbol-anchors` / `check-doc-symbol-pins` 本地全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)