### PR TITLE
feat(display): #1545 describeCreateRejection —— 拒绝载荷也走同一份修法表

### DIFF
--- a/agent-network/src/daemon-capability-display.test.ts
+++ b/agent-network/src/daemon-capability-display.test.ts
@@ -7,7 +7,7 @@
 //    不同的话**。全渲染成 "blocked" 的实现能通过任何只检查"有没有输出"的测试。
 
 import { describe, expect, test } from "bun:test";
-import { describeCapability, describeFetchFailure, formatAge, type CapabilityFetchFailure } from "./daemon-capability-display.js";
+import { describeCapability, describeFetchFailure, formatAge, type CapabilityFetchFailure, describeCreateRejection } from "./daemon-capability-display.js";
 
 const NOW = 1_700_000_000_000;
 const iso = (ms: number) => new Date(ms).toISOString();
@@ -367,5 +367,96 @@ describe("🔴 取不到这一格的五种原因,必须说成五句不同的话"
 
   test("🔴 分母自证:确实枚举了 5 种 why,不是空跑", () => {
     expect(new Set(ALL.map(f => f.why)).size).toBe(5);
+  });
+});
+
+/* #1545 —— hub 拒绝 create_node 时那条载荷的渲染。
+ *
+ * 缺口是实测的:代理路由 `app/api/anet/node-create/route.ts` **已经把 hub 的完整
+ * `result` 透传出来**,而向导只渲染 `创建失败:${data.error}` ⇒ 用户看到的是裸的
+ * `创建失败:daemon_cannot_create_nodes`,hub 辛苦算出来的 reason/年龄全被丢掉。 */
+describe("#1545 describeCreateRejection —— 拒绝载荷的渲染", () => {
+  const base = { error: "daemon_cannot_create_nodes", blocked_reason: "anet_bin_permission" };
+
+  test("不是这类拒绝 → 返回 null(调用方走它自己的通用文案)", () => {
+    expect(describeCreateRejection({ error: "node_name_conflict" })).toBeNull();
+    expect(describeCreateRejection({})).toBeNull();
+  });
+
+  test("年龄已知 → kind=blocked,并把年龄写进句子", () => {
+    const v = describeCreateRejection({ ...base, capability_age: "known", capability_observed_ms_ago: 65_000 })!;
+    expect(v.kind).toBe("blocked");
+    expect(v.line).toContain("1m 前");
+    expect(v.line).toContain("anet_bin_permission");
+  });
+
+  /* 🔴 本组的重点:两种「给不出年龄」必须是**两句不同的话**,因为动作差一台机器。
+   *   legacy       → 去升级/重启那台 daemon
+   *   no-heartbeat → 它报了,是 hub 没有心跳时间 —— 别急着升级,先看它在不在线 */
+  test("🔴 两种 unknown 的 line 逐字不同", () => {
+    const legacy = describeCreateRejection({ ...base, capability_age: "unknown_legacy_daemon", capability_observed_ms_ago: null })!;
+    const noHb = describeCreateRejection({ ...base, capability_age: "unknown_no_heartbeat_time", capability_observed_ms_ago: null })!;
+    expect(legacy.line).not.toBe(noHb.line);
+    expect(noHb.line).toContain("心跳");
+    expect(noHb.line).toContain("别急着升级");
+    expect(legacy.line).toContain("开机时算一次");
+    // 反向锚:legacy 那句**不**该出现"心跳",否则上面的区分只是碰巧
+    expect(legacy.line).not.toContain("心跳");
+  });
+
+  /* 两种 unknown 的 **kind 相同**是刻意的:kind 是呈现分桶(禁不禁用/什么色调),
+   * 而这两种在 UI 上要的处理完全一样。区分放在 line 里(上一条已钉)。
+   * 写成断言,是为了让下一个人知道这不是漏了,而是选的。 */
+  test("两种 unknown 的 kind 相同(呈现分桶一致,语义差别在 line 里)", () => {
+    const a = describeCreateRejection({ ...base, capability_age: "unknown_legacy_daemon" })!;
+    const b = describeCreateRejection({ ...base, capability_age: "unknown_no_heartbeat_time" })!;
+    expect(a.kind).toBe("blocked-age-unknown");
+    expect(b.kind).toBe("blocked-age-unknown");
+  });
+
+  test("capability_age 说 known 但数字不合法 → 退回 age-unknown,不渲染成刚测的", () => {
+    for (const bad of [null, undefined, Number.NaN, -1]) {
+      const v = describeCreateRejection({ ...base, capability_age: "known", capability_observed_ms_ago: bad as number })!;
+      expect(v.kind).toBe("blocked-age-unknown");
+    }
+    // 正控:合法值确实走 blocked —— 证明上面不是恒真
+    expect(describeCreateRejection({ ...base, capability_age: "known", capability_observed_ms_ago: 0 })!.kind).toBe("blocked");
+  });
+
+  /* 🔴 「判据只有一个作者」的可执行断言:同一个 code,拒绝路径给出的修法
+   * 必须和列 daemon 那条路径**逐字相同**。哪天有人只改了一处,这条会红。 */
+  test("🔴 修法与 describeCapability 同源(同一个 code → 逐字相同的 fix)", () => {
+    for (const code of ["anet_bin_identity", "anet_bin_source", "anet_bin_shape",
+                        "anet_bin_permission", "anet_bin_unknown", "anet_bin_pin_unresolved"]) {
+      const viaList: any = describeCapability(
+        { can_create_nodes: false, create_nodes_blocked_reason: code }, NOW);
+      const viaReject: any = describeCreateRejection(
+        { error: "daemon_cannot_create_nodes", blocked_reason: code });
+      expect(viaReject.fix).toEqual(viaList.fix);
+    }
+  });
+
+  test("未知 code → 不套用任何已知修法(本端可能比那台机器旧)", () => {
+    const v: any = describeCreateRejection({ error: "daemon_cannot_create_nodes", blocked_reason: "anet_bin_future" });
+    expect(v.fix.command).toBeNull();
+    expect(v.fix.explain).toContain("anet_bin_future");
+  });
+
+  test("🔴 渲染里不含任何机器路径", () => {
+    for (const code of ["anet_bin_identity", "anet_bin_source", "anet_bin_shape", "anet_bin_permission"]) {
+      const v = describeCreateRejection({ error: "daemon_cannot_create_nodes", blocked_reason: code })!;
+      expect(v.line).not.toContain("/home/");
+      expect(v.line).not.toContain("/Users/");
+      expect(v.line).not.toContain("node_modules");
+    }
+    // 正控:上面不是恒真 —— 通用修法确实引用了 anet 的位置,只是现解析
+    expect(describeCreateRejection({ error: "daemon_cannot_create_nodes", blocked_reason: "anet_bin_permission" })!
+      .line).toContain("command -v anet");
+  });
+
+  test("没有 blocked_reason → 兜底到 anet_bin_unknown(不猜一个具体类别)", () => {
+    const v: any = describeCreateRejection({ error: "daemon_cannot_create_nodes" });
+    expect(v.line).toContain("anet_bin_unknown");
+    expect(v.fix.command).toBeNull();
   });
 });

