### PR TITLE
fix(qa): #1599 L1 失败套件的 rc 和时间线被 set -e 吞掉(rc=%s 从来没打印过 0 以外的值)

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -468,8 +468,24 @@ if [[ $RUN_L1 -eq 1 ]]; then
     #    「它前面那个慢套件的结束时刻」—— 数字看起来完全正常,只是错的。
     (
       _s=$(( $(date +%s) - START ))
-      dockerrun "docker run --rm anet-$t" >/tmp/qa-l1-$t-run.log 2>&1
-      _rc=$?
+      # 🔴 `|| _rc=$?` 不是风格,是这一行**唯一**能拿到非零 rc 的写法。
+      #    本脚本第 17 行是 `set -euo pipefail`。写成
+      #        dockerrun …
+      #        _rc=$?
+      #    时,`docker run` 一旦非零,**子 shell 在第一行就被 set -e 打死**,
+      #    下面的 `_rc=$?`、TSV 落盘、`· L1 done … rc=%s` 一行都不会执行。
+      #    于是:**失败的套件既没有 rc、也没有时间线**,而成功的两样都有。
+      #
+      #    实测(run 33301710195 / job 99231846024):该 job 打出 67 行 `· L1 done`,
+      #    **rc 全部是 0**;而当次真正失败的 qa-dash-10-incremental-poll
+      #    **一行 `L1 done` 都没有**。也就是说 `rc=%s` 这个占位符
+      #    **在它被加进来之后,从来没有打印过 0 以外的值** —— 它只在不需要它的时候工作。
+      #
+      #    这正是本文件上面 #1333 那条注释说的那件事的另一半:
+      #    「唯一需要这条时间线的场合,正是它打不出来的场合」——
+      #    那条讲的是整个 job 被 30 分钟天花板 kill,而**每一次单套件失败也是**。
+      _rc=0
+      dockerrun "docker run --rm anet-$t" >/tmp/qa-l1-$t-run.log 2>&1 || _rc=$?
       _e=$(( $(date +%s) - START ))
       printf '%s\t%s\t%s\n' "$t" "$_s" "$_e" >> /tmp/qa-l1-timing.tsv
       # 🔴 **完成即打印**,不要只留给结尾的汇总。

--- a/tests/test823-l1-concurrency-cap/run.sh
+++ b/tests/test823-l1-concurrency-cap/run.sh
@@ -53,7 +53,9 @@ cat > "$BIN/docker" <<'STUB'
 printf 'S %s %s\n' "$(date +%s%N)" "$$" >> "$T823_EV"
 sleep 1.2
 printf 'E %s %s\n' "$(date +%s%N)" "$$" >> "$T823_EV"
-exit 0
+# #1599 —— 让桩能按需失败。qa.sh 的「失败套件也要有 rc」那条断言需要一个
+# 真的非零 docker run,而不是一个逻辑副本。
+exit "${T823_RUN_RC:-0}"
 STUB
 chmod +x "$BIN/docker"
 
@@ -118,6 +120,33 @@ IFS='|' read -r p eff warned <<< "$(run_case cap2 2)"
 say "- cap=2      峰值=$p 生效值=$eff 告警=$warned"
 check cap2 "$eff" 2 "生效上限"
 [[ "$p" -le 2 && "$p" -ge 1 ]] && say "  ok   cap2: 峰值 $p ≤ 2" || { say "  FAIL cap2: 峰值 $p 超过上限 2"; fails=$((fails+1)); }
+
+# ── #1599 —— 失败的套件必须也能报出 rc ────────────────────────────────
+#
+# 🔴 缺陷:qa.sh 第 17 行是 `set -euo pipefail`,而它原来写的是
+#        dockerrun "docker run --rm anet-$t" > … 2>&1
+#        _rc=$?
+#    `docker run` 一旦非零,**子 shell 在第一行就被 set -e 打死** ——
+#    `_rc=$?`、TSV 落盘、`· L1 done … rc=%s` 一行都不会执行。
+#    于是 `rc=%s` 这个占位符**只在 rc=0 时才打得出来**:它只在不需要它的时候工作。
+#    实测(run 33301710195):67 行 `L1 done` **rc 全是 0**,而真正失败的那个套件
+#    **一行都没有**。
+#
+# 两向:先证明失败时能拿到非零 rc,再证明成功时仍是 0(否则一个恒打 rc=1
+# 的实现也能过第一条)。
+say ""
+say "## #1599 失败套件的 rc"
+
+T823_RUN_RC=7 run_case failrc 2 >/dev/null
+_fail_out=/tmp/t823-failrc.log
+_rc_seen=$(sed -n 's/.*· L1 done .* rc=\([0-9][0-9]*\).*/\1/p' "$_fail_out" | sort -u | tr '\n' ',')
+say "- docker run 恒返回 7 时,打印出的 rc 集合 = ${_rc_seen:-（一个 L1 done 都没有）}"
+check failrc_nonzero "$_rc_seen" "7," "失败套件必须打出非零 rc"
+
+_ok_out=/tmp/t823-cap2.log
+_rc_ok=$(sed -n 's/.*· L1 done .* rc=\([0-9][0-9]*\).*/\1/p' "$_ok_out" | sort -u | tr '\n' ',')
+say "- 正常情况下打印出的 rc 集合 = ${_rc_ok:-（无）}"
+check failrc_zero "$_rc_ok" "0," "成功套件仍然是 0(否则恒非零的实现也能过上一条)"
 
 IFS='|' read -r p eff warned <<< "$(run_case bad two)"
 say "- 非法值 two  峰值=$p 生效值=$eff 告警=$warned"


### PR DESCRIPTION
查 #1599(qa-dash-10 那条 flake「只有一行 source_commit」)时,在 harness 上撞到的:

```bash
# scripts/qa.sh 第 17 行:set -euo pipefail
dockerrun "docker run --rm anet-$t" >/tmp/qa-l1-$t-run.log 2>&1
_rc=$?                                    # ← 永远到不了
…
printf '· L1 done %s [L1+%ss..%ss, %ss] rc=%s\n' … "$_rc"
```

`docker run` 一旦非零,**子 shell 在第一行就被 `set -e` 打死** ——
`_rc=$?`、TSV 落盘、`· L1 done … rc=%s` **一行都不会执行**。

🔴 也就是说 `rc=%s` 这个占位符**只在 rc=0 时才打得出来:它只在不需要它的时候工作**。
   而失败的套件**既没有 rc,也没有时间线** —— 恰恰是要做失败分析的那一次。

## 现场证据(CI,不是构造的)

run 33301710195 / job 99231846024:
```
· L1 done …  rc=0   × 67 行,rc 全部是 0,没有一行非零
真正失败的 qa-dash-10-incremental-poll —— 一行 L1 done 都没有
```

这和本文件 #1333 那条注释说的是同一件事的另一半:
「**唯一需要这条时间线的场合,正是它打不出来的场合**」——
那条讲的是整个 job 撞 30 分钟天花板被 kill,而**每一次单套件失败也是**。

## 修法

`|| _rc=$?` —— 这不是风格,是 `set -e` 下**唯一**能拿到非零 rc 的写法
(CLAUDE.md 复核纪律 ② 记的就是这条:别让退出码穿过管道/被 set -e 吃掉)。

## 见证:三向,用真的 scripts/qa.sh + docker 桩(不是逻辑副本)

| qa.sh | docker run rc | `· L1 done` 行数 | 打印出的 rc 集合 |
|---|---|---|---|
| 修复后 | 7 | 68 | `{7}` |
| 修复后 | 0 | 68 | `{0}` |
| **旧写法** | 7 | **0** | —— |

第三行**逐字复现了 CI 上看到的现象**(失败时一行都没有)。
第二行是必需的另一侧:只验第一行的话,一个恒打 `rc=1` 的实现也能过。

## 同时把这条钉进 test823

test823 跑的是**真的 `scripts/qa.sh`**(把 `docker` 换成 PATH 上的桩),
所以这条断言不需要新套件:给桩加一个 `T823_RUN_RC`,新增两条用例 ——
失败时 rc 集合必须是 `{7}`,正常时必须是 `{0}`。

⚠️ **test823 的容器化跑法我本地没跑**(要 Docker + 盘,本机 99%)。
   我验的是它所断言的那个行为:用同样的桩直接跑真 `scripts/qa.sh`,三向如上表。
   容器里那一遍留给 CI。


---

## 这条和 #1599 的关系

#1599 问的是「qa-dash-10 为什么只有一行 `source_commit=`」。查那条时发现:
**就算它的容器打了东西、就算它非零退出,harness 也不会把 rc 告诉你。**

所以这是 #1599 的**前置**,不是它本身:
- 本 PR 之后,下一次任何 L1 套件失败,日志里会有 `· L1 done <suite> [L1+…] rc=N`;
- `qa-dash-10` 那条 flake 到底是 rc=1(断言失败)还是别的(OOM/被杀/端口冲突),
  **在此之前无从分辨** —— 而这两类的修法完全不同。

#1599 里我原本写的第一步是「失败时 upload-artifact」。**那条我已经在 issue 里更正了**:
那个文件本来就被 `Dump test logs on failure` 打印出来了,内容只有一行 —— 
**把一个空文件上传成 artifact,还是空的。**

## 不在本 PR 里

- 让套件自己在早停时报「停在第几行 / 共几行」(`tests/lib/early-stop.sh`,#1026 的做法):
  那是 `run.sh` 侧,本 PR 是 harness 侧。两件事,先做便宜且覆盖全部 68 个套件的这一件。
- `qa-dash-10` 本身的 flake:等这条合了、下次它红时**先看 rc**,再定方向。

Refs #1599 #1593
