### PR TITLE
fix(test751): 失败诊断不再静默降级成空串 (#1342)

### DIFF
--- a/tests/test751-codex-copresence-windows/windows-e2e.mjs
+++ b/tests/test751-codex-copresence-windows/windows-e2e.mjs
@@ -69,9 +69,19 @@ function terminal(args, onData, timeoutMs = 45_000) {
       clearTimeout(timer);
       if (exitCode !== 0) {
         const appLog = join(project, ".anet", "nodes", "windows-picker", "windows-appsrv.log");
-        const diagnostics = existsSync(appLog) ? `\n--- app-server log ---\n${readFileSync(appLog, "utf8")}` : "";
-        const rpcDiagnostics = existsSync(rpcLog) ? `\n--- fake rpc log ---\n${readFileSync(rpcLog, "utf8")}` : "";
-        reject(new Error(`PTY failed (${exitCode}): ${args.join(" ")}\n${output}${diagnostics}${rpcDiagnostics}`));
+        // 🔴 #1342 —— 三段诊断原先在文件不存在 / PTY 无输出时**静默降级成空串**,
+        //    于是 CI 上只剩 `PTY failed (1): …` 一行。「有诊断」和「诊断为空」
+        //    在报错文本里长得一模一样,读的人会以为那一行就是全部信息。
+        //    改成显式说明缺席,下一次采样才能分辨「TUI 有输出但没帮助」
+        //    还是「TUI 根本没产出任何东西」—— 两者指向完全不同的根因。
+        const ptyOutput = output ? `\n${output}` : `\n--- PTY 无输出(0 字节) ---`;
+        const diagnostics = existsSync(appLog)
+          ? `\n--- app-server log ---\n${readFileSync(appLog, "utf8")}`
+          : `\n--- app-server log: 不存在 (${appLog}) ---`;
+        const rpcDiagnostics = existsSync(rpcLog)
+          ? `\n--- fake rpc log ---\n${readFileSync(rpcLog, "utf8")}`
+          : `\n--- fake rpc log: 不存在 (${rpcLog}) ---`;
+        reject(new Error(`PTY failed (${exitCode}): ${args.join(" ")}${ptyOutput}${diagnostics}${rpcDiagnostics}`));
       }
       else resolvePromise(output);
     });


### PR DESCRIPTION
## 这条 flake 采了 4 次,每次 CI 上只有一行

```
PTY failed (1): node start windows-picker --no-inherit-codex-home
```

读代码才发现:错误对象**本来要拼三段诊断**,而三段在失败路径上全是空。

```js
output          PTY 无输出        → 空
diagnostics     appLog 不存在      → ""
rpcDiagnostics  rpcLog 不存在      → ""
```

## 🔴 「有诊断」和「诊断为空」在报错文本里长得一模一样

读的人看到那一行会以为**这就是全部信息**,而不会意识到后面本该有三段、只是都没写出来。
这条 flake 之所以查了四次还停在"知道它红、不知道为什么",**根因是诊断链路在失败时不出声**。

## 改法

三处空串换成**显式的缺席说明(含路径)**。下一次采样就能分辨
「TUI 有输出但没帮助」还是「TUI 根本没产出任何东西」——**两者指向完全不同的根因**。

## 🔴 有一处同形态**故意不动**

第 178 行 `const wire = existsSync(rpcLog) ? readFileSync(rpcLog) : "";`
在 `waitUntil` 的**轮询判据**里:文件未出现时返回空串 → 判据不满足 → 继续等,**那是正确行为**。
改成打印缺席说明会在每轮轮询刷屏,而且语义上它本来就允许"暂时还没有"。

**同一个 `existsSync ? : ""` 形态,在两个位置的对错相反 —— 不能按形态一刀切。**

## 验证

`node --check` 通过。这一改**只影响失败路径的报错文本**,不改变任何判定逻辑。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)