--- a/agent-network/src/daemon-capability-display.ts
+++ b/agent-network/src/daemon-capability-display.ts
@@ -22,7 +22,7 @@ export type DaemonCapabilityRow = {
 };
 
 export type CapabilityView =
-  /** hub 上根本没有这一格 —— 旧 daemon(preview.55 之前)不上报。 */
+  /** hub 上根本没有这一格 —— 旧 daemon(agent-node ≤ 2.5.0-preview.54)不上报。 */
   | { readonly kind: "never-reported"; readonly line: string }
   /** 报了 ready/blocked,且知道是多久以前测的。 */
   | { readonly kind: "ready" | "blocked"; readonly ageMs: number; readonly line: string; readonly fix?: CapabilityFix }
@@ -92,7 +92,7 @@ const FIX_BY_REASON: Record<string, CapabilityFix> = Object.freeze({
     command: null,
   },
   anet_bin_pin_unresolved: {
-    explain: "旧版 daemon(preview.40 及更早)只报这一个笼统原因。升级该机器的 agent-node 并重启 daemon 后才能拿到具体类别",
+    explain: "旧版 daemon(agent-node 2.5.0-preview.40 及更早)只报这一个笼统原因。升级该机器的 agent-node 并重启 daemon 后才能拿到具体类别",
     command: null,
   },
 });
