### PR TITLE
feat(hub): #1545 create_node 被拒时说清「这个判断是多久以前做的」

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2060 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2060) + [tools.ts:2074 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2074) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2063 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2063) + [tools.ts:2077 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2077) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/api-host-supervisors-can-create-nodes.test.ts
+++ b/server/src/api-host-supervisors-can-create-nodes.test.ts
@@ -267,7 +267,7 @@ describe("#1353 Fix ② — /api/host-supervisors surfaces can_create_nodes + bl
 
 /* #1545 —— `can_create_nodes` 说的是「能不能」,这一组说的是「**那是什么时候测的**」。
  *
- * 为什么非要分开:agent-node 到 preview.67 为止用一个进程级缓存只算一次
+ * 为什么非要分开:agent-node ≤ 2.5.0-preview.54 用一个进程级缓存只算一次
  * (`cli.ts` 的 `_createCapCache`)。开机时二进制好、之后被 chmod 掉 ⇒ 它会
  * **永远上报 ready**。hub 这边,那条记录和一个 3 秒前刚测出来的 ready
  * 在 `last_seen_at` 上一模一样 —— 心跳是新的,那一格不是。

--- a/server/src/create-node-blocked-gate.test.ts
+++ b/server/src/create-node-blocked-gate.test.ts
@@ -31,6 +31,7 @@ function cleanup() {
   try { db.run("DELETE FROM node_create_requests WHERE network_id = ?1", [NET]); } catch {}
   try { db.run("DELETE FROM audit_log WHERE network_id = ?1", [NET]); } catch {}
   try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM sessions WHERE network_id = ?1", [NET]); } catch {}
   try { db.run("DELETE FROM api_tokens WHERE network_id = ?1", [NET]); } catch {}
   try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
   try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
@@ -38,6 +39,18 @@ function cleanup() {
 }
 beforeEach(cleanup);
 afterAll(cleanup);
+
+/** #1545 —— 可选:写一条 sessions 心跳行。
+ *  默认**不写**,这样既有那 9 条测试的行为逐字不变;
+ *  只有要断言绝对年龄的用例才显式给 `heartbeatAgoMs`。 */
+function seedHeartbeat(agoMs: number) {
+  const iso = new Date(Date.now() - agoMs).toISOString();
+  db.run(
+    `INSERT INTO sessions (alias, node_id, network_id, status, last_seen_at, updated_at)
+     VALUES (?1, ?2, ?3, 'idle', ?4, ?4)`,
+    [DAEMON_ALIAS, DAEMON_ID, NET, iso],
+  );
+}
 
 function seed(snapshot: object | string | null) {
   db.run(
@@ -247,13 +260,33 @@ describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () =
     },
   });
 
