### PR TITLE
fix(grok): #1548 liveness 不知道有些 build 按设计就没有 leader.sock ⇒ 永久假 blocked

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3799,8 +3799,16 @@ async function retireCachedGrokCopresenceRuntime(): Promise<void> {
 
 function resolveReportedStatus(status: string): string {
   if (!GROK_COPRESENCE || !isGrokCopresenceHubStatus(status)) return status;
+  // #1548 —— autoLeader 从会话本身取(它与 settleLeader 用同一个判据)。
+  // 🔴 没有会话时传 `true`:那是**更严**的一侧(要求 leader socket 在),
+  //    而 `describeGrokCopresenceLiveness(null, …)` 本来就直接返回 usable:false,
+  //    所以这个值不影响结论 —— 但即便将来那条捷径被改掉,默认也落在保守那侧,
+  //    不会因为"没有会话"而意外放行。
   return resolveGrokCopresenceHubStatus(
-    describeGrokCopresenceLiveness(grokCopresenceRuntimeSession),
+    describeGrokCopresenceLiveness(
+      grokCopresenceRuntimeSession,
+      grokCopresenceRuntimeSession?.autoLeader ?? true,
+    ),
     status,
   );
 }

--- a/agent-node/src/runtime/grok-copresence/liveness.test.ts
+++ b/agent-node/src/runtime/grok-copresence/liveness.test.ts
@@ -32,7 +32,7 @@ async function listenUnix(path: string): Promise<Server> {
 
 describe("Grok copresence liveness and hub status", () => {
   test("a missing session is never idle or working", () => {
-    const liveness = describeGrokCopresenceLiveness(null);
+    const liveness = describeGrokCopresenceLiveness(null, true);
     expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
     expect(resolveGrokCopresenceHubStatus(liveness, "working")).toBe("blocked");
     expect(resolveGrokCopresenceHubStatus(liveness, "offline")).toBe("offline");
@@ -57,19 +57,19 @@ describe("Grok copresence liveness and hub status", () => {
     };
     expect(isNamedGrokCopresenceSocket(attachSocket, "attach")).toBe(true);
     expect(isNamedGrokCopresenceSocket(leaderSocket, "leader")).toBe(true);
-    expect(resolveGrokCopresenceHubStatus(describeGrokCopresenceLiveness(live), "idle")).toBe("idle");
-    expect(resolveGrokCopresenceHubStatus(describeGrokCopresenceLiveness(live), "working")).toBe("working");
+    expect(resolveGrokCopresenceHubStatus(describeGrokCopresenceLiveness(live, true), "idle")).toBe("idle");
+    expect(resolveGrokCopresenceHubStatus(describeGrokCopresenceLiveness(live, true), "working")).toBe("working");
 
     expect(resolveGrokCopresenceHubStatus(
-      describeGrokCopresenceLiveness({ ...live, tuiReady: false }),
+      describeGrokCopresenceLiveness({ ...live, tuiReady: false }, true),
       "idle",
     )).toBe("blocked");
     expect(resolveGrokCopresenceHubStatus(
-      describeGrokCopresenceLiveness({ ...live, isRunning: false }),
+      describeGrokCopresenceLiveness({ ...live, isRunning: false }, true),
       "idle",
     )).toBe("blocked");
     expect(resolveGrokCopresenceHubStatus(
-      describeGrokCopresenceLiveness({ ...live, attachSocket: relaySocket }),
+      describeGrokCopresenceLiveness({ ...live, attachSocket: relaySocket }, true),
       "idle",
     )).toBe("blocked");
 
@@ -82,7 +82,7 @@ describe("Grok copresence liveness and hub status", () => {
     expect(isNamedGrokCopresenceSocket(short.attachSocket, "attach")).toBe(true);
     expect(isNamedGrokCopresenceSocket(short.leaderSocket, "leader")).toBe(true);
     expect(resolveGrokCopresenceHubStatus(
-      describeGrokCopresenceLiveness(short, () => true),
+      describeGrokCopresenceLiveness(short, true, () => true),
       "idle",
     )).toBe("idle");
   });
@@ -102,5 +102,101 @@ describe("Grok copresence liveness and hub status", () => {
     });
     expect(liveness.attach.present).toBe(false);
     expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
+  });
+});
+
+/* #1548 —— leaderless build 上的 `usable`。
+ *
+ * 病灶:有些 grok build **按设计不建 leader.sock**(`runtime.ts` 能力表里
+ * `autoLeader: false`,例如 1.0.5);`settleLeader()` 对这类 build 把 **ENOENT 当成功**。
+ * 而本函数此前**无条件**要求 `leaderPresent` ⇒ 这类节点上 `usable` 结构性恒假
+ * ⇒ 心跳的 `idle` 每 3 分钟被改写成 `blocked`,永远。
+ * 现场:名册 3 个 blocked 全是这类节点,非 grok 节点 **0/114**。
+ *
+ * 🔴 三格验收,缺一不可(通信龙 定):
+ *   1. leaderless + 运行时可用      → 不再 blocked
+ *   2. leaderless + 运行时真不可用  → 仍然 blocked   ← 只做 1 会把真故障一起放过,
+ *                                                      **而放过之后没有别的信号会报警**
+ *   3. autoLeader:true + 缺 socket  → 仍然 blocked   ← 别把老 build 的保护一起拆了
+ */
+describe("#1548 leaderless build 的 usable", () => {
+  const base = (root: string) => ({
+    isRunning: true,
+    tuiReady: true,
+    attachSocket: join(root, "attach.sock"),
+    leaderSocket: join(root, "leader.sock"),
+  });
+
+  test("① leaderless + 运行时可用(只有 attach.sock)→ 不再 blocked", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-leaderless-ok-"));
+    cleanup.push(root);
+    await listenUnix(join(root, "attach.sock"));      // 只建 attach,不建 leader
+    const liveness = describeGrokCopresenceLiveness(base(root), false);
+    expect(liveness.leader.present).toBe(false);       // 事实照实报
+    expect(liveness.usable).toBe(true);
+    expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("idle");
+    expect(resolveGrokCopresenceHubStatus(liveness, "working")).toBe("working");
+  });
+
+  /* 🔴 第 2 格是整组的重点:只做第 1 格的话,一个"leaderless ⇒ 一律 usable"的实现
+   * 也能全绿,而那会**把真故障一起放过去** —— 且放过之后没有任何别的信号会报警,
+   * 因为这一格是唯一的。 */
+  test("② leaderless + 子进程死了 → 仍然 blocked", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-leaderless-dead-"));
+    cleanup.push(root);
+    await listenUnix(join(root, "attach.sock"));
+    const liveness = describeGrokCopresenceLiveness({ ...base(root), isRunning: false }, false);
+    expect(liveness.usable).toBe(false);
+    expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
+  });
+
+  test("② leaderless + TUI 没就绪 → 仍然 blocked", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-leaderless-notui-"));
+    cleanup.push(root);
+    await listenUnix(join(root, "attach.sock"));
+    const liveness = describeGrokCopresenceLiveness({ ...base(root), tuiReady: false }, false);
+    expect(liveness.usable).toBe(false);
+    expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
+  });
+
+  test("② leaderless + attach.sock 不在 → 仍然 blocked", () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-leaderless-noattach-"));
+    cleanup.push(root);                                // 一个 socket 都不建
+    const liveness = describeGrokCopresenceLiveness(base(root), false);
+    expect(liveness.usable).toBe(false);
+    expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
+  });
+
+  test("🔴 ③ autoLeader:true + 缺 leader.sock → 仍然 blocked(老 build 的保护一格没松)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-autoleader-missing-"));
+    cleanup.push(root);
+    await listenUnix(join(root, "attach.sock"));
+    const liveness = describeGrokCopresenceLiveness(base(root), true);
+    expect(liveness.usable).toBe(false);
+    expect(resolveGrokCopresenceHubStatus(liveness, "idle")).toBe("blocked");
+  });
+
+  /* 🔴 反向 fail-closed:leaderless build 上 socket **不该出现**。它若出现,
+   * 说明「这个 build 不外派工具」这个前提不成立 —— `settleLeader()` 在启动时
+   * 就是这么处理的(「verified as leaderless yet created …」直接抛)。
+   * 这里不比它松:出现了就不 usable。 */
+  test("🔴 leaderless build 上 leader.sock 竟然出现 → 不 usable(与 settleLeader 同向)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grok-leaderless-unexpected-"));
+    cleanup.push(root);
+    await listenUnix(join(root, "attach.sock"));
+    await listenUnix(join(root, "leader.sock"));       // 不该有,却有
+    const liveness = describeGrokCopresenceLiveness(base(root), false);
+    expect(liveness.leader.present).toBe(true);
+    expect(liveness.usable).toBe(false);
+  });
+
+  /* 分母自证:上面这组里 usable 两侧都有(1 真 / 5 假),
+   * 否则"恒假"或"恒真"的实现都能挑一半用例过。 */
+  test("分母自证:这组用例 usable 两侧都有", async () => {
+    const ok = mkdtempSync(join(tmpdir(), "grok-denom-ok-"));
+    cleanup.push(ok);
+    await listenUnix(join(ok, "attach.sock"));
+    expect(describeGrokCopresenceLiveness(base(ok), false).usable).toBe(true);
+    expect(describeGrokCopresenceLiveness(base(ok), true).usable).toBe(false);
   });
 });

