### PR TITLE
docs(grok-copresence): 重启前先看 grok 版本 —— 补上我自己那条告示的缺口 (#1615)

### DIFF
--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -28,6 +28,23 @@ agent-node --version
 npm i -g @sleep2agi/agent-node@2.5.0-preview.57
 anet daemon restart <daemon>        # requires anet >= 2.3.0-preview.74
 ```
+
+🔴 **Check your grok version before restarting** ([#1615](https://github.com/sleep2agi/agent-network/issues/1615)):
+
+```bash
+grok --version
+```
+
+grok **updates itself**. Once it moves to a version outside the verified list, co-presence nodes
+**fail to start on the next restart** (fail-closed), while **already-running nodes look completely fine** —
+they are using the process spawned earlier. The problem only surfaces when you run the restart above,
+and by then the node is already stopped.
+
+The error lists the verified versions. The older binary is usually still in `~/.grok/downloads/`:
+
+```bash
+GROK_BINARY=~/.grok/downloads/grok-<verified-version>-<platform> anet node start <name>
+```
 :::
 
 ::: danger Old state as of 2026-08-18 (archived)

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -28,6 +28,22 @@ agent-node --version
 npm i -g @sleep2agi/agent-node@2.5.0-preview.57
 anet daemon restart <daemon>        # 需要 anet ≥ 2.3.0-preview.74
 ```
+
+🔴 **重启之前先看一眼 grok 版本**（[#1615](https://github.com/sleep2agi/agent-network/issues/1615)）：
+
+```bash
+grok --version
+```
+
+grok 会**自我更新**。更新到不在验证清单里的版本之后，**共存节点一重启就起不来**
+（fail-closed 拒绝启动），而**在跑的节点看起来完全正常** —— 因为它们用的是启动时那份旧进程。
+也就是说：这个问题只在你执行上面那条 restart 的时候才暴露，而那时节点已经停了。
+
+已验证的版本会列在报错里。旧版二进制通常还在 `~/.grok/downloads/`，可以用它起：
+
+```bash
+GROK_BINARY=~/.grok/downloads/grok-<已验证版本>-<平台> anet node start <name>
+```
 :::
 
 ::: danger 2026-08-18 时点的旧状态（保留存档）


### PR DESCRIPTION
## 缺口是我自己造成的

今天加的告示让用户「升级后 `anet daemon restart`」,**但没说这条命令可能失败并把节点留在停止状态**。
我今天就是这样丢了一个节点(约 2 分钟中断)。

## 补的三样,都紧跟在升级命令后面

```bash
grok --version          # 1. 预检
```

2. **失败时的现象**:grok 会自我更新;更新到不在验证清单里的版本之后,共存节点**一重启就起不来**
   (fail-closed),而**在跑的节点看起来完全正常**——它们用的是启动时那份旧进程。
   **问题只在执行 restart 的那一刻暴露,而那时节点已经停了。**

3. **恢复路径**(旧二进制通常还在 `~/.grok/downloads/`):
```bash
GROK_BINARY=~/.grok/downloads/grok-<已验证版本>-<平台> anet node start <name>
```

## 落点

紧跟升级命令,不放在页面别处 —— 用户读到升级步骤的那一刻就会读到它。
(今天已经因为落点错误返工过一次:把当前缺陷写进了 archived 块。)

中英两页同步。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)