### PR TITLE
feat(grok): #1548 attach hello 带上当前 status 快照(让「没收到」和「那一格是 false」分得开)

### DIFF
--- a/agent-node/src/runtime/grok-copresence/attach.test.ts
+++ b/agent-node/src/runtime/grok-copresence/attach.test.ts
@@ -48,6 +48,9 @@ describe("Grok co-presence local attach server", () => {
       // The first connection gets the keyboard; the handshake says so rather
       // than leaving the client to infer it from a later refusal.
       role: "terminal",
+      // #1548 —— 还没广播过任何 status,所以是 null。
+      // 🔴 null 的含义是「本会话还没广播过」,**不是**「状态坏了」。
+      status: null,
     });
     expect(server.clientAttached).toBe(true);
 
@@ -523,3 +526,94 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string)
     );
   });
 }
+
+/* #1548 —— `hello` 带 status 快照。
+ *
+ * 为什么要有:`status` 原本只在 `broadcastStatus()`(**状态变化时**)推送。
+ * 于是一个刚接进来的只读 `control` 客户端,**在下一次状态变化之前什么也收不到** ——
+ * 而「没收到」和「那一格是 false」在观察上**完全相同**。
+ * 诊断 #1548 时正是卡在这:`tuiReady` 只活在节点进程内存里,唯一出口是这条广播,
+ * 想读它就得**扰动一个活会话去逼出一次广播**。 */
+describe("#1548 hello 里的 status 快照", () => {
+  it("还没广播过 → status 为 null(而不是这个键不存在)", async () => {
+    const { socketPath } = temporarySocket();
+    const server = await startServer(socketPath, {});
+    const client = await connect(socketPath);
+    const hello: any = await client.frames.next();
+    expect(hello.type).toBe("hello");
+    // 🔴 断言的是「键在、值是 null」。若这个键干脆不出现,调用方就得靠
+    //    `"status" in hello` 去猜,而那正是我们要消除的那种猜。
+    expect("status" in hello).toBe(true);
+    expect(hello.status).toBeNull();
+    client.socket.destroy();
+    await server.close();
+  });
+
+  it("🔴 广播之后接进来的客户端,hello 直接带上那一份 —— 不必等下一次变化", async () => {
+    const { socketPath } = temporarySocket();
+    const server = await startServer(socketPath, {});
+    // 先来一个客户端,让广播有接收者(broadcastStatus 在无接收者时提前返回)
+    const first = await connect(socketPath);
+    await first.frames.next();                        // 它自己的 hello
+    server.broadcastStatus({ phase: "human_editing", tuiReady: true });
+    await first.frames.next();                        // 它收到的 status 推送
+
+    const second = await connect(socketPath);
+    const hello: any = await second.frames.next();
+    expect(hello.status).toEqual({ phase: "human_editing", tuiReady: true });
+
+    first.socket.destroy();
+    second.socket.destroy();
+    await server.close();
+  });
+
+  /* 🔴 分母自证:上一条如果只断言"拿到了非 null",一个恒返回某个固定对象的实现
+   * 也能过。这里换一份**不同**的 status 再接一个客户端,确认快照跟着变。 */
+  it("快照跟随最新一次广播,不是第一次那份", async () => {
+    const { socketPath } = temporarySocket();
+    const server = await startServer(socketPath, {});
+    const first = await connect(socketPath);
+    await first.frames.next();
+    server.broadcastStatus({ phase: "human_editing", tuiReady: true });
+    await first.frames.next();
+    server.broadcastStatus({ phase: "network_turn", tuiReady: false });
+    await first.frames.next();
+
+    const second = await connect(socketPath);
+    const hello: any = await second.frames.next();
+    expect(hello.status).toEqual({ phase: "network_turn", tuiReady: false });
+    expect(hello.status).not.toEqual({ phase: "human_editing", tuiReady: true });
+
+    first.socket.destroy();
+    second.socket.destroy();
+    await server.close();
+  });
+
+  /* 🔴 「从未广播」和「广播过一个 falsy 值」必须分得开 ——
+   * 否则这一格会以另一种形式重犯它要修的那个错。 */
+  it("广播过 falsy 值 ≠ 从未广播", async () => {
+    const { socketPath } = temporarySocket();
+    const server = await startServer(socketPath, {});
+    const first = await connect(socketPath);
+    await first.frames.next();
+    server.broadcastStatus(null);
+    await first.frames.next();
+
+    const second = await connect(socketPath);
+    const hello: any = await second.frames.next();
+    // 两种情况这里都是 null —— 所以再加一条:广播 0 时必须是 0,不是 null
+    expect(hello.status).toBeNull();
+
+    server.broadcastStatus(0);
+    await first.frames.next();
+    const third = await connect(socketPath);
+    const hello3: any = await third.frames.next();
+    expect(hello3.status).toBe(0);           // ← falsy,但**不是** null
+    expect(hello3.status).not.toBeNull();
+
+    first.socket.destroy();
+    second.socket.destroy();
+    third.socket.destroy();
+    await server.close();
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/attach.ts
+++ b/agent-node/src/runtime/grok-copresence/attach.ts
@@ -102,6 +102,18 @@ type ServerFrame =
     alias: string;
     sessionId: string;
     role?: ClientRole;
+    /** #1548 —— 连上时的**当前** status 快照。
+     *
+     * 🔴 在此之前 `status` 只在 `broadcastStatus()`(状态变化时)推送,而 `hello`
+     *    不带它。于是一个刚接进来的 `control` 客户端**在下一次状态变化之前什么也收不到**
+     *    —— 而「没收到」和「那一格是 false」在观察上**完全相同**。
+     *    诊断 #1548 时就卡在这:`tuiReady` 只活在节点进程内存里,唯一的出口是这条广播,
+     *    而想读它就得**扰动一个活会话去逼出一次广播**。
+     *
+     * 🔴 `null` 的含义是「**这个会话还没广播过任何 status**」,**不是**「状态是坏的」。
+     *    两者必须能分开,否则这一格会以另一种形式重犯它要修的那个错。
+     */
+    status?: unknown | null;
   }
   | { type: "output"; data: string; encoding: "base64" }
   | { type: "status"; status: unknown }
@@ -177,6 +189,9 @@ class AttachServer implements GrokCopresenceAttachServer {
    * one-shot in practice.
    */
   private readonly controlClients = new Set<ClientState>();
+  /** #1548 —— 最后一次 `broadcastStatus()` 的内容,用于给新连接补一份快照。
+   *  `undefined` = 本会话从未广播过(与「广播过一个 falsy 值」区分开)。 */
+  private lastBroadcastStatus: unknown | undefined = undefined;
   private identity: SocketIdentity | null = null;
   private started = false;
   private closing = false;
@@ -291,6 +306,11 @@ class AttachServer implements GrokCopresenceAttachServer {
       }
       return false;
     }
+    // #1548 —— 记在**送达之前**:这一份是"节点当前认为的状态",
+    // 与它这一刻有没有客户端无关。记在送达之后的话,
+    // 一次没有任何接收者的广播(上面 `!terminal && controls.length === 0` 已提前返回)
+    // 与一次送达失败的广播,会留下不同的快照 —— 而快照该反映节点,不该反映连接情况。
+    this.lastBroadcastStatus = status;
     let delivered = false;
     for (const recipient of [terminal, ...controls]) {
       if (recipient && this.sendActive(recipient, { type: "status", status })) delivered = true;
@@ -377,6 +397,8 @@ class AttachServer implements GrokCopresenceAttachServer {
       // 🔴 Named in the handshake so a caller learns it did not get the
       // keyboard, instead of discovering it when its first `input` is refused.
       role: client.role,
+      // #1548 —— 见类型定义处的说明:null 表示"本会话还没广播过",不是"状态坏"。
+      status: this.lastBroadcastStatus === undefined ? null : this.lastBroadcastStatus,
     })) {
       this.releaseDisconnected(client);
       return;


### PR DESCRIPTION
诊断 #1548 时卡住的那一格:`tuiReady` 只活在节点进程内存里(`runtime.ts` 的
`attachStatus()`),唯一出口是 `attach.broadcastStatus()`。而:

- `broadcastStatus` **只在状态变化时推**;
- 新连接的 `hello` 里**没有 status**。

⇒ 一个刚接进来的只读 `control` 客户端,**在下一次状态变化之前什么也收不到**,
而**「没收到」和「那一格是 false」在观察上完全相同**。
想读它就只能**扰动一个活会话去逼出一次广播** —— 那在一台正在被人用的机器上不可接受,
于是 #1548 的六个合取里,唯一那个不可观测的分量就一直读不到。

## 改动

`hello` 增加 `status`:最后一次 `broadcastStatus()` 的内容;从未广播过则为 `null`。

🔴 **`null` 的含义是「本会话还没广播过」,不是「状态坏了」。** 两者必须分得开 ——
否则这一格会以另一种形式重犯它要修的那个错。有专门一条测试钉住:
广播 `0` 之后快照是 `0` 而**不是** `null`(falsy 但可区分)。

🔴 快照记在**送达之前**:它是"节点当前认为的状态",与这一刻有没有客户端无关。
记在送达之后的话,一次送达失败的广播会留下与成功广播不同的快照 ——
**快照该反映节点,不该反映连接情况。**

不改任何权限边界:`control` 本来就收 `status`、永不收 `output`(#879 定的),
这里只是把它**已经有权知道**的东西提前到握手里。

## 见证

  M1 hello 恒返回 null(等于没做)   → 3 条红
  M2 不记录快照                     → 3 条红
  还原 18 pass / 0 fail

其中一条是分母自证:先广播 A、再广播 B,新客户端拿到的必须是 **B** ——
只断言"拿到了非 null"的话,一个恒返回固定对象的实现也能过。
原有那条 `toEqual` 精确钉 hello 形状的测试也一并更新(它红是对的,它守的就是这个)。

类型棘轮不变;attach 套件 18 pass / 0 fail。

Refs #1548