--- a/agent-node/src/runtime/grok-copresence/liveness.ts
+++ b/agent-node/src/runtime/grok-copresence/liveness.ts
@@ -63,8 +63,24 @@ export function isNamedGrokCopresenceSocket(path: string, role: "attach" | "lead
   return name === "leader.sock" || name === "l.sock";
 }
 
+/**
+ * #1548 —— `autoLeader` 是**必填**的,故意不给默认值。
+ *
+ * 🔴 背景:有些 grok build **按设计就不建 leader.sock**
+ *    (`runtime.ts` 的能力表里 `autoLeader: false`,例如 1.0.5)。
+ *    `runtime.ts` 的 `settleLeader()` 对这类 build 把 **ENOENT 当成功路径**;
+ *    而本函数此前**无条件**要求 `leaderPresent`,于是这类节点上
+ *    `usable` **结构性恒为 false** ⇒ 心跳的 `idle` 每 3 分钟被改写成 `blocked`,永远。
+ *    实测:名册上 3 个 blocked 全是这类节点,非 grok 节点 0/114(#1548)。
+ *    **同一个仓里两处对"该不该有 leader.sock"判断相反,而 leaderless 这个事实只写在一处。**
+ *
+ * 🔴 为什么必填而不是 `autoLeader = true`:带默认值的话,**漏传会静默恢复成老行为**
+ *    —— 也就是恢复成这个缺陷本身,而且不会有任何东西红。
+ *    做成必填,漏传就是编译错误:把一个安静的运行时缺陷换成一个吵闹的构建失败。
+ */
 export function describeGrokCopresenceLiveness(
   session: GrokCopresenceLivenessSource | null | undefined,
+  autoLeader: boolean,
   inspect: GrokSocketInspector = grokSocketIsPresent,
 ): GrokCopresenceLiveness {
   if (!session) {
@@ -82,12 +98,18 @@ export function describeGrokCopresenceLiveness(
   const leaderPresent = inspect(session.leaderSocket);
   const tuiReady = session.tuiReady === true;
   const childAlive = session.isRunning === true;
+  // 🔴 两个方向都 fail-closed,和 `settleLeader()` 逐条对齐:
+  //    · autoLeader:true  —— socket 必须**在**且名字对(老行为,一格没放松);
+  //    · autoLeader:false —— socket 必须**不在**。它若出现,说明"这个 build 不外派工具"
+  //      这个前提不成立,`settleLeader()` 在启动时就是这么 fail-closed 的
+  //      (「verified as leaderless yet created …」)。这里不比它松。
+  const leaderOk = autoLeader ? (leaderPresent && leaderNamed) : !leaderPresent;
   return {
     tuiReady,
     childAlive,
     attach: { present: attachPresent, named: attachNamed },
     leader: { present: leaderPresent, named: leaderNamed },
-    usable: childAlive && tuiReady && attachPresent && leaderPresent && attachNamed && leaderNamed,
+    usable: childAlive && tuiReady && attachPresent && attachNamed && leaderOk,
   };
 }
 

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -462,6 +462,11 @@ export interface GrokCopresenceRuntimeSession {
   readonly attachSocket: string;
   readonly isRunning: boolean;
   readonly tuiReady: boolean;
+  /** #1548 —— 这个 build 会不会自动起 Leader(`grokBuildAutoLeader`)。
+   *  暴露出来是为了让 liveness 的调用方**不必自己去查版本表** ——
+   *  查两遍就会有两份判据,而 #1548 正是"启动认为不该有 leader.sock、
+   *  liveness 认为必须有"这种自相矛盾造成的。 */
+  readonly autoLeader: boolean;
   readonly state: GrokCopresenceState;
   /** The model the next spawn will request; moves only via `switchModel`. */
   readonly model: string | undefined;
@@ -753,8 +758,13 @@ export const GROK_COPRESENCE_VERIFIED_BUILDS: ReadonlyMap<string, GrokVerifiedBu
   //        并在 reducedGuarantees 里逐条列出;这不是"放松断言",是**如实登记已失去的保证**。
   //   · `--leader` 在 help 里;`--no-memory` / `--no-auto-update` 与 Linux 一样是隐藏 flag
   //   · TUI 能起来:同机 `grok` 起 TUI 正常(Grok 4.6 / Grok Build 1.0.5)
-  //   · 🔴 grok 在 macOS 上是 leaderless —— 跑一次 grok 之后 ~/.grok/leader.sock 与
-  //        leader.lock 都没有被创建(Linux 上两者都在)。autoLeader 沿用 false。
+  //   · 🔴 grok **1.0.5** 是 leaderless —— 跑一次 grok 之后 ~/.grok/leader.sock 与
+  //        leader.lock 都没有被创建。autoLeader 沿用 false。
+  //     🔴 **分界线是版本,不是平台。** 这条原本写作「(Linux 上两者都在)」,
+  //        那句是 **0.2.93 时代在 Linux 上量的**,却写在这张**按版本键**的表旁边,
+  //        读起来像在讲平台。2026-08-30 在 Linux/DEV 上实测
+  //        `grok 1.0.5 (5115b46bc9) [stable]`:**leader.sock 同样不存在**(#1548)。
+  //        照平台去分支会分错 —— 要判就查 `grokBuildAutoLeader(version)`。
   ["grok 1.0.5 (5115b46bc909)", { autoLeader: false }],
   ["grok 1.0.5 (5115b46bc909) [stable]", { autoLeader: false }],
 ]);
@@ -1118,8 +1128,16 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     return this.tuiComposerReady;
   }
 
