### PR TITLE
fix(daemon): restart 起不来时说清楚「它现在是停着的」

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8560,7 +8560,20 @@ async function daemonRestartCommand() {
   console.log(`[anet daemon] restart "${id}" —— 先停`);
   await stopCommand();
   console.log(`[anet daemon] restart "${id}" —— 再起`);
-  await startCommand();
+  // 🔴 起不来时,daemon 现在是**停着的** —— 而上面那条 "先停" 已经打印过了,
+  //    用户很容易以为 restart 只是"没成功",而不是"我的 daemon 现在没了"。
+  //    2026-08-30 实测两次:先 stop 再发现起不来(一次是 grok 自更新到未验证版本
+  //    #1615,一次是启动进程没活过父会话)。两次都是停掉之后才知道。
+  //    所以这里不吞异常(原样抛出保留退出码与栈),只在抛之前把**当前状态**说清楚。
+  try {
+    await startCommand();
+  } catch (e) {
+    console.error(``);
+    console.error(`🔴 [anet daemon] "${id}" 已经停了,但没能起来 —— 现在它是**停着的**。`);
+    console.error(`   重试:  anet daemon start ${id}`);
+    console.error(`   先看上面的启动报错;常见原因是运行时二进制的版本不在验证清单里(见 #1615)。`);
+    throw e;
+  }
 }
 
 async function daemonUpCommand() {


### PR DESCRIPTION
## 问题

`anet daemon restart` = `stop` 然后 `start`。**`start` 失败时 daemon 处于停止状态** ——
而上面已经打印过「先停」，用户很容易把结果读成「restart 没成功」，
而不是「**我的 daemon 现在没了**」。

## 今天实测两次，都是这个形状

| 场次 | 先做了什么 | 之后才发现 |
|---|---|---|
| 1 | `stop` 了一个共存节点 | grok 自更新到未验证版本 ⇒ fail-closed 拒绝启动（#1615） |
| 2 | `stop` 了另一个共存节点 | 启动进程没活过父会话 ⇒ 起来了个寂寞 |

两次都是**停掉之后才知道起不来**。第 2 次造成了约 2 分钟的真实节点中断。

## 改法

不吞异常（原样 `throw`，退出码与栈都保留），只在抛之前把**当前状态**说清楚：

```
🔴 [anet daemon] "<name>" 已经停了,但没能起来 —— 现在它是**停着的**。
   重试:  anet daemon start <name>
   先看上面的启动报错;常见原因是运行时二进制的版本不在验证清单里(见 #1615)。
```

## 为什么不做成「起不来就自动回滚」

回滚需要知道"之前那个版本是什么"并能把它装回去，这不是 restart 该背的责任，
而且会掩盖真实原因。**这里要的是让状态可见，不是替用户决定。**

## 更彻底的方向（不在这个 PR 里）

#1615 提的「预检前置到 stop 之前」才是根治：版本/二进制/依赖先查，通过了再 stop。
本 PR 只把**已经发生的坏状态**从隐式变成显式。

## 🔴 本地没能跑 typecheck

这个检出没装 `node_modules`；`npx tsc` 抓到的是 npm 上的**同名占位包**
（`rc=1` 但 `error TS` 计数 **0** —— 一个没跑起来的 typecheck 和一个干净的 typecheck
在 grep 下一模一样）。所以本地只做了结构自证（try/catch/throw 各 1、大括号配平 0），
**类型检查交给 CI**。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
