### PR TITLE
fix(cli): `anet status` 的未知状态不再被渲染成「空闲、正常」

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -11954,7 +11954,7 @@ async function statusCommand() {
     console.log(`  Tasks:  ${tasks.length} recent\n`);
 
     if (attention.length > 0) {
-      console.log("  Needs attention (blocked / error — not progressing):");
+      console.log("  Needs attention (blocked / error / 未知状态 — not progressing):");
       for (const s of attention) {
         console.log(`    ${String(s.alias).padEnd(16)} ${String(s.status || "").padEnd(8)} ${(s.task || "").slice(0, 48)}`);
       }

--- a/agent-network/src/session-status-class.test.ts
+++ b/agent-network/src/session-status-class.test.ts
@@ -29,10 +29,32 @@ describe("#1548 anet status 不能把「卡住」显示成「在干活」", () =
     expect(got).toEqual(new Set(["idle", "working", "attention", "offline"]));
   });
 
-  // 正控:大小写与未知值不会被静默归错
-  test("大小写不敏感;未知值归 idle 而不是抛错", () => {
+  // 正控:大小写不会被静默归错
+  test("大小写不敏感", () => {
     expect(classifySessionStatus("BLOCKED")).toBe("attention");
     expect(classifySessionStatus("Working")).toBe("working");
-    expect(classifySessionStatus("some-new-state")).toBe("idle");
+  });
+
+  // 🔴 这一组是本文件从前**反向钉死**的那条:原先断言
+  //    `classifySessionStatus("some-new-state")` 是 `"idle"`,注释还写着
+  //    「未知值不会被静默归错」—— 而那一行做的正是静默归错。
+  //    去修兜底的人会看到一条红测试,以为自己弄坏了有意的设计。
+  test("未知状态归 attention —— 兜底不朝好的一侧", () => {
+    expect(classifySessionStatus("some-new-state")).toBe("attention");
+    // 服务端将来可能加的形状,举几个具体的:
+    expect(classifySessionStatus("paused")).toBe("attention");
+    expect(classifySessionStatus("stopped")).toBe("attention");
+    expect(classifySessionStatus("degraded")).toBe("attention");
+  });
+
+  // 🔴 反向见证:把「缺失」和「有值但不认识」分开。
+  //    缺失(没上报过 / null / 空串)不该报警 —— 它是 idle,这一条**没变**。
+  //    如果有人把兜底改回 `return "idle"`,上面那组会红;
+  //    如果有人图省事把整支都改成 attention,这一组会红。两个方向都有见证。
+  test("缺失(空/null/undefined)仍是 idle,不是 attention", () => {
+    expect(classifySessionStatus("")).toBe("idle");
+    expect(classifySessionStatus(null)).toBe("idle");
+    expect(classifySessionStatus(undefined)).toBe("idle");
+    expect(classifySessionStatus("idle")).toBe("idle");
   });
 });

--- a/agent-network/src/session-status-class.ts
+++ b/agent-network/src/session-status-class.ts
@@ -22,5 +22,15 @@ export function classifySessionStatus(raw: unknown): SessionClass {
   // 需要人看一眼的:卡住、出错。**不算 working。**
   if (s === "blocked" || s === "error") return "attention";
   if (["working", "waiting_input", "running", "busy"].includes(s)) return "working";
-  return "idle";
+  if (s === "idle" || s === "") return "idle";
+  // 🔴 兜底不能朝好的一侧。走到这里意味着**服务端说了一个我们不认识的状态** ——
+  //    那是「不知道」,不是「空闲、正常」。而这个分类器和它分类的那个枚举
+  //    (server/src/tools.ts 的 report_status `status: z.enum([...])`)
+  //    分属两个**独立发版**的 npm 包(@sleep2agi/agent-network 与
+  //    @sleep2agi/commhub-server),版本错位是常态:生产 hub 长期停在 .38,
+  //    而包已经发到 .44。服务端加第七个状态、CLI 没跟着升,就会走到这一支 ——
+  //    本仓不会有任何东西红(没有编译错误、没有测试红、没有 lint 警告)。
+  //    归 attention 的含义是「有人看一眼」,恰好是我们此刻唯一诚实的说法。
+  //    ⚠️ 规则是**方向**,不是「记得枚举新值」——后者只在有人记得时生效。
+  return "attention";
 }


### PR DESCRIPTION
fix(cli): `anet status` 的未知状态不再被渲染成「空闲、正常」

`classifySessionStatus` 的兜底是 `return "idle"` —— 走到那一支的含义是
**服务端说了一个我们不认识的状态**,而它被呈现成「空闲、正常」。

这正是本文件头注释写着要防的那件事(「把卡住算成在干活的分类器,
和一个正确的分类器,在输出上长得一模一样」)。#1577 修了已知的两个值
(blocked / error),把兜底留在了好的那一侧。

## 今天够不着 —— 这也正是现在改最便宜的理由

服务端 `report_status` 的 `status` 是**闭合枚举**
(`z.enum(["working","idle","blocked","error","waiting_input","offline"])`),
六个值分类器全都显式处理;另外两个写入方(`report_completion` 写字面 `'idle'`、
stale-sweeper 写字面 `'offline'`)也是闭合的。**所以这一支今天走不到。**

风险不在今天,在**跨包**:分类器发在 `@sleep2agi/agent-network`(2.3.0-preview.75),
枚举发在 `@sleep2agi/commhub-server`(0.9.0-preview.44),两个包独立发版。
而**版本错位是常态不是假设** —— 生产 hub 长期停在 .38。
服务端加第七个状态、CLI 没跟着升,就会落到这一支,**本仓不会有任何东西红**
(没有编译错误、没有测试红、没有 lint 警告)。

## 测试原先把它反向钉死了

```ts
// 正控:大小写与未知值不会被静默归错
expect(classifySessionStatus("some-new-state")).toBe("idle");   // ← 这正是静默归错
```

注释说的和断言做的是反的。去修兜底的人会看到一条红测试,
以为自己弄坏了有意的设计。这一条现在翻过来了。

## 改了什么

- 把「缺失」和「有值但不认识」分开:
  - 缺失(`""` / `null` / `undefined` / `"idle"`)→ `idle`,**没变**(没上报过不该报警);
  - 有值但不在已知集合里 → `attention`(「有人看一眼」,此刻唯一诚实的说法)。
- 规则写成**方向**而不是「记得枚举新值」—— 后者只在有人记得时生效。
- `anet status` 那一格的表头补上「未知状态」,否则文案与它现在会装的东西不符。

## 双向见证(都实跑过)

| 变异 | 结果 |
|---|---|
| 兜底改回 `return "idle"` | `未知状态归 attention` **红**,其余 6 绿 |
| 拿掉缺失分支(整支归 attention) | 3 条红,含新加的「缺失仍是 idle」 |
| 还原 | 7 pass / 0 fail |

## 一条本 PR **没有**修的相邻问题

`cli.ts` 里是 `const summary = statusRes.summary || sessions.reduce(...)` ——
**当服务端返回 summary 时,客户端这个分类器不参与计数**。
所以 idle/working/offline 三个数在那种情况下由服务端决定,不受本 PR 影响
(受影响的是 `attention` 那一格和四个明细列表)。服务端侧的同类问题另开。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