@@ -145,8 +145,16 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
       return {
         kind: "ready-age-unknown",
         // 🔴 这句必须说清「不知道什么时候测的」**以及为什么**。
-        //    preview.67 及更早的 daemon 在开机时算一次就永久缓存 —— 也就是说
-        //    这个 ready 可能是几周前的事,而二进制早被换掉了。
+        //    **agent-node ≤ 2.5.0-preview.54** 的 daemon 在开机时算一次就永久缓存
+        //    —— 也就是说这个 ready 可能是几周前的事,而二进制早被换掉了。
+        //
+        // 🔴 这个版本号原先写的是「preview.67」,**指向一个不存在的版本**:
+        //    agent-node 已发布的最高 preview 是 2.5.0-preview.56(.67 是
+        //    **agent-network** 的号,两个包的序列被串了)。
+        //    实测边界:agent-node 2.5.0-preview.54 的产物里没有
+        //    `create_capability_observed_ms_ago`,.55 有。
+        //    **所以以后写代际边界一律带包名 + 完整版本号** ——
+        //    裸的 `preview.NN` 在一个有三个包各自独立编号的仓里,不指向任何东西。
         line: ("创建能力:可用\n" +
         "    ⚠ 不知道是什么时候测的 —— 该版本开机只算一次。重启它,或升级。"),
       };

--- a/agent-network/src/daemon-capability-display.ts
+++ b/agent-network/src/daemon-capability-display.ts
@@ -236,3 +236,82 @@ export function describeFetchFailure(f: CapabilityFetchFailure): string {
         + (f.detail ? `(${f.detail})` : "") + "。" + TAIL;
   }
 }
+
+// ── #1545 —— hub 拒绝 create_node 时那条载荷的渲染 ────────────────────────
+
+/**
+ * `create_node` 被拒时 hub 返回的形状(`server/src/tools.ts` 的
+ * `daemon_cannot_create_nodes` 分支)。
+ *
+ * 🔴 它和 `DaemonCapabilityRow` **不是同一个形状**,所以单独一个入口 ——
+ *    在调用方做一次字段映射,等于开出**第二个理解这些字段含义的地方**。
+ */
+export type CreateRejectionPayload = {
+  readonly error?: string;
+  readonly blocked_reason?: string;
+  /** 🔴 已经是**到现在为止**的绝对年龄(hub 在拒绝时把心跳那一段补上了)。
+   *  null = 补不出来 —— 见 `capability_age`。 */
+  readonly capability_observed_ms_ago?: number | null;
+  readonly capability_age?: string;
+};
+
+/**
+ * 把拒绝载荷渲染成人能读的一段。不是这类拒绝就返回 null,调用方走它原来的通用文案。
+ *
+ * 🔴 **这里没有第二份年龄公式。** `describeCapability` 里那段
+ * `(now − last_seen_at) + observed` 是给「列 daemon」那条路用的;
+ * 拒绝这条路上,**hub 已经算好了绝对年龄**(它手里有心跳时间)。
+ * 所以这里只做格式化,复用同一个 `formatAge`。
+ * 两份年龄算法一旦并排存在,出现分歧时不会有任何东西红。
+ *
+ * 🔴 **没有新增第六种 kind**,这是刻意的:
+ *   `kind` 是**呈现分桶**(禁不禁用、什么色调),不是完整语义。
+ *   「daemon 没报年龄」和「hub 没有它的心跳时间」在 UI 上要的处理**完全一样**
+ *   (都是 blocked、都给不出年龄),差别在**说哪句话** —— 那放在 `line` 里。
+ *   反过来,给共享联合加第六个值,会让所有既有消费者的映射多一个
+ *   它们没写过的分支,而**落进 default 的那一支通常是"看起来最正常"的那个**。
+ *   区分没有丢:两种 unknown 的 `line` 逐字不同,并有测试钉住。
+ */
+export function describeCreateRejection(
+  payload: CreateRejectionPayload,
+): CapabilityView | null {
+  if (payload?.error !== "daemon_cannot_create_nodes") return null;
+
+  const reason = payload.blocked_reason || "anet_bin_unknown";
+  const fix: CapabilityFix = FIX_BY_REASON[reason] ?? {
+    explain: `未知原因代码 ${reason} —— 本端可能比那台机器的 anet 旧,升级本端或看它的 daemon 日志`,
+    command: null,
+  };
+  const where = "完整原文(含真实路径)只在那台机器的 daemon 日志里 —— 它带机器路径,按设计不上报。";
+  const body = [
+    `原因:${fix.explain}`,
+    fix.command ? `修法(可整行粘贴):${fix.command}` : "修法:没有单条命令能修,见上。",
+    where,
+  ].join("\n");
+
+  const age = payload.capability_observed_ms_ago;
+  const ageKnown = payload.capability_age === "known"
+    && typeof age === "number" && Number.isFinite(age) && age >= 0;
+
+  if (ageKnown) {
+    return {
+      kind: "blocked",
+      ageMs: age as number,
+      line: `这台 daemon 报告它现在**建不了节点**(${reason},${formatAge(age as number)}测)\n${body}`,
+      fix,
+    };
+  }
+
+  // 🔴 两种"给不出年龄",必须说成两句不同的话:动作差一台机器。
+  //    legacy       → 去**升级/重启那台 daemon**(它的版本只在开机时算一次)
+  //    no-heartbeat → 那台 daemon **报了**,是 hub 这边没有它的心跳时间;
+  //                   别去升级它,先看它还在不在线
+  const why = payload.capability_age === "unknown_no_heartbeat_time"
+    ? "**它报了这个判断,但 hub 这边没有它的心跳时间**,所以算不出是多久以前的 —— 先看这台 daemon 是否还在线,别急着升级它"
+    : "**不知道是多久以前测的** —— 该 daemon 版本在开机时算一次就不再重测,这个结论可能早就过期了。重启或升级它";
+  return {
+    kind: "blocked-age-unknown",
+    line: `这台 daemon 报告它现在**建不了节点**(${reason});${why}\n${body}`,
+    fix,
+  };
+}


