### PR TITLE
anet daemon restart —— 重启 daemon 不该要用户拼两条命令,而且第二条还不在这个命令族里

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8333,6 +8333,7 @@ async function daemonCommand() {
 Subcommands:
   init <name>          Create a host_supervisor daemon node (role + defaults)
   start <name>         Start a daemon (delegates to anet node start; verifies role)
+  restart <name>       stop then start (daemon 是长驻进程,换包/改配置都要重启才生效)
   up [<name>]          init + start one-shot (default name: "${DAEMON_DEFAULT_NAME}")
   list                 List locally-configured daemon nodes
 
@@ -8349,11 +8350,12 @@ Run \`anet hub start\` first if you don't yet have a CommHub.`);
     case "init":  args.splice(0, 1); prepareDaemonAnetBin(); await daemonInitCommand(); break;
     case "start": args.splice(0, 1); prepareDaemonAnetBin(); await daemonStartCommand(); break;
     case "up":    args.splice(0, 1); prepareDaemonAnetBin(); await daemonUpCommand(); break;
+    case "restart": args.splice(0, 1); prepareDaemonAnetBin(); await daemonRestartCommand(); break;
     case "list": case "ls": await daemonListCommand(); break;
     default: {
-      const suggestion = suggestSimilar(sub, ["init", "start", "up", "list"]);
+      const suggestion = suggestSimilar(sub, ["init", "start", "restart", "up", "list"]);
       if (suggestion) console.log(`Unknown daemon subcommand "${sub}". Did you mean: anet daemon ${suggestion}?`);
-      console.log(`Usage: anet daemon <init|start|up|list> [name]`);
+      console.log(`Usage: anet daemon <init|start|restart|up|list> [name]`);
       process.exit(1);
     }
   }
@@ -8520,6 +8522,44 @@ async function daemonStartCommand() {
 
   // Delegate to existing startCommand — it reads args[1] for the node name,
   // which is what we have after the `daemon start` splice in daemonCommand.
+  await startCommand();
+}
+
+/**
+ * `anet daemon restart <name>` —— stop 然后 start。
+ *
+ * 2026-08-30 加的。在此之前重启一台 daemon 要敲两条命令,而且**第二条不在
+ * `anet daemon` 底下**:`anet node stop <name>` + `anet daemon start <name>`。
+ * 因为 `daemon start` 委托给 `node start`,所以停也走 `node`。
+ * 这个「停和起不在同一个命令族里」是实现细节漏到了用户面前。
+ *
+ * 🔴 为什么这一条值得单独加:daemon 是**长驻进程**,而今天已经有两处文案
+ * 要用户「升级后重启 daemon」(换包对已经在跑的进程没有任何影响)。
+ * 一条被反复指示的动作,不该需要用户自己拼两条命令、还得知道停要走 node。
+ */
+async function daemonRestartCommand() {
+  const id = args[1];
+  if (!id || id.startsWith("--")) {
+    console.error("Usage: anet daemon restart <name>");
+    process.exit(1);
+  }
+  const profile = loadProfile(id);
+  if (!profile) {
+    console.error(`Daemon "${id}" not found. Create it first:`);
+    console.error(`  anet daemon init ${id}`);
+    process.exit(1);
+  }
+  if (profile.role !== "host_supervisor") {
+    console.error(`Error: node "${id}" exists but role="${profile.role || "(none)"}", not "host_supervisor".`);
+    console.error(`Re-init as daemon: anet daemon init ${id} --force`);
+    process.exit(1);
+  }
+  // 🔴 停不掉不能当成"那就直接起" —— 那会变成两个同 alias 的进程同时在跑。
+  //    stopCommand() 对「本来就没在跑」是**正常返回**的(它会说 not running locally),
+  //    所以这里只需要让它的**异常**冒出去,不要 catch 成"继续"。
+  console.log(`[anet daemon] restart "${id}" —— 先停`);
+  await stopCommand();
+  console.log(`[anet daemon] restart "${id}" —— 再起`);
   await startCommand();
 }
 

--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -260,12 +260,19 @@ Hub 那一侧每 3 分钟能看到它的心跳：
 
 🔴 **升级完必须重启 —— 光换包不够。** daemon 是**长驻进程**，这一格由它在进程内算出；
 换掉磁盘上的包，对一个**已经在跑**的进程没有任何影响，`anet daemon list` 会照旧显示「未知」。
