### PR TITLE
docs(comments): 两处「已发布最高是 .56」改成不会腐烂的写法

### DIFF
--- a/agent-network/src/daemon-capability-display.ts
+++ b/agent-network/src/daemon-capability-display.ts
@@ -149,8 +149,9 @@ export function describeCapability(row: DaemonCapabilityRow, nowMs: number): Cap
         //    —— 也就是说这个 ready 可能是几周前的事,而二进制早被换掉了。
         //
         // 🔴 这个版本号原先写的是「preview.67」,**指向一个不存在的版本**:
-        //    agent-node 已发布的最高 preview 是 2.5.0-preview.56(.67 是
-        //    **agent-network** 的号,两个包的序列被串了)。
+        //    agent-node 从来没有过 .67(.67 是 **agent-network** 的号,
+        //    两个包的序列被串了)。**这里不写「当前最高版本」** ——
+        //    那种句子每次发版都会变成假话,而没有任何门会红。
         //    实测边界:agent-node 2.5.0-preview.54 的产物里没有
         //    `create_capability_observed_ms_ago`,.55 有。
         //    **所以以后写代际边界一律带包名 + 完整版本号** ——

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -418,7 +418,8 @@ export interface DaemonCapabilities {
    *
    * 🔴 版本号带包名 + 完整版本号:仓里三个包各自独立编号,裸的 `preview.NN`
    *    同时是三个不同的时间点。此处曾写成「preview.67」—— 那是 **agent-network**
-   *    的号,agent-node 根本没有 .67(npm 404,已发布最高 2.5.0-preview.56)。
+   *    的号,agent-node 根本没有 .67(写下时实测 npm 404;
+   *    **别在这里记「当前最高版本」—— 它每次发版都会变成假话**)。
    *    实测边界:.54 的产物里无此字段,.55 起有。
    *
    * 🔴 缺席 ≠ 0。**agent-node ≤ 2.5.0-preview.54** 的 daemon 在**开机时算一次**就永久缓存,


### PR DESCRIPTION
## 问题

两处注释写着「agent-node **已发布最高**是 `2.5.0-preview.56`」。
`.57` 一发(PR #1611)这句就是假的,**而没有任何门会红**。

## 修法不是改数字

把 `.56` 改成 `.57` 的话,下次发版又假一次。改的是**句子的形状** ——
去掉那个会腐烂的数字,并把规则写给下一个人:

> **别在这里记「当前最高版本」—— 它每次发版都会变成假话,而没有任何门会红。**

注释原本要表达的意思一点没丢:`.67` 不存在、两个包的序列被串了、
代际边界一律带包名 + 完整版本号。

## 自证

```
两文件里「已发布最高 / 最高 preview 是」式断言 = 0 处
```

## 动手前查过门

这两个文件只被一道**按数量**的 typecheck 棘轮覆盖(不是行号 pin),改注释不影响。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)