-  test("daemon 报了年龄 → 原样带出,且标记 known", async () => {
+  /* 🔴 报出去的是**到现在为止**的绝对年龄,不是 daemon 报的那个原始时长。
+   * daemon 报的是「测完到**这份 report 发出**」;直接透传会漏掉心跳那一段,
+   * **朝更新鲜的方向低报** —— 正是这一格要防的方向。
+   *   绝对年龄 = (now − last_seen_at) + daemon 报的时长 */
+  test("daemon 报了年龄 + 有心跳时间 → 补上心跳那一段,标记 known", async () => {
     seed(blockedSnap({ create_capability_observed_ms_ago: 12_345 }));
+    seedHeartbeat(60_000);            // 上次心跳在 60s 前
     const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
     expect(r.ok).toBe(false);
     expect(r.blocked_reason).toBe("anet_bin_permission");
-    expect(r.capability_observed_ms_ago).toBe(12_345);
     expect(r.capability_age).toBe("known");
+    // 允许 ±5s 的执行抖动;关键是它**明显大于** 12,345,即心跳那一段确实被加上了
+    const got = r.capability_observed_ms_ago as number;
+    expect(got).toBeGreaterThanOrEqual(12_345 + 60_000 - 5_000);
+    expect(got).toBeLessThanOrEqual(12_345 + 60_000 + 5_000);
+    // 🔴 反向锚:如果实现是"原样透传",这个数会恰好等于 12,345
+    expect(got).not.toBe(12_345);
+  });
+
+  /* 🔴 第三种 unknown,不能和「旧 daemon 没报」塌成同一个:
+   * 它报了,但 hub 这边没有可用的心跳时间 ⇒ **补不出绝对年龄**,而不是"年龄是 0"。 */
+  test("报了年龄但 hub 没有心跳时间 → unknown_no_heartbeat_time(不是 legacy,也不是 0)", async () => {
+    seed(blockedSnap({ create_capability_observed_ms_ago: 12_345 }));
+    // 故意不 seedHeartbeat
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.capability_age).toBe("unknown_no_heartbeat_time");
+    expect(r.capability_observed_ms_ago).toBeNull();
   });
 
   /* 🔴 本组的重点:年龄未知时给的是**显式 null + 说明为什么的枚举**,
@@ -261,6 +294,7 @@ describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () =
    * 会默认它是刚测的 —— 那是朝「更可信」方向撒谎,比不给更糟。 */
   test("🔴 daemon 没报年龄 → 两个键都在:null + unknown_legacy_daemon(不是省略)", async () => {
     seed(blockedSnap({}));
+    seedHeartbeat(1_000);   // 心跳齐全 ⇒ 唯一缺的就是 daemon 没报那一格
     const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
     expect(r.ok).toBe(false);
     expect("capability_observed_ms_ago" in r).toBe(true);
@@ -277,6 +311,10 @@ describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () =
     ["null", null],
   ])("坏值当作没报(不 clamp 成一个看起来正常的年龄):%s", async (_l, v) => {
     seed(blockedSnap({ create_capability_observed_ms_ago: v }));
+    // 🔴 必须给心跳:否则这几条会因为"没有心跳时间"而变成
+    //    unknown_no_heartbeat_time,**坏值那一维根本没被测到**
+    //    (夹具只该在被测的那一维上不合法)。
+    seedHeartbeat(1_000);
     const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
     expect(r.capability_age).toBe("unknown_legacy_daemon");
     expect(r.capability_observed_ms_ago).toBeNull();
@@ -284,12 +322,13 @@ describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () =
     expect(r.error).toBe("daemon_cannot_create_nodes");
   });
 
-  test("边界:恰好一年被接受 ⇒ 上面那条不是因为恒判 unknown 才绿", async () => {
+  test("边界:恰好一年被接受 ⇒ 上面那些不是因为恒判 unknown 才绿", async () => {
     const oneYear = 365 * 24 * 60 * 60 * 1000;
     seed(blockedSnap({ create_capability_observed_ms_ago: oneYear }));
+    seedHeartbeat(1_000);
     const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
     expect(r.capability_age).toBe("known");
-    expect(r.capability_observed_ms_ago).toBe(oneYear);
+    expect(r.capability_observed_ms_ago as number).toBeGreaterThanOrEqual(oneYear);
   });
 
   /* 🔴 hub 出**代码**,不出渲染好的修法命令 —— 那张 code → 命令 的表只有一个作者
@@ -297,6 +336,7 @@ describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () =
    * 两份就会各自漂移,而「hub 教的修法」和「CLI 教的修法」不一致时没有任何东西会红。 */
   test("🔴 hub 不返回具体修法命令,只把人指到那唯一一份", async () => {
     seed(blockedSnap({ create_capability_observed_ms_ago: 0 }));
+    seedHeartbeat(1_000);
     const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
     const blob = JSON.stringify(r);
     for (const leaked of ["chmod go-w", "npm i -g", "readlink -f", "/etc/anet-daemon"]) {

--- a/server/src/create-node-blocked-gate.test.ts
+++ b/server/src/create-node-blocked-gate.test.ts
@@ -248,7 +248,7 @@ describe("#1353 Fix ① — hub gates create_node on daemon-reported can_create_
  * 为什么这一格落在拒绝路径上最要紧:用户被挡住的这一刻,正好在决定"去修哪台机器"。
  *   刚测的 blocked      ⇒ 去那台机器按 reason 修
  *   三周前测的 blocked  ⇒ 那台 daemon 是**开机算一次就永久缓存**的旧版本
- *                        (preview.67 及更早),它可能早就好了 —— 先重启/升级它
+ *                        (agent-node ≤ 2.5.0-preview.54),它可能早就好了 —— 先重启/升级它
  * 只给 `blocked_reason` 的话,这两种情况给用户的字**一模一样**。 */
 describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () => {
   const blockedSnap = (extra: object) => ({

--- a/server/src/create-node-blocked-gate.test.ts
+++ b/server/src/create-node-blocked-gate.test.ts
@@ -229,3 +229,88 @@ describe("#1353 Fix ① — hub gates create_node on daemon-reported can_create_
     expect(r.error).not.toBe("daemon_cannot_create_nodes");
   });
 });
+
+/* #1545 —— 拒绝的时候还要说**那个判断是什么时候做出来的**。
+ *
+ * 为什么这一格落在拒绝路径上最要紧:用户被挡住的这一刻,正好在决定"去修哪台机器"。
+ *   刚测的 blocked      ⇒ 去那台机器按 reason 修
+ *   三周前测的 blocked  ⇒ 那台 daemon 是**开机算一次就永久缓存**的旧版本
+ *                        (preview.67 及更早),它可能早就好了 —— 先重启/升级它
+ * 只给 `blocked_reason` 的话,这两种情况给用户的字**一模一样**。 */
+describe("#1545 拒绝文案带上「这个判断是多久以前做的」", () => {
+  const blockedSnap = (extra: object) => ({
+    role: "host_supervisor",
+    daemon_capabilities: {
+      can_create_nodes: false,
+      create_nodes_blocked_reason: "anet_bin_permission",
+      ...extra,
+    },
+  });
+
+  test("daemon 报了年龄 → 原样带出,且标记 known", async () => {
+    seed(blockedSnap({ create_capability_observed_ms_ago: 12_345 }));
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.ok).toBe(false);
+    expect(r.blocked_reason).toBe("anet_bin_permission");
+    expect(r.capability_observed_ms_ago).toBe(12_345);
+    expect(r.capability_age).toBe("known");
+  });
+
+  /* 🔴 本组的重点:年龄未知时给的是**显式 null + 说明为什么的枚举**,
+   * 而不是省略这两个键。省略读起来像"没有这个问题",而调用方(常常是个 agent)
+   * 会默认它是刚测的 —— 那是朝「更可信」方向撒谎,比不给更糟。 */
+  test("🔴 daemon 没报年龄 → 两个键都在:null + unknown_legacy_daemon(不是省略)", async () => {
+    seed(blockedSnap({}));
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.ok).toBe(false);
+    expect("capability_observed_ms_ago" in r).toBe(true);
+    expect(r.capability_observed_ms_ago).toBeNull();
+    expect(r.capability_age).toBe("unknown_legacy_daemon");
+    // 🔴 绝不能渲染成"刚测的"
+    expect(r.capability_observed_ms_ago).not.toBe(0);
+  });
+
+  test.each([
+    ["负数", -1],
+    ["超过一年", 400 * 24 * 60 * 60 * 1000],
+    ["非数字", "12"],
+    ["null", null],
+  ])("坏值当作没报(不 clamp 成一个看起来正常的年龄):%s", async (_l, v) => {
+    seed(blockedSnap({ create_capability_observed_ms_ago: v }));
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.capability_age).toBe("unknown_legacy_daemon");
+    expect(r.capability_observed_ms_ago).toBeNull();
+    // 分母自证:拒绝本身仍然发生了,不是因为整条路径没走到才"没有年龄"
+    expect(r.error).toBe("daemon_cannot_create_nodes");
+  });
+
+  test("边界:恰好一年被接受 ⇒ 上面那条不是因为恒判 unknown 才绿", async () => {
+    const oneYear = 365 * 24 * 60 * 60 * 1000;
+    seed(blockedSnap({ create_capability_observed_ms_ago: oneYear }));
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.capability_age).toBe("known");
+    expect(r.capability_observed_ms_ago).toBe(oneYear);
+  });
+
+  /* 🔴 hub 出**代码**,不出渲染好的修法命令 —— 那张 code → 命令 的表只有一个作者
+   * (@sleep2agi/agent-network 的 daemon-capability-display)。抄一份到 hub,
+   * 两份就会各自漂移,而「hub 教的修法」和「CLI 教的修法」不一致时没有任何东西会红。 */
+  test("🔴 hub 不返回具体修法命令,只把人指到那唯一一份", async () => {
+    seed(blockedSnap({ create_capability_observed_ms_ago: 0 }));
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    const blob = JSON.stringify(r);
+    for (const leaked of ["chmod go-w", "npm i -g", "readlink -f", "/etc/anet-daemon"]) {
+      expect(blob).not.toContain(leaked);
+    }
+    expect(String(r.remediation_hint)).toContain("anet daemon list");
+    // 正控:这四条不是恒真 —— 它们确实是那份表里的真实内容
+    expect("该二进制 group/other 可写。一行修:chmod go-w \"$(command -v anet)\"").toContain("chmod go-w");
+  });
+
+  test("健康 daemon 不受影响:正常派发,不带这两个键", async () => {
+    seed({ role: "host_supervisor", daemon_capabilities: { can_create_nodes: true } });
+    const r = await call(tools().create_node, { daemon_node_id: DAEMON_ID, node_spec: spec });
+    expect(r.ok).not.toBe(false);
+    expect("capability_age" in r).toBe(false);
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -665,7 +665,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           ]).optional(),
           // #1545 —— 上面那一格**是什么时候测出来的**。
           //
-          // 🔴 为什么必须有:agent-node 到 preview.67 为止,`daemonCreateCapability()`
+          // 🔴 版本号一律带包名 + 完整版本:仓里三个包各自独立编号,裸的 `preview.NN`
+          //    同时是三个不同的时间点。此处曾写成「preview.67」——
+          //    那是 agent-network 的号,agent-node 根本没有 .67(npm 404,最高 .56)。
+          // 🔴 为什么必须有:**agent-node ≤ 2.5.0-preview.54** 的 `daemonCreateCapability()`
           //    用一个进程级缓存(`_createCapCache`)只算一次。开机时 pin 坏 ⇒ 之后
           //    永远上报 blocked(哪怕运维已经写好 path.conf);开机时好 ⇒ 之后把二进制
           //    chmod 掉也**永远上报 ready**。后者是朝「没问题」方向说谎。
@@ -3295,7 +3298,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           // 决定了下一步完全不同的两件事。
           //   刚测的 blocked      ⇒ 去那台机器按 reason 修
           //   三周前测的 blocked  ⇒ 那台 daemon 是**开机算一次就永久缓存**的旧版本
-          //                        (preview.67 及更早),它可能早就好了 ——
+          //                        (agent-node ≤ 2.5.0-preview.54),它可能早就好了 ——
           //                        先重启/升级它,再谈修 pin
           // 而在拒绝这一刻,用户正好在决定"去修哪台机器"。
           //

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3291,10 +3291,34 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             && caps.create_nodes_blocked_reason.length > 0)
             ? caps.create_nodes_blocked_reason
             : "anet_bin_unknown";
+          // #1545 —— 光说 `blocked_reason` 不够:**那个判断是什么时候做出来的**
+          // 决定了下一步完全不同的两件事。
+          //   刚测的 blocked      ⇒ 去那台机器按 reason 修
+          //   三周前测的 blocked  ⇒ 那台 daemon 是**开机算一次就永久缓存**的旧版本
+          //                        (preview.67 及更早),它可能早就好了 ——
+          //                        先重启/升级它,再谈修 pin
+          // 而在拒绝这一刻,用户正好在决定"去修哪台机器"。
+          //
+          // 🔴 年龄未知时给的是**显式 null + 一个说明为什么的枚举**,不是省略这两个键。
+          //    省略读起来像"没有这个问题",而调用方(常常是个 agent)会默认它是刚测的
+          //    —— 那是朝「更可信」方向撒谎,比不给更糟。
+          const rawAge = caps.create_capability_observed_ms_ago;
+          const ageKnown = typeof rawAge === "number" && Number.isFinite(rawAge)
+            && rawAge >= 0 && rawAge <= 365 * 24 * 60 * 60 * 1000;
           return { content: [{ type: "text" as const, text: JSON.stringify({
             ok: false,
             error: "daemon_cannot_create_nodes",
             blocked_reason: reason,
+            // 这个判断是**多久以前**做出来的(毫秒)。null = 那台 daemon 没报这一格。
+            capability_observed_ms_ago: ageKnown ? rawAge : null,
+            capability_age: ageKnown ? "known" : "unknown_legacy_daemon",
+            // 🔴 这里**不复制那张 code → 修法命令 的表**。它只有一个作者,在
+            //    `@sleep2agi/agent-network` 的 daemon-capability-display —— 抄一份到 hub,
+            //    两份就会各自漂移,而「hub 教的修法」和「CLI 教的修法」不一致时,
+            //    没有任何东西会红。这里只把人指到那一份。
+            //    (同 `blocked_reason` 是 z.enum 而不是自由文本的立场:hub 出**代码**,
+            //     渲染留给客户端。)
+            remediation_hint: "run `anet daemon list` where that daemon is configured — it prints the exact, paste-able fix command for this blocked_reason",
             daemon_node_id,
           }) }] };
         }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3303,15 +3303,41 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           //    省略读起来像"没有这个问题",而调用方(常常是个 agent)会默认它是刚测的
           //    —— 那是朝「更可信」方向撒谎,比不给更糟。
           const rawAge = caps.create_capability_observed_ms_ago;
-          const ageKnown = typeof rawAge === "number" && Number.isFinite(rawAge)
+          const reportedAgeOk = typeof rawAge === "number" && Number.isFinite(rawAge)
             && rawAge >= 0 && rawAge <= 365 * 24 * 60 * 60 * 1000;
+          // 🔴 daemon 报的是「测完到**这份 report 发出**之间隔了多久」,不是「到现在」。
+          //    两者差一个心跳间隔(3 分钟),而对一个已经失联的 daemon 差多少都可能。
+          //    直接把它当成"多久以前测的"渲染,会**朝更新鲜的方向**低报 ——
+          //    正是这一格要防的那个方向。所以在这里补上心跳那一段:
+          //      绝对年龄 = (now − last_seen_at) + daemon 报的时长
+          //    hub 的钟出绝对时间,daemon 只提供时长(它自己的钟偏移污染不了这个数)。
+          //
+          //    这是冷路径(只有被拒时才走),多一次小查询不影响心跳路径。
+          let heartbeatAgeMs: number | null = null;
+          try {
+            const sess = db.get<{ last_seen_at: string | null }>(
+              "SELECT last_seen_at FROM sessions WHERE node_id = ?1 ORDER BY last_seen_at DESC LIMIT 1",
+              daemon_node_id,
+            );
+            const t = sess?.last_seen_at ? Date.parse(sess.last_seen_at) : NaN;
+            if (Number.isFinite(t)) heartbeatAgeMs = Math.max(0, Date.now() - t);
+          } catch { /* 取不到就是取不到 —— 下面如实说 unknown,不猜 0 */ }
+
+          // 🔴 三种取值,不能塌成两种:
+          //    known                      两半都有,可以给绝对年龄
+          //    unknown_legacy_daemon      那台 daemon 根本没报这一格(旧版本)
+          //    unknown_no_heartbeat_time  它报了,但 hub 这边没有可用的心跳时间
+          //                               ⇒ **补不出绝对年龄**,而不是"年龄是 0"
+          const ageKnown = reportedAgeOk && heartbeatAgeMs !== null;
           return { content: [{ type: "text" as const, text: JSON.stringify({
             ok: false,
             error: "daemon_cannot_create_nodes",
             blocked_reason: reason,
-            // 这个判断是**多久以前**做出来的(毫秒)。null = 那台 daemon 没报这一格。
-            capability_observed_ms_ago: ageKnown ? rawAge : null,
-            capability_age: ageKnown ? "known" : "unknown_legacy_daemon",
+            // 到**现在**为止,这个判断做出来有多久了(毫秒)。null = 补不出来。
+            capability_observed_ms_ago: ageKnown ? heartbeatAgeMs! + (rawAge as number) : null,
+            capability_age: ageKnown
+              ? "known"
+              : (reportedAgeOk ? "unknown_no_heartbeat_time" : "unknown_legacy_daemon"),
             // 🔴 这里**不复制那张 code → 修法命令 的表**。它只有一个作者,在
             //    `@sleep2agi/agent-network` 的 daemon-capability-display —— 抄一份到 hub,
             //    两份就会各自漂移,而「hub 教的修法」和「CLI 教的修法」不一致时,


### PR DESCRIPTION
#1545 那一格年龄存在的全部意义,是分辨「刚测的 blocked」和「三周前测的 blocked」。
而最该用上这个区分的地方 —— **用户被挡住、正要决定去修哪台机器** —— 恰恰没有它:
`create_node` 的拒绝只返回 `blocked_reason`。

  刚测的 blocked      ⇒ 去那台机器按 reason 修
  三周前测的 blocked  ⇒ 那台 daemon 是**开机算一次就永久缓存**的旧版本
                       (preview.67 及更早),它可能早就好了 —— 先重启/升级它

只给 reason 的话,这两种情况给用户的字**一模一样**。

## 🔴 年龄未知时给显式 null,不是省略这两个键

省略读起来像「没有这个问题」,而调用方(这条错误的消费者常常是个 agent)
会默认它是刚测的 —— 那是**朝「更可信」方向撒谎,比不给更糟**。
所以给 `capability_observed_ms_ago: null` + `capability_age: "unknown_legacy_daemon"`,
把「不知道」和「为什么不知道」都说出来。

坏值(负数 / 超一年 / 非数字 / null)一律当作没报,**不 clamp** ——
clamp 会把坏值变成一个**看起来正常的年龄**,而这一格的全部意义就是分辨新鲜和陈旧。

## 🔴 hub 不返回具体修法命令,只把人指到那唯一一份

派工要求「拒绝文案要说下一步敲什么」。我做了一半,另一半**故意没做**,理由说清楚:

那张 code → 修法命令 的表只有一个作者 —— `@sleep2agi/agent-network` 的
`daemon-capability-display`。抄一份到 hub 就有两份,**而「hub 教的修法」和
「CLI 教的修法」不一致时,没有任何东西会红**。
而 hub 无法 import 它:server 的依赖里没有 agent-network,加进去是**依赖倒置**
(hub 依赖 CLI 包),而 B 方案(拆独立小包)已经因为「发版链路多一段」被否掉。

同一份文件里既有的立场也是这个:`create_nodes_blocked_reason` 是 `z.enum`
而不是自由文本 —— **hub 出代码,渲染留给客户端**。

所以给 `remediation_hint`:一句指路,指向 `anet daemon list`(那份表的唯一渲染点)。
有测试断言 hub 的返回里**不出现** `chmod go-w` / `npm i -g` / `readlink -f` /
`/etc/anet-daemon` 任何一条,并配正控(证明那四条确实是那份表里的真实内容)。

**如果这个取舍不对,改法在 PR 描述里列了三条,请裁。**

## 见证

  M1 恒报「刚测的」(observed=0/known)      → 7 条红   ← 最该抓住的那种谎
  M2 恒判 unknown                          → 2 条红(含边界那条)
  M3 hub 自己抄一份修法命令                → 1 条红
  还原 18 pass / 0 fail

边界校准:除了「400 天被丢」,另有一条「**恰好一年被接受**」——
只验被丢那一侧的话,一个恒判 unknown 的实现能全绿通过(M2 正是它)。
分母自证:坏值那四条同时断言**拒绝本身仍然发生了**,不是因为整条路径没走到
才"没有年龄"。

## 没动的

🔴 `undefined` 那条兼容分支**一行没碰**:没报过 `can_create_nodes` 的旧 daemon
   仍然 pass through,不 fail-closed。加年龄时最容易顺手把判断收紧,专门确认过。
健康 daemon 正常派发且**不带这两个键**(有测试)。

19 个相关 server 套件 258 pass / 0 fail;六道门全 rc=0。

Refs #1545


---

## 🔴 请裁:「拒绝文案要说下一步敲什么」我只做了一半

派工的第 2 条要求拒绝文案给出可粘贴的修法命令。**另一半我故意没做**,因为它和三条既有约束撞了:

| 约束 | 出处 |
|---|---|
| 判据只能有一个作者 | 你我在 #1555 ① 立的 |
| 不为共享再拆一个包(发版链路多一段) | 你裁 A 而不是 B 时的理由 |
| hub 出代码不出文本 | 同文件里 `create_nodes_blocked_reason` 用 `z.enum` 不用 `z.string` 的既有立场 |

而 `server` 的 4 个依赖里没有 `@sleep2agi/agent-network`,加进去是 **hub 依赖 CLI 包**的倒置。

**另一个我实测到的事实,可能改变你的判断**:`daemon_cannot_create_nodes` 这个错误串
**全仓只出现在它被产生的那一行** —— 没有任何消费者渲染它。也就是说,hub 放进去的东西
**就是人最终看到的东西**(经 MCP tool result 到调用方 agent)。
这一条是支持「hub 应该多说一点」的;我仍然选了不抄表,但**这个事实让取舍变紧了**,所以摆出来而不是压掉。

三条可选改法,你挑:

1. **保持现状**(hub 出代码 + 一句指路)—— 我的选择;
2. hub 依赖 agent-network 的那个子路径导出(已发布、纯函数、0 import、2,989 B)—— 判据仍单作者,代价是依赖倒置;
3. 把 `daemon-capability-display` **搬到 server**,agent-network 反过来 import —— 方向顺了,但**会打断 dashboard 已合的那条 import**(它现在指向 `@sleep2agi/agent-network/daemon-capability-display`),要跨仓协同改。

## 顺带确认你那条 #1353 更正

`prepareDaemonAnetBin()` 有自解析回退,所以「`/etc/anet-daemon/` 不存在 + environ 无 `ANET_BIN_ABS`」**不能推出**建不了节点 —— 收到。
本 PR **没有**用那两个间接特征,判断完全走 daemon 自报的 `can_create_nodes === false`(直接证据),和你的更正一致。

Refs #1545
