### PR TITLE
docs(cli): 说明 `anet status` 那四个数字各是什么意思(中英同步)

### DIFF
--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -194,6 +194,35 @@ Channel settings are not hot-reloaded; restart the node after changing them. `an
 
 See the [Upgrade guide](/en/guide/upgrade) for upgrade details.
 
+### Reading the four numbers in `anet status`
+
+```
+  CommHub: http://127.0.0.1:9200
+  Agents: 127 idle, 0 working, 1 needs attention, 143 offline
+  SSE:    12 connected
+  Tasks:  10 recent
+```
+
+| Number | Meaning |
+|---|---|
+| `idle` | Free, waiting for work |
+| `working` | **Actively progressing** a turn (includes `waiting_input` — the turn is alive, just waiting on a human) |
+| `needs attention` | **Someone should look**: `blocked` / `error`, plus any status this version does not recognise |
+| `offline` | Heartbeat expired, or stopped cleanly |
+
+The four add up to the node total. The `needs attention` slot is hidden when it is 0.
+
+🔴 **`blocked` / `error` are not counted as `working`.** They mean "stuck", not
+"making progress" — folding them into `working` would let an operator read
+"N working" as "all fine". When `needs attention` is above 0, the nodes behind it
+are listed with their self-reported status and the task they were on.
+
+⚠️ **These statuses are self-reported and carry no liveness proof.** A node whose
+process died but has not yet been swept can still show as `idle` here. To confirm
+it is still there, **send it a task** — `anet status` answers "what it last said
+about itself", not "whether it is still running".
+
+
 ## Preview-only features
 
 The following commands exist in the current preview and must not be presented as stable features:

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -194,6 +194,34 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 
 升级细节见 [升级指南](/guide/upgrade)。
 
+### `anet status` 的四个数字怎么读
+
+```
+  CommHub: http://127.0.0.1:9200
+  Agents: 127 idle, 0 working, 1 needs attention, 143 offline
+  SSE:    12 connected
+  Tasks:  10 recent
+```
+
+| 数字 | 含义 |
+|---|---|
+| `idle` | 空闲,等派活 |
+| `working` | **正在推进**一个回合(含 `waiting_input` —— 回合还在,只是在等人) |
+| `needs attention` | **需要人看一眼**:`blocked` / `error`,以及任何本版本不认识的状态 |
+| `offline` | 心跳过期,或已正常停止 |
+
+四个数相加等于节点总数。`needs attention` 为 0 时那一格不显示。
+
+🔴 **`blocked` / `error` 不算在 `working` 里。** 它们的含义是「卡住了」而不是
+「在干活」—— 一个卡住的节点如果被算进 `working`,运维看到「N working」会以为
+一切正常。`needs attention` 大于 0 时,下面会列出是哪几个节点、它们自报的状态、
+以及当时的任务。
+
+⚠️ **这些状态是 agent 自报的,不含活性成分。** 一个进程已经死掉但还没被心跳
+清扫的节点,在这里仍可能显示成 `idle`。要确认它还在不在,**发一条任务试试** ——
+`anet status` 回答的是「它上次说自己怎么样」,不是「它现在还在不在」。
+
+
 ## Preview 专属能力
 
 以下能力存在于当前 preview，不应写成 stable 已支持：


### PR DESCRIPTION
docs(cli): 说明 `anet status` 那四个数字各是什么意思(中英同步)

## 为什么现在写

`docs-site/docs/guide/cli.md` 里 `anet status` 只有一行表格
(「显示当前 Network 的节点和任务概览」),**没有任何地方解释屏幕上那四个数字**。
而 #1548/#1577 之后多了一格 `needs attention`,用户看到它没有任何依据。

🔴 **顺序是有意的**:直到 #1626(`8ae8ee27`)合入之前,那四个数**加起来比总数多**
(一个 `blocked` 节点同时被算进 `working` 和 `needs attention`,见 #1625)。
先写文档等于把一个 bug 写进文档,所以等修复落地才写。

## 写了什么

一张表(idle / working / needs attention / offline 各是什么),加两条:

- **`blocked` / `error` 不算在 `working` 里** —— 这是 #1548 的结论,
  也是这一格存在的全部理由;
- ⚠️ **这些状态是 agent 自报的,不含活性成分** —— 进程死了但还没被心跳清扫的
  节点仍会显示成 `idle`;要确认它还在不在,**发一条任务试试**。
  (这句话在 CLI 的输出里已经有了:`(状态由 agent 自报,不含活性成分;…)`,
  文档里也得有 —— 只在终端里说一次,读文档的人看不到。)

内容按 `origin/main` 的实际输出代码写(`bin/cli.ts` 的 `statusCommand`),
不是凭记忆:示例里的 `127 / 0 / 1 / 143` 就是当前生产军团的真实构成。

## 本地跑过的门(提交前,不是提交后)

```
check-doc-symbol-pins.py .                     rc=0  漂移 0
check-doc-symbol-pins.py . --doc-root docs-site rc=0  漂移 0
check-docs-integrity.py                        rc=0  no problems.
check-release-channel-assertions.py            rc=0
check-doc-symbol-anchors.py                    rc=0  every symbol anchor exists
check-no-memory-slugs.py .                     rc=0
```

## ⚠️ 这次改动**不会**自动出现在 anet.sh

`deploy-anet-sh.yml` 在 `VERCEL_TOKEN` 未配置时**静默跳过**(`skip=true`,
而且仍然报 success)——见 #1619。所以合并后 anet.sh 上不会有这段,
除非有人手工部署或补上那个 secret。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
