### PR TITLE
漂移门:指纹句是列表项时永远匹配不上 —— 站点是好的,门在喊狼来了

### DIFF
--- a/.github/scripts/check-docs-site-drift.py
+++ b/.github/scripts/check-docs-site-drift.py
@@ -325,6 +325,14 @@ def run() -> int:
         text = re.sub(r"\s*([,;:])\s*", r"\1", text)
         fp_norm = re.sub(r"\s+", " ", html_unescape(fp))
         fp_norm = re.sub(r"\s*([,;:])\s*", r"\1", fp_norm)
+        #   ③ 2026-08-30 —— 指纹句若是**列表项**,源里带 `1. ` / `- ` / `* ` 这些
+        #      Markdown 标记,而渲染成 <li> 之后标记就没了 ⇒ 永远匹配不上。
+        #      实测:`2. 输入框写一句话("现在几点？" / "做个 hello world"), 回车`
+        #      —— 整页其余判据全过、版本戳也在线上,只有这一句 MISS,
+        #      而去掉前导 `2. ` 之后立刻命中(True)。
+        #      同 ① ② 一样是**判据自身的洞**:它会让人以为站点没部署,
+        #      于是去重复部署 —— 而那不会有任何效果。
+        fp_norm = re.sub(r"^\s*(?:\d+[.)]|[-*+])\s+", "", fp_norm)
         stale_stamp = None
         for stamp in version_stamps(rel):
             # 线上那一页必须出现 main 上声明的同一个版本号。


### PR DESCRIPTION
> 取代 #1592 —— 那个 PR 因为我的操作失误，装的是别人早先那条已合并的提交，不是本修复。原因写在 #1592 的关闭说明里。

## 现象

刚发完 `agent-network@2.3.0-preview.73` 并部署 anet.sh 之后，漂移门报：

```
MISS guide/getting-started.md → /guide/getting-started
差异: 2. 输入框写一句话("现在几点？" / "做个 hello world"), 回车
1 page(s) behind main.
```

**但站点是好的。** 同一次采样里其余 6 页全 `ok`，版本戳 `2.3.0-preview.73` 也确实在线上。

## 根因：指纹句是**列表项**

门拿「最近新增的一行」当指纹去线上找。那一行在源里是 Markdown 列表项，带前导 `2. `；渲染成 `<li>` 之后**标记没了**，于是永远匹配不上。

两侧都过门自己的归一化之后实测：

```
完整指纹命中           → False
去掉前导 `2. ` 后命中  → True
```

## 这是这个文件已经记过两次的同一类洞

文件里已有的注释写着 ① VitePress 把 `"` 渲染成 `&quot;`、② 语法高亮把 token 拆进 span 导致多出空格。**两条都是判据自身的洞**，并且都写明了代价：

> 会让人以为"站点没部署"，然后去重复部署（而那不会有任何效果）。

**这次它差点让我这么做。** 我一度以为部署失败，去查了 `.vercel/output`、比对了 www 与 apex、翻了缓存头 —— 而站点从头到尾是对的。

## 修法

与既有两条并列，在同一处归一化里把**指纹侧**的前导列表标记去掉（线上侧本来就没有标记，所以只动一侧）：

```python
fp_norm = re.sub(r"^\s*(?:\d+[.)]|[-*+])\s+", "", fp_norm)
```

## 见证（同一份线上站点，只改这一行）

```
带补丁  rc=0   every sampled page on the live site matches main
去掉它  rc=1   1 page(s) behind main
```

方向安全：它只让**本来就在页面上**的句子被认出来，**不可能把一个不存在的句子变出来** —— 只消除假红，不制造假绿。

## 🔴 排查中我自己犯的三个错，一并记下

1. **先猜是引号转义**，还写了个 `html.unescape` 补丁 —— 跑了才发现文件里早就在两侧做了 `html_unescape`（第 324/326 行，正是 #1592 那条提交带来的）。**我的补丁既多余又坏（`NameError`）。**
2. **用 `curl` 查线上时查的是 apex `anet.sh`** —— 它对所有路径 `307` 跳 `www.anet.sh`，不跟随时拿到的是重定向体。于是我"测"出线上连版本戳都没有，**那几次测量全是无效的**。
3. **`git checkout -b` 失败被我用 `>/dev/null 2>&1` 吞掉**，导致后续全在分离 HEAD 上操作、推错分支、开错 PR。

三条同一形状：**我以为我在测/改 A，实际是 B。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)