### PR TITLE
fix(test751): 「日志存在但 0 字节」不再打印成一片空白 (#1342 第二层)

### DIFF
--- a/tests/test751-codex-copresence-windows/windows-e2e.mjs
+++ b/tests/test751-codex-copresence-windows/windows-e2e.mjs
@@ -74,13 +74,23 @@ function terminal(args, onData, timeoutMs = 45_000) {
         //    在报错文本里长得一模一样,读的人会以为那一行就是全部信息。
         //    改成显式说明缺席,下一次采样才能分辨「TUI 有输出但没帮助」
         //    还是「TUI 根本没产出任何东西」—— 两者指向完全不同的根因。
-        const ptyOutput = output ? `\n${output}` : `\n--- PTY 无输出(0 字节) ---`;
-        const diagnostics = existsSync(appLog)
-          ? `\n--- app-server log ---\n${readFileSync(appLog, "utf8")}`
-          : `\n--- app-server log: 不存在 (${appLog}) ---`;
-        const rpcDiagnostics = existsSync(rpcLog)
-          ? `\n--- fake rpc log ---\n${readFileSync(rpcLog, "utf8")}`
-          : `\n--- fake rpc log: 不存在 (${rpcLog}) ---`;
+        // 🔴 #1342 补第二层(2026-08-31,在 #1623 的一次真实失败里当场看到):
+        //    上面只分辨了「文件在不在」。**文件在、但读出来是空串**时,
+        //    这里会打印一个只有表头、下面一片空白的段 ——
+        //    与「我打印了它,它确实没内容」逐字相同。那一次 `app-server log`
+        //    正是 0 字节,而 `fake rpc log` 满的:两段并排,读的人无法判断
+        //    前者是「没写」还是「写了但为空」。而这两件事指向不同的根因
+        //    (app-server 没起来 vs 起来了不落盘)。
+        //    ⚠️ 这是同一个缺陷隔了一层 —— 修 A 分支的人天然不会去看 B 分支。
+        const readLog = (label, path) => {
+          if (!existsSync(path)) return `\n--- ${label}: 不存在 (${path}) ---`;
+          const body = readFileSync(path, "utf8");
+          if (body.length === 0) return `\n--- ${label}: 存在但 0 字节 (${path}) ---`;
+          return `\n--- ${label} (${body.length} 字节) ---\n${body}`;
+        };
+        const ptyOutput = output ? `\n--- PTY 输出 (${output.length} 字节) ---\n${output}` : `\n--- PTY 无输出(0 字节) ---`;
+        const diagnostics = readLog("app-server log", appLog);
+        const rpcDiagnostics = readLog("fake rpc log", rpcLog);
         reject(new Error(`PTY failed (${exitCode}): ${args.join(" ")}${ptyOutput}${diagnostics}${rpcDiagnostics}`));
       }
       else resolvePromise(output);


### PR DESCRIPTION
fix(test751): 「日志存在但 0 字节」不再打印成一片空白 (#1342 第二层)

#1621 修的是「文件在不在」。**文件在、但读出来是空串**那一支没修 ——
它会打印一个只有表头、下面一片空白的段,与「我打印了它,它确实没内容」
逐字相同。

## 不是推演,是在一次真实失败里当场看到的

#1623 的 CI 上 `Windows Codex co-presence native smoke` 失败,
#1621 的诊断如期打了出来(这条本身证明 #1621 生效),而它打出来的是:

```
--- app-server log ---
                          ← 空的
--- fake rpc log ---
invoke:["app-server","-c","approval_policy=on-request",...]
appsrv-home:D:\a\_temp\anet-test751-e2e\...
rpc:initialize
...
```

两段并排:后者满的,前者一片空白。**读的人无法判断 app-server log 是
「没被写」还是「写了但为空」** —— 而这两件事指向不同的根因
(app-server 没起来 vs 起来了不落盘)。

真实失败内容本身现在是可读的,附在这里供 #1342 取样:
`TUI second-client health failed: the launched Codex TUI exited (code=0)
before it connected`,而同一次的 fake rpc log 里有
`rpc:thread/resume` 与 `rpc:thread/read` —— 即 TUI 确实与 fake rpc 交互过。
(本 PR 不认领这个根因,只保证下一次采样能分辨。)

## 改了什么

三段诊断抽成一个 `readLog(label, path)`,产出**三个互不相同**的串:

| 情形 | 输出 |
|---|---|
| 不存在 | `--- app-server log: 不存在 (<path>) ---` |
| 存在但 0 字节 | `--- app-server log: 存在但 0 字节 (<path>) ---` |
| 有内容 | `--- app-server log (N 字节) ---` + 正文 |

PTY 输出同样带上字节数(原先有内容时不带,与「无输出」那支不对称)。

## 见证

```
[不存在]  --- app-server log: 不存在 (missing.log) ---
[0 字节]  --- app-server log: 存在但 0 字节 (empty.log) ---
[有内容]  --- app-server log (5 字节) --- ⏎ hello
三态互不相同: ✅ 3/3
```
`node --check` 通过。

## 一条给读者的提醒

🔴 **这是同一个缺陷隔了一层。** #1621 我修了 A 分支(不存在),
B 分支(存在但空)完全没进视野 —— 修 A 的人天然不会去看 B。
注释里钉了这一点。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
