### PR TITLE
fix(cli): `anet status` 的计数改用本地分类 —— 修双计,并堵掉一个「一执行就 NaN」的兜底 (#1625)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -35,7 +35,7 @@ import {
   type SessionInfo,
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
-import { classifySessionStatus } from "../src/session-status-class";
+import { classifySessionStatus, summarizeSessions } from "../src/session-status-class";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
@@ -11933,11 +11933,14 @@ async function statusCommand() {
     //    是一个**没有出口**的状态(只有 report_completion 能把它拉回 idle),
     //    所以一个 agent 可以永远停在那里而被报成「在干活」。
     const classifyStatus = (s: any) => classifySessionStatus(s?.status);
-    const summary = statusRes.summary || sessions.reduce((acc: any, s: any) => {
-      acc[classifyStatus(s)]++;
-      acc.total++;
-      return acc;
-    }, { idle: 0, working: 0, offline: 0, total: 0 });
+    // 🔴 #1625 —— **不再用 `statusRes.summary`**。`/api/status` 总是返回一个
+    //    summary,于是原先的 `statusRes.summary || …` 让本地分类器从不执行,
+    //    屏幕上的数字来自服务端一份停在 #1548 之前的分类(`blocked`/`error`
+    //    被折进 `working`)。症状:一个 blocked 节点同时出现在 `working` 和
+    //    `needs attention` 两格,四个数加起来比 total 多。
+    //    范围等价性已核:该端点只加 `addNetworkScope`、无状态/别名过滤,
+    //    且服务端的 summary 就是从同一个 sessions 数组算的。
+    const summary = summarizeSessions(sessions);
     const idle = sessions.filter((s: any) => classifyStatus(s) === "idle");
     const working = sessions.filter((s: any) => classifyStatus(s) === "working");
     const attention = sessions.filter((s: any) => classifyStatus(s) === "attention");
@@ -11946,7 +11949,7 @@ async function statusCommand() {
     console.log(`\n  CommHub: ${hub}`);
     // 🔴 attention 单独一格。折进 working 会让「需要人看一眼」消失在一个看起来
     //    正常的数字里 —— 这正是 #1548 那一族问题:两种不同的事渲染成同一个词。
-    const attnCount = summary.attention ?? attention.length;
+    const attnCount = summary.attention;
     console.log(`  Agents: ${summary.idle || 0} idle, ${summary.working || 0} working`
       + (attnCount > 0 ? `, ${attnCount} needs attention` : "")
       + `, ${summary.offline || 0} offline`);

--- a/agent-network/src/session-status-class.test.ts
+++ b/agent-network/src/session-status-class.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { classifySessionStatus } from "./session-status-class";
+import { classifySessionStatus, summarizeSessions } from "./session-status-class";
 
 describe("#1548 anet status 不能把「卡住」显示成「在干活」", () => {
   // 🔴 这一条是本次修的那个 bug 的红夹具:改之前 blocked/error 返回 "working"
@@ -56,5 +56,47 @@ describe("#1548 anet status 不能把「卡住」显示成「在干活」", () =
     expect(classifySessionStatus(null)).toBe("idle");
     expect(classifySessionStatus(undefined)).toBe("idle");
     expect(classifySessionStatus("idle")).toBe("idle");
+  });
+});
+
+describe("#1625 summarizeSessions —— 屏幕上那几个数字", () => {
+  // 🔴 正控用**当前生产军团的真实构成**(2026-08-31 实测:271 个会话,
+  //    127 idle / 143 offline / 1 blocked)。服务端那份分类会把这 1 个 blocked
+  //    算进 working,于是它同时出现在 working 和 needs attention 两格。
+  const fleet = [
+    ...Array.from({ length: 127 }, () => ({ status: "idle" })),
+    ...Array.from({ length: 143 }, () => ({ status: "offline" })),
+    { status: "blocked" },
+  ];
+
+  test("blocked 只进 attention,不进 working", () => {
+    const s = summarizeSessions(fleet);
+    expect(s.working).toBe(0);
+    expect(s.attention).toBe(1);
+  });
+
+  test("🔴 四个数加起来 == total(原先是 272 > 271)", () => {
+    const s = summarizeSessions(fleet);
+    expect(s.idle + s.working + s.attention + s.offline).toBe(s.total);
+    expect(s.total).toBe(271);
+  });
+
+  // 🔴 这一条钉的是那个「从不执行、一执行就 NaN」的老兜底:
+  //    累加器原先只有 {idle, working, offline, total},`acc["attention"]++`
+  //    得到 NaN,而 `?? ` 不接 NaN ⇒ 屏幕印 `NaN needs attention`。
+  test("attention 是数字,不是 NaN(累加器必须显式初始化它)", () => {
+    const s = summarizeSessions([{ status: "blocked" }, { status: "error" }]);
+    expect(Number.isNaN(s.attention)).toBe(false);
+    expect(s.attention).toBe(2);
+  });
+
+  test("空输入给出全 0,不是 NaN 也不是空对象", () => {
+    expect(summarizeSessions([])).toEqual({ idle: 0, working: 0, attention: 0, offline: 0, total: 0 });
+  });
+
+  test("未知状态进 attention(与 classifySessionStatus 同一套判据)", () => {
+    const s = summarizeSessions([{ status: "some-new-state" }, { status: "" }]);
+    expect(s.attention).toBe(1);
+    expect(s.idle).toBe(1);
   });
 });

--- a/agent-network/src/session-status-class.ts
+++ b/agent-network/src/session-status-class.ts
@@ -34,3 +34,34 @@ export function classifySessionStatus(raw: unknown): SessionClass {
   //    ⚠️ 规则是**方向**,不是「记得枚举新值」——后者只在有人记得时生效。
   return "attention";
 }
+
+/**
+ * `anet status` 顶部那三/四个数字。
+ *
+ * 🔴 为什么它必须和上面的分类器用同一套判据(#1625):
+ *    原先 `cli.ts` 是 `statusRes.summary || sessions.reduce(…)`,而
+ *    `/api/status` **总是**返回 summary ⇒ 右边那支从不执行,屏幕上的数字
+ *    来自**服务端**一份还停在 #1548 之前的分类(它把 `blocked`/`error`
+ *    折进 `working`)。于是一个 blocked 节点同时出现在 `working` 和
+ *    `needs attention` 两格里,四个数加起来比总数多一个。
+ *
+ * 🔴 为什么本地算是安全的:`/api/status` 只加 `addNetworkScope`,没有任何
+ *    状态/别名过滤,而它的 summary 就是从**同一个 sessions 数组** reduce 出来的
+ *    —— 两者范围逐字相同。(这一点对 MCP 的 `get_all_status` **不成立**:
+ *    那边 summary 走独立的 `GROUP BY status` 查询、无视 filter,所以别照搬。)
+ *
+ * 🔴 `attention` 必须显式初始化为 0。原来的累加器只有
+ *    `{idle, working, offline, total}`,`acc["attention"]++` 会得到 **NaN**,
+ *    而 `summary.attention ?? attention.length` 里的 `??` **不接 NaN**,
+ *    屏幕会印 `NaN needs attention`。那一支从不执行,所以从没人见过。
+ */
+export type SessionSummary = { idle: number; working: number; attention: number; offline: number; total: number };
+
+export function summarizeSessions(sessions: Array<{ status?: unknown }>): SessionSummary {
+  const acc: SessionSummary = { idle: 0, working: 0, attention: 0, offline: 0, total: 0 };
+  for (const s of sessions) {
+    acc[classifySessionStatus(s?.status)]++;
+    acc.total++;
+  }
+  return acc;
+}


### PR DESCRIPTION
fix(cli): `anet status` 的计数改用本地分类 —— 修双计,并堵掉一个「一执行就 NaN」的兜底 (#1625)

## 症状(可复算)

拿当前生产军团的真实构成(271 会话:127 idle / 143 offline / 1 blocked):

```
修前: Agents: 127 idle, 1 working, 1 needs attention, 143 offline
                        ↑ 同一个 blocked 节点在这两格里各数了一次
      127+1+1+143 = 272 > 271
修后: Agents: 127 idle, 0 working, 1 needs attention, 143 offline   = 271
```

## 机制

`cli.ts` 原先是 `const summary = statusRes.summary || sessions.reduce(…)`,
而 `/api/status` **总是**返回 summary ⇒ **右边那支从不执行**,屏幕上的数字
全部来自服务端 `server.ts:1693` 一份停在 #1548 之前的分类:

```js
else if (["working","blocked","error","waiting_input","running","busy"].includes(raw)) acc.working++;
```

`blocked`/`error` 被折进 `working` —— 正是 #1548/#1577 认定为错的那件事。
而 `attnCount = summary.attention ?? attention.length` 里的 `??` 会落到
客户端算的 `attention.length`,于是同一个节点被数两次。

⇒ **#1577 那个修好的分类器,对屏幕上的数字一直没起作用。**

## 为什么本地算是安全的(核过,不是假设)

`/api/status`(`server.ts:1628`)只加 `addNetworkScope`,**没有任何状态/别名过滤**,
而它的 summary 就是从**同一个 sessions 数组** reduce 出来的 —— 两者范围逐字相同。

🔴 这一点对 MCP 的 `get_all_status` **不成立**:那边 summary 走独立的
`GROUP BY status` 查询、无视 filter(`tools.ts:1348` 的注释明说了)。**别照搬。**
本 PR 只动 `/api/status` 这一个调用点。

## 🔴 顺带堵掉一个从没人见过的缺陷

那个「从不执行」的老兜底自己是坏的:

```js
}, { idle: 0, working: 0, offline: 0, total: 0 });   // 没有 attention 键
   acc["attention"]++                                 // → NaN
   summary.attention ?? attention.length              // ?? 不接 NaN
   // 屏幕: "0 idle, 0 working, NaN needs attention"
```

**任何人按 #1625 的建议去掉 `statusRes.summary ||`,会当场发出 `NaN needs attention`。**
本 PR 把累加器抽成 `summarizeSessions()` 并显式初始化 `attention: 0`。

## 双向见证(都实跑)

| 变异 | 结果 |
|---|---|
| `attention` 不初始化(还原成老兜底的形状) | **5 红** / 7 绿 |
| `blocked` 折回 `working`(还原成服务端那份分类) | **5 红** / 7 绿 |
| 还原 | **12 pass / 0 fail** |

## 没做的

- **没有改服务端** `server.ts:1693`。它仍然把 `blocked`/`error` 算进 `working`,
  dashboard 也读那个字段 —— 那一半留在 #1625 里,改它要先看现有消费者。
- 没有跑真实 hub 验证屏幕输出(不碰生产);正控用的是真实军团构成的**夹具**。

Closes #1625 的客户端一半(服务端一半留在 issue 里)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
