### PR TITLE
fix(release): .74 的 release notes 补 Install / Upgrade 两节 —— 门 3 拦住了发布

### DIFF
--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -306,6 +306,38 @@ git commit -m "chore(release): @sleep2agi/agent-node 2.3.2-preview.0"
 > Conventional Commits：`chore(release): ...` 或 `release: ...`。
 > 不加 `Co-Authored-By` 类 footer（OSS rule，见仓库 commit history）。
 
+### Step 5.5：release notes 的**形状**是一道门，而它只在发版时才跑
+
+`docs/tests/release-v<版本>.md` **必须**有这两节，否则 `release-gate (v0)` 的
+`gate 3 — release notes shape` 会红，`publish` 被跳过：
+
+```markdown
+## Install
+
+```bash
+npm i -g @sleep2agi/<包>@<版本>
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/<包>@<版本>
+```
+```
+
+三条要求（门逐条检查，报错会指名缺哪一条）：
+
+1. 有 `## Install` —— 新用户安装路径；
+2. 有 `## Upgrade` —— 老用户升级路径；
+3. **`## Install` 段里必须出现被门的那个版本号**（`@<版本>`）。
+
+🔴 **为什么单独写在这里**：`release.yml` 的触发只有 `push: tags` 和 `workflow_dispatch`，
+**它不在 PR 上跑**。也就是说这条要求在 PR 阶段**没有任何东西会提醒你** ——
+notes 写漏两节的 PR 会一路绿灯合进 main，直到你触发发版才发现 `publish` 被跳过。
+（2026-08-30 的 `.74` 就是这么返工了一轮；当时 SOP 里也没写这一条，所以读文档也躲不掉。）
+
+⇒ 写 notes 时**照着上一版的文件抄形状**，别从空白开始。
+
 ### Step 6：publish preview —— 走 GitHub Actions，**不在本机发**
 
 🔴 **本机不发包。** 这是 Vincent 2026-08-27 定的规则：发版一律走 GitHub Actions，

--- a/docs/tests/release-v2.3.0-preview.74.md
+++ b/docs/tests/release-v2.3.0-preview.74.md
@@ -45,6 +45,23 @@ git log origin/main --since=2026-08-27 --oneline -- server/src/auth.ts   →  0
 
 仍然成立，才搬到 `.74`。
 
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.74
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.74
+# 🔴 本机的 anet 升级即生效;但**远端那台 daemon**要重启才会用新逻辑。
+# 而这一版正好把这件事变简单了(#1601):
+anet daemon restart <daemon>
+# 你的版本里没有 restart 的话(≤ .73)用两步:
+anet node stop <daemon> && anet daemon start <daemon>
+```
+
 ## 发布方式
 
 走 GitHub Actions（`release-gate (v0)` 发 preview）。**不从本机 publish，不从非 main 分支出对外产物。**


### PR DESCRIPTION
## 门说了什么

```
::error:: docs/tests/release-v2.3.0-preview.74.md missing '## Install' section (new-user install path)
```

`release-gate (v0)` 的 gate 3 要求 release notes 有 `## Install`(新用户装)与 `## Upgrade`(老用户升)两节,
且 Install 段里要出现被门的那个版本号。我写 `.74` 的 notes 时漏了这两节。

**`publish` 因此被跳过 —— 包没有发出去。门起作用了。**

## 自证

```
'## Install': 1 | '## Upgrade': 1 | Install 段含 @2.3.0-preview.74: True
```

## Upgrade 段用上了这一版自己的改进

远端 daemon 升级后要重启才生效。而 #1601 正好把它从两条命令变成一条:

```bash
anet daemon restart <daemon>
# ≤ .73 的用户没有 restart,用两步:
anet node stop <daemon> && anet daemon start <daemon>
```

发版说明演示的正是这一版的价值。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)