### PR TITLE
#1583 只修了一半 —— CONTRIBUTING 才是人真正读的那份

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,26 @@ Every PR to `main` runs [`bash scripts/qa.sh`](./scripts/qa.sh) (L0 unit + L1 Do
 1. Update version in each affected `package.json` (use `x.y.z-preview.N` for pre-releases)
 2. Update `docs-site/docs/changelog.md`
 3. Tag: `git tag vX.Y.Z`
-4. **`npm publish --tag preview`** first (release-preview-first policy since 2026-05-11 — avoid pushing bugs to all `@latest` users)
-5. After manual smoke test, promote: `npm dist-tag add @sleep2agi/<pkg>@x.y.z latest`
+4. **Publish to the preview channel via GitHub Actions** (release-preview-first policy since 2026-05-11 — avoid pushing bugs to all `@latest` users):
 
-Note: no CI auto-publish workflow yet (`e2e-docker.yml` runs Docker E2E on PRs, `qa.yml` runs `bash scripts/qa.sh` as report-only PR gate); all `npm publish` is manual by a maintainer.
+   ```bash
+   gh workflow run release.yml -f package=<pkg> -f version=<x.y.z-preview.N> -f publish=true --ref main
+   ```
+
+5. After a real-environment smoke test (≥30 min) **and an explicit owner/lead ACK**, promote:
+
+   ```bash
+   gh workflow run promote-latest.yml -f package=<pkg> -f version=<x.y.z-preview.N> \
+     -f must_contain='<a string only that version contains>' -f ack=true --ref main
+   ```
+
+🔴 **Do not publish from a local machine.** No `npm publish`, no `npm dist-tag add`. This rule
+was set on 2026-08-27 after a local `npm publish` that omitted `--tag preview` overwrote the
+`latest` tag. Releases go through Actions, and only from `main`.
+
+Note: `release.yml` has a `publish (preview only)` job that runs **only** when four gates all
+pass; if any gate is red the publish job is skipped, so a half-broken build never reaches npm.
+A local publish has none of that.
 
 ## Where to ask
 

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -546,8 +546,10 @@ workflow 优雅跳过），main 改了文档不会自动上线。⇒ **一旦 to
 
 ```bash
 # 不要 unpublish（npm 24h 之后禁 unpublish 且影响信誉）
-# 改用 dist-tag 把 latest 指回上一稳定版本：
-npm dist-tag add @sleep2agi/<pkg>@<old-stable> latest
+# 改用 dist-tag 把 latest 指回上一稳定版本 —— 同样走 workflow，不在本机敲：
+gh workflow run promote-latest.yml \
+  -f package=<pkg> -f version=<old-stable> \
+  -f must_contain='<只有 old-stable 才有的串>' -f ack=true --ref main
 # 然后立刻发一个修复版 preview，重走完整 SOP
 ```
 


### PR DESCRIPTION
## 我上一个 PR 漏了两处

[#1583](https://github.com/sleep2agi/agent-network/pull/1583) 把 `RELEASE-SOP` 的本机 `npm publish` 改成了走 workflow。但我当时**只 grep 了 `npm publish` 这一个词**，于是漏掉：

### 1. `CONTRIBUTING.md` §Releasing —— 这是新贡献者真正会读的那一份

```
4. **`npm publish --tag preview`** first …
5. After manual smoke test, promote: `npm dist-tag add @sleep2agi/<pkg>@x.y.z latest`

Note: no CI auto-publish workflow yet …; all `npm publish` is manual by a maintainer.
```

🔴 **最后那句不是过时的建议，是一句已经不成立的事实断言。** `release.yml` 里有 `publish (preview only)` job，四门全绿才发。

一个人读到「**没有** CI 发版流程」，自然就会去本机发 —— 这句话不只是没更新，它**主动把人推向**那个出过事故的动作。

一份 SOP 修好了、而 CONTRIBUTING 还在教旧办法，等于没修：CONTRIBUTING 是门槛更低、被读得更多的那一份。

### 2. `RELEASE-SOP` §5 出错回滚 —— 我在同一个文件里自相矛盾

我在 Step 8 写下「本机 `npm dist-tag add` 同样属于本机发包，一并禁掉」，却漏了 550 行回滚段：

```bash
npm dist-tag add @sleep2agi/<pkg>@<old-stable> latest
```

**而回滚恰恰是最容易跳过安全流程的时刻** —— 出事了、着急、手边就有一条能立刻生效的命令。

## 这次怎么避免再漏

改之前把动词**枚举全**（`npm publish` / `npm dist-tag` / `npm unpublish`），在所有指导性文档上搜一遍，而不是只搜我脑子里当时想着的那一个词。

改完复查，指导性文档里已无残留（记录类的历史行仍**刻意保留**，理由见 #1583）。

## 门

`check-docs-integrity` / `check-doc-symbol-pins` 本地 rc=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)