### PR TITLE
fix(test): #1599 qa-dash-10 早停出声 —— 同时是一次判别实验

### DIFF
--- a/tests/qa-dash-10-incremental-poll/run.sh
+++ b/tests/qa-dash-10-incremental-poll/run.sh
@@ -11,6 +11,39 @@ set -euo pipefail
 # 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
 printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
+# ── #1599 —— 早停出声 ─────────────────────────────────────────────────
+#
+# 🔴 病灶(实测,run 33301710195 / job 99231846024):这个套件那一次红时,
+#    它的 run.log **整份只有上面那一行 `source_commit=`**,再无一字。
+#    对照隔壁通过的套件(`source_commit=` + 一串 PASS),说明它是在
+#    **第一句进度输出(下面的 `echo "[0] start hub"`)之前**就死了。
+#    而 `set -e` 死的时候**一个字都不打** —— 于是「它失败了」有,
+#    「它为什么失败」没有,**连死在哪一行都不知道**。
+#
+# 🔴 这一行同时是一次**判别实验**,不只是修诊断:
+#    下次它再红,若打出行号 ⇒ 确实是 `set -e` 早停,而且直接定位到行;
+#    若**仍然静默** ⇒ 反而排除了「set -e 早停」这个假说
+#    (那时容器被杀 / OOM / 拿不到端口这类死法更可信,它们不走 ERR trap)。
+#    **两种结果都有信息量**,所以不必先在两个假说之间选一个。
+#
+# 🔴 为什么**不加 `set -E`**:实测(bash 5.2)一个 `trap … ERR`,
+#      顶层失败 → 出声;子 shell → 出声;管道 → 出声;
+#      **函数内部失败 → 静默**,只有 `set -E` 才覆盖。
+#    但 `set -E` 会让子 shell 的一次失败**打印两行**(子 shell 一次 + 父 shell 一次),
+#    读的人会以为发生了两次。
+#    而本套件的静默区(下面到 `[0] start hub` 之间)全是顶层语句
+#    (`export` / `source` / `mkdir -p` / `cd`)—— **朴素 trap 就够,不引入那个副作用。**
+#    等真遇到「失败在 helper 函数里」的套件,再单独决定要不要为那一类开 `set -E`。
+#
+# 范本:tests/test225-grok-preview-package-live/run.sh(#1026)——
+# 全仓 224 个 run.sh 里,在早停时报位置的**只有它一个**。
+_QA_TOTAL_LINES=$(wc -l < "$0")
+_early_stop() {
+  printf 'diagnostic: 早停于 run.sh:%s / 共 %s 行 —— 该行之后的判据本次**未执行**,不是通过\n' \
+    "${BASH_LINENO[0]}" "$_QA_TOTAL_LINES" >&2
+}
+trap _early_stop ERR
+
 export HOME=/tmp/anethome
 
 # P0 guardrail (2026-06-16 incident) — refuse rm -rf outside /tmp/*.


### PR DESCRIPTION
病灶(实测 run 33301710195 / job 99231846024):该套件那次红时,
run.log **整份只有一行 `source_commit=`**。对照隔壁通过的套件
(`source_commit=` + 一串 PASS),说明它在**第一句进度输出之前**就死了,
而 `set -e` 死的时候一个字都不打 —— 「它失败了」有,「为什么」没有,
**连死在哪一行都不知道**。

## 🔴 这不只是修诊断,它同时是一次判别实验

现在有两个假说:`set -e` 早停 vs 容器被杀/OOM/端口冲突。
**现有输出无法区分它们**,而这一行让两种结果都有信息量:

- 下次它红时**打出行号** ⇒ 确实是 `set -e` 早停,而且直接定位到行;
- 下次它红时**仍然静默** ⇒ 反而**排除**了 `set -e` 早停
  (被杀 / OOM / 拿不到端口这些死法不走 ERR trap),另一个假说可信度上升。

所以不必先在两个假说之间选一个。

## 为什么不加 `set -E`(量过的取舍,不是默认)

bash 5.2 实测,一个被 source/设置的 `trap … ERR`:

```
不加 set -E:  顶层 ✓   子 shell ✓   管道 ✓   **函数内部 ✗(静默)**
加   set -E:  函数内部 ✓,但**子 shell 一次失败打印两行**(子 shell + 父 shell)
```

本套件的静默区(`source_commit` 到 `[0] start hub` 之间)全是顶层语句
(`export` / `source` / `mkdir -p` / `cd`)⇒ **朴素 trap 就够,不引入重复打印。**
等真遇到「失败在 helper 函数里」的套件,再单独为那一类决定 —— 那时是一个
有具体代价、具体收益的选择,而不是现在替所有套件预支。

## 见证:两向,而且"之前"那一侧逐字复现了 CI 现象

在 `trap` 之后**紧接着**注入一条 `false`(保证碰不到 `export HOME`/`mkdir`/`cd`,
更碰不到起 hub —— 9200 是本机生产口,**不能在宿主机上跑这个套件的网络部分**):

```
有 trap:  source_commit=unknown
          diagnostic: 早停于 run.sh:47 / 共 204 行 —— 该行之后的判据本次**未执行**,不是通过
          rc=1

无 trap:  source_commit=unknown
          rc=1                      ← 一个字都没有,与 CI 上那次逐字相同
```

## 还没做的那一步(说清楚,不含糊)

⚠️ **真实 CI 上"下次它红时确实给出行号"这一步,只能等** ——
这条 flake 在 21 个 attempt 里出现 1 次。加了 trap 不算数,**真的接住一次才算**。

范本:`tests/test225-grok-preview-package-live/run.sh`(#1026)——
全仓 224 个 `run.sh` 里,在早停时报位置的**只有它一个**;
`set -e` 型的有 171 个,本套件是其中之一。**先证明这一个有效,再谈铺开。**

Refs #1599 #1593

