### PR TITLE
fix(comment): #1563 pushUserEvent 那段注释被同一个函数里的代码证伪

### DIFF
--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2487,9 +2487,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           ],
         );
       });
-      // #1459 — pushUserEvent 在没有订阅者时静默 return，而这个工具既不写
-      // inbox、也没有任何 user 级回读路径（/api/messages 只 SELECT FROM inbox）。
-      // 也就是说用户 dashboard 关着的时候这条消息就永久没了。
+      // #1459 / #1563 — pushUserEvent 在没有订阅者时静默 return。
+      // 🔴 这段注释原先写「本工具既不写 inbox、也没有 user 级回读路径 ⇒ dashboard
+      //    关着时消息永久没了」。**那半句已经不成立** —— 上面 20 行就在
+      //    `INSERT INTO user_inbox`，且 `/api/messages?scope=user` 能回读
+      //    （desktop-message-seam.test.ts 有真实 send → 真实 GET 的端到端断言）。
+      //    留着它会把 debug 未读数的人直接带向错误的一层。
       //
       // 这里先把**丢失变可见**：`ok` 仍表示「请求被接受、审计已落库」，
       // 新增 `delivered` 表示「此刻真的有人收到」。判据取自订阅者注册表，


### PR DESCRIPTION
## 注释说的和代码做的相反

注释(约 2489 行):

> pushUserEvent … 这个工具**既不写 inbox、也没有任何 user 级回读路径**
> (`/api/messages` 只 SELECT FROM inbox)。也就是说用户 dashboard 关着的时候**这条消息就永久没了**。

实际:

- **上面 20 行**(约 2468)就是 `INSERT INTO user_inbox`;
- `/api/messages?scope=user` 能回读,`desktop-message-seam.test.ts` 里有
  **真实 send → 真实 GET** 的端到端断言(不是两半各对自己的夹具绿)。

## 为什么值得单独修

它会把 debug **未读数**的人直接带向错误的一层 —— 而未读数正是今天 app#203 在修的东西。
一条"服务端根本不存这个消息"的注释,会让人去查服务端,而缺陷在客户端。

## 这条注释自己预言过会过期

同一段里写着:「持久化落地之后同一个事实会变成『已入库、等重连补投』」。
**预言兑现了,但没人回来改。**

## 自证与门

```
「永久没了」残留 = 0 处
check-docs-integrity.py            rc=0
check-action-pins.py               rc=0
check-bun-install-pin.py           rc=0
check-copresence-profile-pin.py    rc=0
check-doc-symbol-anchors.py        rc=0
```

(改 `server/src/tools.ts` 会挤漂行号 pin,所以本地先跑了这几道。)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)