### PR TITLE
docs(grok-copresence): #1606 已在 agent-node 2.5.0-preview.57 修复 —— 告示改成按版本分叉

### DIFF
--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -4,7 +4,7 @@
 The danger block below captures the 2026-08-18 qualification state and is **outdated**: the `grok-build-cli` co-presence path now works end to end — on a Mac mini with npm-installed `anet 2.3.0-preview.43` + the global `agent-node` (grok `1.0.5 (5115b46bc909)`, on the verified list), creating the node, entering the shared TUI via `anet grok attach`, and receiving an answer to an injected network task in 19 seconds. For current usage see [Grok Co-presence TUI (grok-build-cli)](/en/guide/grok-tui). The historical warnings are preserved below for the record.
 :::
 
-::: warning Known defect: `blocked` in the roster currently cannot tell real from false (measured 2026-08-30, [#1606](https://github.com/sleep2agi/agent-network/issues/1606))
+::: warning `blocked` cannot tell real from false — **fixed from agent-node `2.5.0-preview.57`** ([#1606](https://github.com/sleep2agi/agent-network/issues/1606))
 **With grok 1.0.5 this cell is permanently `blocked`, even while the node is working normally.**
 
 1.0.5 is a **leaderless** build — by design it never creates `leader.sock` (`autoLeader: false` in the capability
@@ -13,8 +13,21 @@ structurally false, and the `idle` the heartbeat reports is rewritten to `blocke
 
 Measured: a node marked `blocked` still injected a network task, returned an answer, and replied to the sender.
 
-**Do not rebuild the node when you see `blocked`.** Until this is fixed, judge these nodes by their logs, not by
-that cell — `injected network task` / `processTask returned` in the log means the runtime is fine.
+**Do not rebuild the node when you see `blocked`.** Check your agent-node version first:
+
+```bash
+agent-node --version
+```
+
+- **≥ `2.5.0-preview.57`** — fixed. A `blocked` here **carries information**: check the TUI child process, composer readiness, and `attach.sock`.
+- **< `2.5.0-preview.57`** — this cell is structurally false for leaderless builds and **carries no information**. Judge by the logs instead: `injected network task` / `processTask returned` means the runtime is fine.
+
+🔴 **Upgrading is not enough — you must restart**, because liveness is computed inside the long-running process:
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.57
+anet daemon restart <daemon>        # requires anet >= 2.3.0-preview.74
+```
 :::
 
 ::: danger Old state as of 2026-08-18 (archived)

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -4,7 +4,7 @@
 下面的 danger 块记录的是 2026-08-18 的验收状态，**已过时**：`grok-build-cli` 共存路径现已端到端跑通 —— macmini 上用 npm 安装的 `anet 2.3.0-preview.43` + 全局 `agent-node`（grok `1.0.5 (5115b46bc909)`，验证清单内）创建节点、`anet grok attach` 进入共享 TUI、网络任务注入并 19 秒收到回答。当前用法见 [Grok 共存 TUI（grok-build-cli）](/guide/grok-tui)。历史告诫保留如下供追溯。
 :::
 
-::: warning 已知缺陷：名册里的 `blocked` 目前分辨不出真假（2026-08-30 实测，[#1606](https://github.com/sleep2agi/agent-network/issues/1606)）
+::: warning `blocked` 分辨不出真假 —— **从 agent-node `2.5.0-preview.57` 起已修**（[#1606](https://github.com/sleep2agi/agent-network/issues/1606)）
 **用 grok 1.0.5 时这一格恒为 `blocked`，即使节点正在正常干活。**
 
 1.0.5 是 **leaderless** build —— 按设计就不创建 `leader.sock`（能力表里 `autoLeader: false`，macOS 与 Linux 都是），
@@ -12,8 +12,22 @@
 
 实测：被标成 `blocked` 的节点仍然成功注入并返回了网络任务，还回复了发起方。
 
-**看到 `blocked` 先别重建节点。** 修复前请以节点日志为准，不要以名册那一格为准 —— 日志里有
-`injected network task` / `processTask returned` 就说明运行时是好的。
+**看到 `blocked` 先别重建节点。** 先看你的 agent-node 版本：
+
+```bash
+agent-node --version
+```
+
+- **≥ `2.5.0-preview.57`** —— 已修。此时的 `blocked` **是有信息量的**，去查 TUI 子进程、composer 就绪、`attach.sock`。
+- **< `2.5.0-preview.57`** —— 这一格对 leaderless build 恒为假，**不携带任何信息**。以节点日志为准：
+  日志里有 `injected network task` / `processTask returned` 就说明运行时是好的。
+
+🔴 **升级之后必须重启，光换包不够** —— liveness 在**长驻进程内**算：
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.57
+anet daemon restart <daemon>        # 需要 anet ≥ 2.3.0-preview.74
+```
 :::
 
 ::: danger 2026-08-18 时点的旧状态（保留存档）


### PR DESCRIPTION
`agent-node@2.5.0-preview.57` 已发布到 npm preview(判据:`npm view … dist-tags.preview` 返回 `.57`,不是"workflow 绿了")。

## 为什么不是删掉告示

`.57` 刚发出去,**绝大多数在跑的节点仍是旧版本** —— 实测 Mac 上装的是 `.55`,
那三个 blocked 节点分别是 `.32 / .40 / .46`。**删早了等于让还在旧版本的人失去唯一的判断依据。**

## 改成一条可执行的分叉

```bash
agent-node --version
```

| 版本 | 那一格意味着什么 |
|---|---|
| ≥ `2.5.0-preview.57` | 已修 —— 此时的 `blocked` **有信息量**,去查 TUI 子进程 / composer 就绪 / `attach.sock` |
| < `2.5.0-preview.57` | 对 leaderless build **恒为假,不携带任何信息**,以节点日志为准 |

## 并写明「换包不够」

```bash
npm i -g @sleep2agi/agent-node@2.5.0-preview.57
anet daemon restart <daemon>        # 需要 anet >= 2.3.0-preview.74
```

liveness 在**长驻进程内**算 —— 不重启等于没升。
(`anet daemon restart` 是今天先发的 `.74` 提供的,两个包在这一步配套。)

## 中英两页同步

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)