### PR DESCRIPTION
缺口是实测的:dashboard 的代理路由 `app/api/anet/node-create/route.ts`
**已经把 hub 的完整 `result` 透传出来了**,而向导只渲染
`创建失败:${data.error}` ⇒ 用户看到的是裸的 `创建失败:daemon_cannot_create_nodes`。
hub 辛苦算出来的 reason 和年龄全被丢在 `data.result` 里没人看。

拒绝载荷和 `/api/host-supervisors` 的行**不是同一个形状**,所以给它一个入口 ——
在调用方做字段映射等于开出**第二个理解这些字段含义的地方**。

## 这里没有第二份年龄公式

`describeCapability` 里那段 `(now − last_seen_at) + observed` 是给「列 daemon」
那条路用的;拒绝这条路上 **hub 已经算好了绝对年龄**(它手里有心跳时间,
见同一批的 tools.ts 改动)。所以这里只做格式化,复用同一个 `formatAge`。
两份年龄算法一旦并排存在,分歧时不会有任何东西红。

## 没有新增第六种 kind —— 这是选的,不是漏的

`kind` 是**呈现分桶**(禁不禁用、什么色调),不是完整语义。
「daemon 没报年龄」和「hub 没有它的心跳时间」在 UI 上要的处理**完全一样**
(都是 blocked、都给不出年龄),差别在**说哪句话** —— 放进 `line`。

🔴 反过来说,给共享联合加第六个值,会让所有既有消费者的映射多一个它们没写过的
分支,而**落进 default 的那一支通常是"看起来最正常"的那个**。

区分一点没丢,而且是两句**动作不同**的话:
  legacy       → 去升级/重启那台 daemon(它开机才算一次,结论可能早过期)
  no-heartbeat → **它报了**,是 hub 这边没有它的心跳时间 ——
                 别急着升级,先看它是否还在线
有测试钉住两句逐字不同,并配反向锚(legacy 那句**不**得出现"心跳",
否则那个区分只是碰巧)。

## 见证

  M1 两种 unknown 说成同一句          → 「line 逐字不同」红
  M2 拒绝路径自己另写一份修法表        → 4 条红(含「与 describeCapability 同源」)
  M3 只信 capability_age、不校验数字   → 「数字不合法要退回 age-unknown」红
  还原 53 pass / 0 fail

其中 M2 那条断言是**「判据只有一个作者」的可执行版本**:同一个 code,
拒绝路径给出的 fix 必须和列 daemon 那条**逐字相同**(`toEqual`)。
哪天有人只改了一处,它会红。

`tsc --noEmit` rc=0;六道门全 rc=0。

## 不在本 PR 里

dashboard 向导接上它 —— 那个仓被 dashboard#42(凭据轮换)卡着,
会叠在 #41 上等一起解锁。**先把不受阻塞的这一半落地。**

Refs #1545