+  /** #1548 —— 这个 build 会不会自动起 Leader。
+   *  与 `settleLeader()` 用的是**同一个**判据(`grokBuildAutoLeader`),
+   *  不是第二份 —— 两处若各判一次,就会出现"启动认为不该有、liveness 认为必须有"
+   *  这种自相矛盾,而那正是 #1548 的成因。 */
+  get autoLeader(): boolean {
+    return grokBuildAutoLeader(this.opts.grokVersion);
+  }
+
   liveness(): GrokCopresenceLiveness {
-    return describeGrokCopresenceLiveness(this);
+    return describeGrokCopresenceLiveness(this, this.autoLeader);
   }
 
   get state(): GrokCopresenceState {

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -16,7 +16,18 @@ preview 2.3.0-preview.39    anet grok attach → Usage: anet grok attach <node>
 
 ⇒ **这个命令在 `preview` 里是存在的**,只是 `latest` 里没有。
 **但「命令存在」不等于「这条共存路径可用」** —— 命令注册不等于端到端可用。
-Hub 不得把死掉/未就绪的 TUI 报成 `idle`（#1005：liveness 快照，缺 named socket 或 composer 未就绪时为 `blocked`）。
+Hub 不得把死掉/未就绪的 TUI 报成 `idle`（#1005：liveness 快照，子进程已死 / composer 未就绪 /
+缺 named attach socket 时为 `blocked`）。
+
+🔴 **更正(2026-08-30,#1548)**:这句原本写作「缺 named socket … 为 `blocked`」，
+把 **leader** socket 也算了进去 —— 而**有些 grok build（能力表里 `autoLeader: false`，例如 1.0.5）
+按设计就不建 `leader.sock`**。于是这类节点的 `usable` 结构性恒为假，名册上永远显示 `blocked`，
+而运行时可能完全正常（实测:被标 blocked 之后仍成功接活并回复）。
+
+所以判据现在**按 build 分**：`autoLeader: true` 的 build 仍要求 `leader.sock` 在且命名正确；
+`autoLeader: false` 的 build **要求它不在**（它若出现，说明「这个 build 不外派工具」的前提不成立，
+与 `settleLeader()` 启动时的 fail-closed 同向）。
+**分界线是版本,不是平台** —— 1.0.5 在 macOS 和 Linux 上都不建。
 本页其余的告诫仍然成立:它仍在重新验收,不要当已发布功能用。
 :::
 


### PR DESCRIPTION
## 病灶

`describeGrokCopresenceLiveness` 里 `usable` **无条件**要求 `leaderPresent`。
而 `runtime.ts` 的能力表里有 `autoLeader: false` 的 build(1.0.5),它们**按设计不建**
`leader.sock` —— 同一个文件的 `settleLeader()` 对这类 build 把 **ENOENT 当成功路径**,
socket 真出现了反而 fail-closed(「verified as leaderless yet created …」)。

⇒ **同一个仓里两处对「该不该有 leader.sock」判断相反,而 leaderless 这个事实只写在一处。**
在这类 build 上 `usable` **结构性恒为假** ⇒ 心跳字面发的 `"idle"` 被
`resolveGrokCopresenceHubStatus` 每 3 分钟改写成 `blocked`,**永远**。

现场(通信龙 从 get_all_status 原始列取的,非兜底链):
```
            blocked  idle  offline
grok 节点        3    11     12
非 grok          0   114    131        ← 负控:这不是通用的"状态陈旧"
```
两台 Mac 跑 `grok-1.0.5-macos-aarch64`、DEV 上 `grok 1.0.5 (5115b46bc9) [stable]`,
都落在 `autoLeader:false` 那两行;它们的 `run/` 下**只有 attach.sock,没有 leader.sock**。

## 改法

`describeGrokCopresenceLiveness(session, autoLeader, inspect?)` —— `autoLeader` **必填,不给默认值**。

🔴 带默认值的话,**漏传会静默恢复成老行为**,也就是恢复成这个缺陷本身,而且不会有任何东西红。
   做成必填 ⇒ 漏传是**编译错误**:把一个安静的运行时缺陷换成一个吵闹的构建失败。

判据两个方向都 fail-closed,与 `settleLeader()` 逐条对齐:
```js
const leaderOk = autoLeader ? (leaderPresent && leaderNamed) : !leaderPresent;
usable = childAlive && tuiReady && attachPresent && attachNamed && leaderOk;
```
`autoLeader:false` 上要求 socket **不在** —— 它若出现,说明「这个 build 不外派工具」
这个前提不成立,和启动路径同向,**不比它松**。

调用方不自己查版本表:`GrokCopresenceRuntimeSession` 暴露 `autoLeader`,
它内部用的就是 `settleLeader()` 用的那个 `grokBuildAutoLeader` —— **不产生第二份判据**。

## 三格验收(通信龙 定)+ 见证

| 变异 | 红 |
|---|---|
| M1 退回缺陷(无条件要求 leaderPresent) | ①「leaderless+可用→不再 blocked」等 3 条 |
| M2 去掉反向 fail-closed(leaderless 一律放行) | 「leader.sock 竟然出现 → 不 usable」 |
| M3 leaderless ⇒ 一律 usable(把真故障也放过) | ② 三条(子进程死 / TUI 未就绪 / attach 不在)+ 老 build 那条 |

🔴 **第 2 格是重点**:只做第 1 格的话,一个「leaderless ⇒ 一律 usable」的实现也能全绿,
   而那会**把真故障一起放过去** —— 且放过之后**没有任何别的信号会报警,因为这一格是唯一的**。
第 3 格(`autoLeader:true` 缺 socket → 仍 blocked)确认老 build 的保护一格没松。
另有分母自证:这组用例 `usable` 两侧都有,否则恒真/恒假的实现能各挑一半过。

## 顺带修两处会把缺陷固化成规格的文字

1. `runtime.ts` 那条「(Linux 上两者都在)」—— 它是 **0.2.93 时代在 Linux 上量的**,
   却写在**按版本键**的能力表旁边,读起来像在讲平台。2026-08-30 在 Linux/DEV 上实测
   1.0.5 **同样没有** leader.sock。**分界线是版本,不是平台**,并注明是哪一版量的。
2. `docs-site/docs/guide/grok-copresence.md` 那句「缺 named socket … 为 `blocked`」——
   它把**有缺陷的判据**当正确行为写进了文档。改成按 build 分,并写明两个方向。

grok-copresence 全套 266 pass / 0 fail;类型棘轮 81 == baseline 81;五道文档门 rc=0。

Refs #1548


---

## 依赖与后续

- 依赖 #1608(`hello` 带 status 快照)么?**不依赖**,两条互不冲突。
  但 #1608 是**验证这条修复的手段**:修完之后要确认「这一格终于携带信息了」,
  仍然需要能从外部读到 `tuiReady`,而那正是 #1608 打开的。
- 🔴 **#1607 那条用户告示要跟着改**:它现在写的是「修复前请以日志为准」。
  这条合了之后那句就过期了 —— 别让它变成一条留在站点上的过期告示。
- **grok-v1 仍未定性**:它也是 blocked,但没有「被标 blocked 之后仍成功接活」的证据,
  所以**不能**归入已证实的假阳性。本 PR 的表述是弱版本:
  **leaderless build 上 `usable` 结构性恒假 ⇒ 无法分辨真假**。
  修完之后它若仍 blocked,那才是第一次有信息量的 blocked。

## 这条修复的第一个收益不是"少报假警"

是**让这一格重新开始携带信息**。在此之前,对所有 leaderless 节点它恒定为 `blocked`,
一个恒定的信号不携带任何信息 —— 我们既看不出坏,也看不出好。
