### PR TITLE
docs(grok-copresence): #1606 —— 告诉用户 leaderless build 上的 blocked 是假的,别重建节点

### DIFF
--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -4,6 +4,19 @@
 The danger block below captures the 2026-08-18 qualification state and is **outdated**: the `grok-build-cli` co-presence path now works end to end — on a Mac mini with npm-installed `anet 2.3.0-preview.43` + the global `agent-node` (grok `1.0.5 (5115b46bc909)`, on the verified list), creating the node, entering the shared TUI via `anet grok attach`, and receiving an answer to an injected network task in 19 seconds. For current usage see [Grok Co-presence TUI (grok-build-cli)](/en/guide/grok-tui). The historical warnings are preserved below for the record.
 :::
 
+::: warning Known defect: `blocked` in the roster currently cannot tell real from false (measured 2026-08-30, [#1606](https://github.com/sleep2agi/agent-network/issues/1606))
+**With grok 1.0.5 this cell is permanently `blocked`, even while the node is working normally.**
+
+1.0.5 is a **leaderless** build — by design it never creates `leader.sock` (`autoLeader: false` in the capability
+table, on both macOS and Linux), while the liveness check requires it unconditionally. `usable` is therefore
+structurally false, and the `idle` the heartbeat reports is rewritten to `blocked` every 3 minutes.
+
+Measured: a node marked `blocked` still injected a network task, returned an answer, and replied to the sender.
+
+**Do not rebuild the node when you see `blocked`.** Until this is fixed, judge these nodes by their logs, not by
+that cell — `injected network task` / `processTask returned` in the log means the runtime is fine.
+:::
+
 ::: danger Old state as of 2026-08-18 (archived)
 Do not follow older instructions for the `grok-build-cli` runtime path — do not run `anet node create ... --runtime grok-build-cli`.
 

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -4,6 +4,18 @@
 下面的 danger 块记录的是 2026-08-18 的验收状态，**已过时**：`grok-build-cli` 共存路径现已端到端跑通 —— macmini 上用 npm 安装的 `anet 2.3.0-preview.43` + 全局 `agent-node`（grok `1.0.5 (5115b46bc909)`，验证清单内）创建节点、`anet grok attach` 进入共享 TUI、网络任务注入并 19 秒收到回答。当前用法见 [Grok 共存 TUI（grok-build-cli）](/guide/grok-tui)。历史告诫保留如下供追溯。
 :::
 
+::: warning 已知缺陷：名册里的 `blocked` 目前分辨不出真假（2026-08-30 实测，[#1606](https://github.com/sleep2agi/agent-network/issues/1606)）
+**用 grok 1.0.5 时这一格恒为 `blocked`，即使节点正在正常干活。**
+
+1.0.5 是 **leaderless** build —— 按设计就不创建 `leader.sock`（能力表里 `autoLeader: false`，macOS 与 Linux 都是），
+而 liveness 判据无条件要求它存在，于是 `usable` 结构性恒假，心跳上报的 `idle` 每 3 分钟被改写成 `blocked`。
+
+实测：被标成 `blocked` 的节点仍然成功注入并返回了网络任务，还回复了发起方。
+
+**看到 `blocked` 先别重建节点。** 修复前请以节点日志为准，不要以名册那一格为准 —— 日志里有
+`injected network task` / `processTask returned` 就说明运行时是好的。
+:::
+
 ::: danger 2026-08-18 时点的旧状态（保留存档）
 `grok-build-cli` 这条 runtime 路径**不要照旧文档使用** —— 不要执行 `anet node create ... --runtime grok-build-cli`。
 


### PR DESCRIPTION
中英两页同步加一条 warning。

## 为什么现在加

代码修复在 #1606,但用户**今天**就会在名册/Dashboard 上看到那一格,而它现在的含义是错的:

- grok 1.0.5 是 **leaderless** build,按设计不创建 `leader.sock`(能力表 `autoLeader: false`,macOS 与 Linux 都是);
- 而 liveness 的 `usable` 无条件要求 `leaderPresent` ⇒ 结构性恒假;
- 心跳上报的 `idle` 每 3 分钟被改写成 `blocked`。

实测:被标成 `blocked` 的节点仍然成功 `injected network task` → `processTask returned(failed=false)` → 回复送达。

## 告示给的是可执行动作

不是"这里有个 bug",而是**看到 blocked 先别重建节点,改看日志**。

## 🔴 落点

放在页顶「当前状态」块之后、archived danger 块**之前**。
第一版我写进了 archived 块里 —— 那块开头就写着「已过时,保留存档」,
一条当前的已知缺陷放进去**等于没写**。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)