### PR TITLE
chore(release): agent-network 2.3.0-preview.75 —— 让 daemon restart 的失败兜底到用户手里

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.74",
+  "version": "2.3.0-preview.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.74",
+      "version": "2.3.0-preview.75",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.74",
+  "version": "2.3.0-preview.75",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.74";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.75";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.57";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.74 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.75 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.74` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.75` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.74 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.75 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.74`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.75`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.75.md
+++ b/docs/tests/release-v2.3.0-preview.75.md
@@ -1,0 +1,67 @@
+# agent-network 2.3.0-preview.75
+
+`.74` 之后 `agent-network/` 上有 3 个提交，**但只有 1 个对用户有实际影响**。
+
+| 提交 | PR | 内容 | 用户可见 |
+|---|---|---|---|
+| `626429e0` | #1616 | `daemon restart` 起不来时说清「它现在是停着的」 | **是** |
+| `16542789` | #1612 | 两处会腐烂的注释改写 | 否（注释） |
+| `22a225fb` | #1611 | `PAIRED_AGENT_NETWORK_VERSION` 跟随 agent-node `.57` | 否（常量） |
+
+发这一版的理由不是"攒了 3 个提交"，而是 **#1616 直接减少用户在真实故障下的困惑**。
+
+## #1616 修的是什么
+
+`anet daemon restart` = `stop` 然后 `start`。**`start` 失败时 daemon 处于停止状态**，
+而上面已经打印过「先停」——用户很容易读成「restart 没成功」，而不是「**我的 daemon 现在没了**」。
+
+现在失败时会明确打印：
+
+```
+🔴 [anet daemon] "<name>" 已经停了,但没能起来 —— 现在它是**停着的**。
+   重试:  anet daemon start <name>
+   先看上面的启动报错;常见原因是运行时二进制的版本不在验证清单里(见 #1615)。
+```
+
+异常**原样抛出**（退出码与栈都保留），只在抛之前把当前状态说清楚。
+
+## 为什么需要它（2026-08-30 实测两次）
+
+| 场次 | 先做了什么 | 之后才发现 |
+|---|---|---|
+| 1 | `stop` 了一个共存节点 | grok 自更新到未验证版本 ⇒ fail-closed 拒绝启动（#1615） |
+| 2 | `stop` 了另一个共存节点 | 启动进程没活过父会话 ⇒ 起来了个寂寞 |
+
+第 2 次造成了约 2 分钟的真实节点中断。**两次都是停掉之后才知道起不来。**
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.75
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.75
+# daemon 是长驻进程,换包要重启才生效:
+anet daemon restart <daemon>
+```
+
+## 版本戳同步（5 处）
+
+`package.json` / `package-lock.json`(2) / `PAIRED_AGENT_NETWORK_VERSION` / 中英 `getting-started.md`(各 2)。
+
+🔴 **有两处 `2.3.0-preview.74` 刻意不改**：
+
+```
+docs-site/docs/{,en/}guide/grok-copresence.md
+  anet daemon restart <daemon>    # 需要 anet ≥ 2.3.0-preview.74
+```
+
+那是**能力下界**（这个命令从 `.74` 起存在），不是版本戳。**它在 `.75` 上依然为真，改了反而变假。**
+
+## 发布方式
+
+走 GitHub Actions（`release-gate (v0)`）。不在本机 publish，对外只从 main 出。
+`latest` 保持 `2.3.0-preview.47` 不动 —— 升 latest 需要 owner ACK。


### PR DESCRIPTION
# agent-network 2.3.0-preview.75

`.74` 之后 `agent-network/` 上有 3 个提交，**但只有 1 个对用户有实际影响**。

| 提交 | PR | 内容 | 用户可见 |
|---|---|---|---|
| `626429e0` | #1616 | `daemon restart` 起不来时说清「它现在是停着的」 | **是** |
| `16542789` | #1612 | 两处会腐烂的注释改写 | 否（注释） |
| `22a225fb` | #1611 | `PAIRED_AGENT_NETWORK_VERSION` 跟随 agent-node `.57` | 否（常量） |

发这一版的理由不是"攒了 3 个提交"，而是 **#1616 直接减少用户在真实故障下的困惑**。

## #1616 修的是什么

`anet daemon restart` = `stop` 然后 `start`。**`start` 失败时 daemon 处于停止状态**，
而上面已经打印过「先停」——用户很容易读成「restart 没成功」，而不是「**我的 daemon 现在没了**」。

现在失败时会明确打印：

```
🔴 [anet daemon] "<name>" 已经停了,但没能起来 —— 现在它是**停着的**。
   重试:  anet daemon start <name>
   先看上面的启动报错;常见原因是运行时二进制的版本不在验证清单里(见 #1615)。
```

异常**原样抛出**（退出码与栈都保留），只在抛之前把当前状态说清楚。

## 为什么需要它（2026-08-30 实测两次）

| 场次 | 先做了什么 | 之后才发现 |
|---|---|---|
| 1 | `stop` 了一个共存节点 | grok 自更新到未验证版本 ⇒ fail-closed 拒绝启动（#1615） |
| 2 | `stop` 了另一个共存节点 | 启动进程没活过父会话 ⇒ 起来了个寂寞 |

第 2 次造成了约 2 分钟的真实节点中断。**两次都是停掉之后才知道起不来。**

## Install

```bash
npm i -g @sleep2agi/agent-network@2.3.0-preview.75
```

## Upgrade

```bash
npm i -g @sleep2agi/agent-network@2.3.0-preview.75
# daemon 是长驻进程,换包要重启才生效:
anet daemon restart <daemon>
```

## 版本戳同步（5 处）

`package.json` / `package-lock.json`(2) / `PAIRED_AGENT_NETWORK_VERSION` / 中英 `getting-started.md`(各 2)。

🔴 **有两处 `2.3.0-preview.74` 刻意不改**：

```
docs-site/docs/{,en/}guide/grok-copresence.md
  anet daemon restart <daemon>    # 需要 anet ≥ 2.3.0-preview.74
```

那是**能力下界**（这个命令从 `.74` 起存在），不是版本戳。**它在 `.75` 上依然为真，改了反而变假。**

## 发布方式

走 GitHub Actions（`release-gate (v0)`）。不在本机 publish，对外只从 main 出。
`latest` 保持 `2.3.0-preview.47` 不动 —— 升 latest 需要 owner ACK。
