### PR TITLE
chore(release): agent-network 2.3.0-preview.73 —— 三条「报错指错方向」的修复

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.72",
+  "version": "2.3.0-preview.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.72",
+      "version": "2.3.0-preview.73",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.72",
+  "version": "2.3.0-preview.73",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.72";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.73";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.56";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.72 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.73 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.72` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.73` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.72 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.73 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.72`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.73`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.73.md
+++ b/docs/tests/release-v2.3.0-preview.73.md
@@ -1,0 +1,83 @@
+# `@sleep2agi/agent-network@2.3.0-preview.73`
+
+## 为什么发这一版：三条「报错指错方向」的修复
+
+这一版全部是同一族缺陷：**命令没崩，但它告诉你的原因是错的**，于是人朝错的方向使劲。
+
+| # | 以前说什么 | 实际是什么 |
+|---|---|---|
+| [#1580](https://github.com/sleep2agi/agent-network/pull/1580) | 「升级 agent-node 才能看到」 | 升级不够 —— daemon 是长驻进程，**必须重启** |
+| [#1581](https://github.com/sleep2agi/agent-network/pull/1581) | 「连不上 hub」 | hub 完全可达，是**本机 CLI 没凭据**（HTTP 401） |
+| [#1586](https://github.com/sleep2agi/agent-network/pull/1586) | （什么都不说） | daemon 启动时就该告诉你：**你装了 grok，但这台 daemon 看不见它** |
+
+### #1580 —— 升级不等于生效
+
+`anet daemon list` 的两条文案叫人升级 `agent-node`，都没说要重启。而 daemon 是长驻进程，
+这一格由它**在进程内**算出；换掉磁盘上的包，对一个已经在跑的进程没有任何影响。
+真机上（Mac mini，daemon 已跑很久、agent-node 是 `.46`）照着做完仍显示「未知」。
+
+### #1581 —— 401 不是「连不上」
+
+实测同一台机器同一刻：`/health` → **200，0.79s**；`/api/host-supervisors` → **401**。
+`fetchDaemonCapabilities()` 以前把**五种**失败（没配 hub / HTTP 错 / 401·403 / 应答读不懂 /
+真连不上）全部返回 `null`，然后只印「连不上 hub」——而那句只对应其中一种。
+现在五种各说各的，401 明说「hub 是通的，要修的是凭据」并给出 `anet login`。
+
+### #1586 —— 在 daemon 启动时就说，而不是等节点报错
+
+真机上那条链是：daemon 的 PATH 少了 `~/.grok/bin` → 建节点（**子节点继承 daemon 的 PATH**）
+→ 节点报 `grok CLI not found` → 用户问它才看到。**问题在 daemon 这边，报错出现在节点那边。**
+现在 `anet daemon start` 直接说，并给出可粘贴的 `export`。
+
+🔴 只在「**装了、却不在 PATH 上**」时出声；「压根没装」不报 —— 因为 `daemon init` 默认声称
+支持全部 runtime，逐个警告会让一台只跑 claude 的机器每次启动刷一屏无关内容，
+**那种警告一周内就会被无视，等于悄悄删掉它**。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.73
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.73
+# 🔴 本机的 anet 升级即生效;但**远端那台 daemon**要重启才会用新逻辑:
+anet node stop <daemon> && anet daemon start <daemon>
+```
+
+验收（SOP §2.5 四步，第 ④ 步不能省）：
+
+```bash
+npm view @sleep2agi/agent-network dist-tags.preview            # 期望 2.3.0-preview.73
+npm pack @sleep2agi/agent-network@2.3.0-preview.73
+tar -xzf *.tgz
+D=package/dist/src/daemon-capability-display.js
+grep -c '必须重启 daemon'        $D   # 期望 >0  (#1580)
+grep -c 'hub 拒绝了本机的身份'   $D   # 期望 >0  (#1581)
+grep -c '升级它才能看到'         $D   # 期望 ==0 (旧文案已消失)
+node package/dist/bin/cli.js --version                          # ④ 真的跑一次
+```
+
+🔴 **为什么验收位置是 `dist/src/daemon-capability-display.js` 而不是 `cli.js`**：
+这个包的 build 会对 `cli.js` / `client.js` / `node-server.js` 跑
+`javascript-obfuscator --string-array-encoding base64`，**裸 grep 在混淆产物上会骗人**。
+`daemon-capability-display.js` 不在混淆名单里（它要在浏览器里被 dashboard import），
+所以它是这个包唯一可靠的字符串验收位置。**这条判据不能从 agent-node 那个包照抄** ——
+那个包只 `--minify` 不混淆。
+
+🔴 **三条判据都先在已发布的 `.72` 上量过两侧**，不是照着猜：
+
+```
+.72:  必须重启 daemon      = 0     ← 目标串在上一版确实不存在
+.72:  hub 拒绝了本机的身份 = 0     ← 同上
+.72:  升级它才能看到       = 1     ← 旧文案在上一版确实存在(所以 .73 变 0 才有信息量)
+```
+
+## 发布方式
+
+`release-gate (v0)`，`package=agent-network`、`version=2.3.0-preview.73`、`publish=true`，
+`--ref main`。只发 preview；promote 到 latest 需要 owner ACK，本次**不做**。
+
+🔴 本机不发包（Vincent 2026-08-27 定）。


### PR DESCRIPTION
## 这一版发什么

三条修复都是同一族缺陷：**命令没崩，但它告诉你的原因是错的**，于是人朝错的方向使劲。三条今天都已进 main，但**没在任何 npm 包里**。

| PR | 以前说什么 | 实际是什么 |
|---|---|---|
| #1580 | 「升级 agent-node 才能看到」 | 升级不够 —— daemon 是长驻进程，**必须重启** |
| #1581 | 「连不上 hub」 | hub 完全可达（实测 `/health` 200 / 0.79s），是**本机 CLI 没凭据**（401） |
| #1586 | （什么都不说） | daemon 启动时就该说：**你装了 grok，但这台 daemon 看不见它** |

## 🔴 验收位置不能从上一个包照抄

这个包的 build 会对 `cli.js` / `client.js` / `node-server.js` 跑 `javascript-obfuscator --string-array-encoding base64` —— **裸 grep 在混淆产物上会骗人（恒 0）**。

我实测确认 `dist/src/daemon-capability-display.js` **不在混淆名单**里（它要被 dashboard 在浏览器里 import），三条改动也恰好都落在那个模块，所以它是这个包可靠的验收位置。

`agent-node@2.5.0-preview.56` 那次用的是 `dist/cli.js`，因为**那个包只 `--minify` 不混淆** —— 两个包不一样，判据不能互抄。

## 🔴 三条判据先在已发布的 `.72` 上量过两侧

```
.72:  必须重启 daemon       = 0     ← 目标串上一版确实不存在
.72:  hub 拒绝了本机的身份  = 0     ← 同上
.72:  升级它才能看到        = 1     ← 旧文案上一版确实存在，所以 .73 变 0 才有信息量
```

不只是「新串出现」，还包含「**旧的错误说法消失**」。

## 手工改的两处（sync 脚本不覆盖）

- **机器戳 ×2**（中英）→ gate 4 检查，本地已模拟：`4 个戳 across 2 docs 全部指向 .73`
- **人读表格行 ×2**（中英）

🔴 人读那一行是**实测记录**，不是说明文字。它写着「未逐版本重测：生成密码的 `server/src/auth.ts` 自 `.49` 发布起**零提交**」。我在改版本号前**复核了这个前提此刻仍成立**（0 commits，并带正控确认该路径本身有提交历史，排除路径写错造成的假 0）—— 前提成立，顺延才合法，否则就是声称做过一次没做过的测试。

中英两份的格式**不一样**（`(当前 preview)` vs `(current preview)`，后者多一个空格），**没有假设中英对称**，是分别定位改的。

## 合并后

```bash
gh workflow run release.yml -f package=agent-network -f version=2.3.0-preview.73 -f publish=true --ref main
```

只发 preview；promote latest 要 owner ACK，本次不做。

## 门

gate 3 三条判据 + gate 4 + `check-docs-integrity` 本地全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)