-`anet daemon` 没有 `restart` 子命令，重启走两步（`daemon start` 委托给 `node start`，停也走 node）：
+```bash
+anet daemon restart <name>
+```
+
+::: tip 你的版本有没有这条？
+跑一下 `anet daemon`（不带子命令）看列表里有没有 `restart`。**没有的话用两步** ——
+因为 `daemon start` 委托给 `node start`，所以停也走 `node`：
 
 ```bash
 anet node stop <name>
 anet daemon start <name>
 ```
+:::
 
 🔴 **年龄那一格不是装饰。** 一个「5s 前测」的 `不可用` 和一个「三周前测」的 `不可用`
 是两件事 —— 后者很可能早就被修好了，只是那台 daemon 用的老版本在开机时算过一次就再没重测。

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -280,14 +280,20 @@ absent it stays quiet: the node's own startup error is more specific.)
 
 🔴 **Upgrading alone changes nothing — restart it.** The daemon is a **long-lived process**
 and computes this field in-process, so swapping the package on disk has no effect on a daemon
-that is **already running**: `anet daemon list` keeps printing "unknown". `anet daemon` has no
-`restart` subcommand; restart is two steps (`daemon start` delegates to `node start`, so
-stopping goes through `node` too):
+that is **already running**: `anet daemon list` keeps printing "unknown". ```bash
+anet daemon restart <name>
+```
+
+::: tip Does your version have it?
+Run `anet daemon` with no subcommand and check the list for `restart`. **If it is absent,
+use the two-step form** — `daemon start` delegates to `node start`, so stopping goes
+through `node` too:
 
 ```bash
 anet node stop <name>
 anet daemon start <name>
 ```
+:::
 
 🔴 **The age is not decoration.** An `unavailable` measured 5s ago and one measured three
 weeks ago are different things — the latter was quite possibly fixed long since, and the

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -280,7 +280,9 @@ absent it stays quiet: the node's own startup error is more specific.)
 
 🔴 **Upgrading alone changes nothing — restart it.** The daemon is a **long-lived process**
 and computes this field in-process, so swapping the package on disk has no effect on a daemon
-that is **already running**: `anet daemon list` keeps printing "unknown". ```bash
+that is **already running**: `anet daemon list` keeps printing "unknown".
+
+```bash
 anet daemon restart <name>
 ```
 


### PR DESCRIPTION
## 为什么

此前重启一台 daemon 要敲两条，**而且第二条不在 `anet daemon` 底下**：

```bash
anet node stop <name>        # ← daemon start 委托给 node start，所以停也走 node
anet daemon start <name>
```

**「停和起不在同一个命令族里」是实现细节漏到了用户面前。**

而这条动作是**被反复指示**的：今天已经有两处文案让用户「升级后重启 daemon」——因为 daemon 是**长驻进程**，换掉磁盘上的包对一个已经在跑的进程没有任何影响。**一条被反复指示的动作，不该需要用户自己拼命令、还得知道停要走 `node`。**

## 行为见证（跑的是改过的 CLI，不是逻辑推演）

```
① anet daemon
     restart <name>       stop then start (daemon 是长驻进程,换包/改配置都要重启才生效)

② anet daemon restrt
     Unknown daemon subcommand "restrt". Did you mean: anet daemon restart?
     Usage: anet daemon <init|start|restart|up|list> [name]

③ anet daemon restart zz-no-such-daemon
     Daemon "zz-no-such-daemon" not found. Create it first:
```

③ 之前还会先撞 `prepareDaemonAnetBin()` 的权限守卫（本机 umask 0002 ⇒ mode=775），**那是对的**：它与 `init`/`start`/`up` 同序调用，pin 检查行为一致。

## 两个安全细节

**不 catch stop 的异常。** 停不掉不能当成「那就直接起」——那会变成**两个同 alias 的进程同时在跑**。（`stopCommand()` 对「本来就没在跑」是正常返回的，只有真异常才冒出去。）

**核过 `stopCommand()` 不修改 `args`**，否则第二步 `startCommand()` 会拿到错的名字：函数体 386 行、**0 行改 `args`**、1 行读。

🔴 第一次我用 `awk` 取函数体，**范围只匹配到 1 行** —— 那次的「没发现修改」什么都没证明。**空结果不是结论**，重查才敢用。

## 文档

中英都把两步改成一条，**并保留两步作为旧版本的退路**。判断方式写成：

> 跑一下 `anet daemon`（不带子命令）看列表里有没有 `restart`。

—— 而不是写一个我此刻还不知道的版本号。**让用户自己验，比让他相信一个我猜的数字好。**

`check-docs-integrity` / `check-docs-site-orphans` / `check-doc-symbol-pins` 本地 rc=0；`tsc --noEmit` rc=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)