### PR TITLE
chore(release): agent-network 2.3.0-preview.74 —— 让 anet daemon restart 真正到用户手里

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.73",
+  "version": "2.3.0-preview.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.73",
+      "version": "2.3.0-preview.74",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.73",
+  "version": "2.3.0-preview.74",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.73";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.74";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.56";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.73 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.74 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.73` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.74` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.73 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.74 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.73`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.74`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.74.md
+++ b/docs/tests/release-v2.3.0-preview.74.md
@@ -1,0 +1,51 @@
+# agent-network 2.3.0-preview.74
+
+`.73` 之后有 3 个提交改到了 `agent-network/`，且都落在 `files: ["dist"]` 覆盖的范围内
+（`bin/cli.ts` 与 `src/` 都编进 `dist`）—— **这一条是查过的，不是假设**：合进 main 不等于进 tarball。
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `3371eabc` | #1601 | **`anet daemon restart <name>`** —— 重启 daemon 不再需要用户拼两条命令 |
+| `b9d53f57` | #1604 | `PINNED_SERVER_VERSION` → `0.9.0-preview.44`，并对齐第三处 server pin |
+| `11bbb5d2` | #1589 | `describeCreateRejection` —— 拒绝载荷走同一份修法表 |
+
+## 为什么这一版值得发
+
+`anet daemon restart` 在 `.73` 里**不存在**。实测（容器内跑真包）：
+
+```
+$ npx @sleep2agi/agent-network@2.3.0-preview.73 daemon --help
+Subcommands:
+  init / start / up / list          ← 没有 restart
+```
+
+文档那一页是诚实的，自带「你的版本有没有这条？没有的话用两步」的提示，所以用户不会卡住；
+但 #1601 的价值要到这一版才真正到用户手里。
+
+## 版本戳同步
+
+| 位置 | 值 |
+|---|---|
+| `agent-network/package.json` | `2.3.0-preview.74` |
+| `agent-network/package-lock.json` | 同上（2 处） |
+| `agent-network/src/opencode-agent-node-pair.ts` `PAIRED_AGENT_NETWORK_VERSION` | 同上 |
+| `docs-site/docs/guide/getting-started.md` `version-claim` + 表格行 | 同上 |
+| `docs-site/docs/en/guide/getting-started.md` 同上 | 同上 |
+
+全仓复扫 `2.3.0-preview.73`：**0 处遗留**（本目录下的历史 release notes 除外）。
+
+## 一条随版本失效的断言，已重新验过
+
+两份 getting-started 里有一行：「生成密码的 `server/src/auth.ts` 自 `.49` 发布起**零提交**，逻辑逐字未变」。
+这是上一版写下的事实，换版本号时**不能照抄**——它的前提也换了。重新量过：
+
+```
+git log origin/main --since=2026-08-27 --oneline -- server/src/auth.ts   →  0
+```
+
+仍然成立，才搬到 `.74`。
+
+## 发布方式
+
+走 GitHub Actions（`release-gate (v0)` 发 preview）。**不从本机 publish，不从非 main 分支出对外产物。**
+`latest` 保持 `2.3.0-preview.47` 不动 —— 升 `latest` 需要 owner ACK。


### PR DESCRIPTION
# agent-network 2.3.0-preview.74

`.73` 之后有 3 个提交改到了 `agent-network/`，且都落在 `files: ["dist"]` 覆盖的范围内
（`bin/cli.ts` 与 `src/` 都编进 `dist`）—— **这一条是查过的，不是假设**：合进 main 不等于进 tarball。

| 提交 | PR | 内容 |
|---|---|---|
| `3371eabc` | #1601 | **`anet daemon restart <name>`** —— 重启 daemon 不再需要用户拼两条命令 |
| `b9d53f57` | #1604 | `PINNED_SERVER_VERSION` → `0.9.0-preview.44`，并对齐第三处 server pin |
| `11bbb5d2` | #1589 | `describeCreateRejection` —— 拒绝载荷走同一份修法表 |

## 为什么这一版值得发

`anet daemon restart` 在 `.73` 里**不存在**。实测（容器内跑真包）：

```
$ npx @sleep2agi/agent-network@2.3.0-preview.73 daemon --help
Subcommands:
  init / start / up / list          ← 没有 restart
```

文档那一页是诚实的，自带「你的版本有没有这条？没有的话用两步」的提示，所以用户不会卡住；
但 #1601 的价值要到这一版才真正到用户手里。

## 版本戳同步

| 位置 | 值 |
|---|---|
| `agent-network/package.json` | `2.3.0-preview.74` |
| `agent-network/package-lock.json` | 同上（2 处） |
| `agent-network/src/opencode-agent-node-pair.ts` `PAIRED_AGENT_NETWORK_VERSION` | 同上 |
| `docs-site/docs/guide/getting-started.md` `version-claim` + 表格行 | 同上 |
| `docs-site/docs/en/guide/getting-started.md` 同上 | 同上 |

全仓复扫 `2.3.0-preview.73`：**0 处遗留**（本目录下的历史 release notes 除外）。

## 一条随版本失效的断言，已重新验过

两份 getting-started 里有一行：「生成密码的 `server/src/auth.ts` 自 `.49` 发布起**零提交**，逻辑逐字未变」。
这是上一版写下的事实，换版本号时**不能照抄**——它的前提也换了。重新量过：

```
git log origin/main --since=2026-08-27 --oneline -- server/src/auth.ts   →  0
```

仍然成立，才搬到 `.74`。

## 发布方式

走 GitHub Actions（`release-gate (v0)` 发 preview）。**不从本机 publish，不从非 main 分支出对外产物。**
`latest` 保持 `2.3.0-preview.47` 不动 —— 升 `latest` 需要 owner ACK。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)