### PR TITLE
fix(hub): 「这个节点根本没有 daemon」不再被说成「请显式传 daemon_node_id」(app#196)

### DIFF
--- a/server/src/node-id-alias.test.ts
+++ b/server/src/node-id-alias.test.ts
@@ -145,3 +145,44 @@ describe("#1281 real handler path — stop_node routes both names to the same pl
     expect(r.error).toBe("node_id_conflict");
   });
 });
+
+describe("app#196 —— 「解析不到 daemon」的两种情况必须给不同的话", () => {
+  // 🔴 生产实测(2026-08-28):218 个节点里 207 个是 `n_…`(有人直接
+  //    `anet node start` 起的),它们**根本没有 daemon**。原先这两种情况
+  //    打印同一句 `pass daemon_node_id explicitly` —— 对那 207 个来说,
+  //    **这句建议的前提是假的**,照着做只会走进死路。
+  const HAND_STARTED = "n_73687f17";      // 手工起的节点,真实形状
+  const DAEMON_CHILD = "node_test_1281";  // daemon 建的子节点
+
+  test("手工起的节点 → not_daemon_managed,并且**不**建议传 daemon_node_id", async () => {
+    const r = await call("stop_node", { node_id: HAND_STARTED });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("not_daemon_managed");
+    // 🔴 这一条是本组的核心:旧文案的那句建议**不能**再出现在这条路径上。
+    expect(r.message).not.toContain("pass daemon_node_id explicitly");
+    // 而且要告诉他真正能走的那条路。
+    expect(r.message).toContain("anet node stop");
+  });
+
+  test("daemon 建的子节点(无 create-request 行) → 仍是 daemon_not_resolvable", async () => {
+    const r = await call("stop_node", { node_id: DAEMON_CHILD });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_not_resolvable");
+    expect(r.message).toContain("pass daemon_node_id explicitly");
+  });
+
+  test("delete_node 走同一条判别(两个调用点不能只改一个)", async () => {
+    const r = await call("delete_node", { node_id: HAND_STARTED, confirm_alias: "x" });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("not_daemon_managed");
+  });
+
+  // 🔴 反向见证:两种情况必须**真的不同**。若有人把判别改成恒定一支,
+  //    上面三条里至少一条会红 —— 但那还不够明显,所以这里直接断言两者不等。
+  test("两种情况的 error 与 message 都不相同", async () => {
+    const a = await call("stop_node", { node_id: HAND_STARTED });
+    const b = await call("stop_node", { node_id: DAEMON_CHILD });
+    expect(a.error).not.toBe(b.error);
+    expect(a.message).not.toBe(b.message);
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3793,6 +3793,38 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     return row?.daemon_node_id ?? null;
   };
 
+  /**
+   * 为什么这里要分两种「解析不到 daemon」(#196 / app 仓)。
+   *
+   * `resolveDaemonForChild` 对两件完全不同的事都返回 `null`:
+   *   ① id 不以 `node_` 开头 —— 这个节点**根本不是 daemon 创建的**,
+   *      是有人在某台机器上直接 `anet node start` 起来的。hub 上没有任何
+   *      daemon 可以代它执行停止,**这条路径对它在概念上就不成立**。
+   *   ② id 以 `node_` 开头,但 `node_create_requests` 里查不到那一行 ——
+   *      它可能确实是 daemon 建的,只是记录缺失,这时「显式传 daemon_node_id」
+   *      是一条真的走得通的路。
+   *
+   * 🔴 原先两种情况打印同一句 `pass daemon_node_id explicitly`。对 ① 来说
+   *    **这句建议的前提是假的** —— 没有 daemon 可传,用户按它做只会走进死路。
+   *    2026-08-28 对生产 hub 实测:218 个节点里 **207 个**是 ① 这种。
+   *
+   * 信息在源头就存在(那个 `startsWith("node_")` 判断),只是被丢在了返回值里。
+   */
+  const explainUnresolvableDaemon = (child_node_id: string) =>
+    child_node_id.startsWith("node_")
+      ? {
+          ok: false, error: "daemon_not_resolvable",
+          message: "no node_create_requests row found for this child_node_id; pass daemon_node_id explicitly",
+        }
+      : {
+          ok: false, error: "not_daemon_managed",
+          message:
+            `node ${child_node_id} was not created by a daemon (it was started by hand with ` +
+            `\`anet node start\` on some machine), so no daemon on the Hub can stop it. ` +
+            `Run \`anet node stop <alias>\` on that machine instead. ` +
+            `Daemon-created children have ids beginning with \`node_\`; this one does not.`,
+        };
+
   const dispatchStopOrDelete = (args: DispatchArgs, clientNetId?: string | null) => {
     // §4.1 — SEC-1 trust-root join: resolve target node row WITHIN the
     // caller's scope. resolveReadScope returns 'denied' if the caller
@@ -4082,10 +4114,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const child_node_id = idArg.node_id;
       const resolved = daemon_node_id ?? resolveDaemonForChild(child_node_id);
       if (!resolved) {
-        return { content: [{ type: "text" as const, text: JSON.stringify({
-          ok: false, error: "daemon_not_resolvable",
-          message: "no node_create_requests row found for this child_node_id; pass daemon_node_id explicitly",
-        }) }] };
+        return { content: [{ type: "text" as const,
+          text: JSON.stringify(explainUnresolvableDaemon(child_node_id)) }] };
       }
       const r = dispatchStopOrDelete(
         { action: "stop", child_node_id, daemon_node_id: resolved, force: force ?? false,
@@ -4114,10 +4144,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const child_node_id = idArg.node_id;
       const resolved = daemon_node_id ?? resolveDaemonForChild(child_node_id);
       if (!resolved) {
-        return { content: [{ type: "text" as const, text: JSON.stringify({
-          ok: false, error: "daemon_not_resolvable",
-          message: "no node_create_requests row found for this child_node_id; pass daemon_node_id explicitly",
-        }) }] };
+        return { content: [{ type: "text" as const,
+          text: JSON.stringify(explainUnresolvableDaemon(child_node_id)) }] };
       }
       const r = dispatchStopOrDelete(
         { action: "delete", child_node_id, daemon_node_id: resolved, force: force ?? false,


### PR DESCRIPTION
fix(hub): 「这个节点根本没有 daemon」不再被说成「请显式传 daemon_node_id」(app#196)

## 用户看到什么

在客户端点「停止节点」,对 **218 个节点里的 207 个**(生产 hub 2026-08-28 实测)
会拿到:

```json
{"ok": false, "error": "daemon_not_resolvable",
 "message": "no node_create_requests row found for this child_node_id; pass daemon_node_id explicitly"}
```

🔴 **这句建议的前提是假的。** 那 207 个是 `n_…` —— 有人在某台机器上直接
`anet node start` 起来的,**hub 上根本没有 daemon 可传**。用户照着做只会走进死路。

(app#196 记录的是更早的形态:那时 schema 上还有 `regex(/^node_[a-z0-9_-]+$/)`,
用户看到的是一段 zod 正则。`953f6ea6`(#1444)拿掉了那个正则 —— 于是失败
**从门口移到了里面**,而 app#196 当时正好预言过这一点:
「放宽正则不解决问题,只会把失败推到更深处」。本 PR 修的是推到更深处之后的那一句。)

## 信息在源头就存在,只是被丢在返回值里

```ts
const resolveDaemonForChild = (child_node_id: string): string | null => {
  if (!child_node_id.startsWith("node_")) return null;   // ← ① 根本不是 daemon 建的
  const row = db.get(…);
  return row?.daemon_node_id ?? null;                    // ← ② 是 daemon 建的,但记录缺失
};
```

两件**含义完全不同、该做的事也完全相反**的事返回同一个 `null`,于是打印同一句话。

## 改了什么

加一个 `explainUnresolvableDaemon(child_node_id)`,两个调用点(stop_node / delete_node)共用:

| 情况 | error | message |
|---|---|---|
| ① id 不以 `node_` 开头 | `not_daemon_managed` | 说明它是手工起的、hub 上没有 daemon 能停它,**并给出真正能走的那条路**:到那台机器上 `anet node stop <alias>` |
| ② `node_` 开头但无 create-request 行 | `daemon_not_resolvable`(**不变**) | 原文案不变 —— 对这一种,「显式传 daemon_node_id」是真的走得通 |

**行为没变**:两种情况仍然都失败,只是失败时说的话不同。

## 兼容性(核过,不是假设)

钉着 `daemon_not_resolvable` 的两处都只用 `node_` 前缀的 id,不受影响:

- `server/src/node-id-alias.test.ts` 用 `VALID_ID = "node_test_1281"`;
- `tests/qa-rfc027-stop-delete/run.sh` 的 L2 用真实 daemon 子节点 `CHILD_L1_NODE_ID`。

## 双向见证(实跑)

| 变异 | 结果 |
|---|---|
| 判别恒走 `daemon_not_resolvable`(等于退回修复) | **3 红** / 25 绿 |
| **只改 stop_node、漏掉 delete_node** | **1 红** —— 正是那条「两个调用点不能只改一个」 |
| 还原 | **28 pass / 0 fail** |

新增 4 条测试,其中一条是反向见证:断言两种情况的 `error` 与 `message` **都不相同**。

## 提交前跑过的门

```
check-doc-symbol-pins.py .                      rc=0
check-doc-symbol-pins.py . --doc-root docs-site  rc=0
check-doc-source-pins.py .                       rc=0
check-docs-integrity.py                          rc=0
check-doc-symbol-anchors.py                      rc=0
```

(⚠ 跑测试时先撞上仓库自己的守卫:`REFUSING to open the default SQLite database
under NODE_ENV=test` —— 它是对的,照它说的加 `COMMHUB_DB=/tmp/…` 即可。)

## 这没有修 app#196 的全部

app#196 的正解是**按钮不该对这 207 个节点可点**(后端给一个明确的
`lifecycle_controllable`,前端置灰 + 一句人话),那要动 app 仓。
本 PR 只保证**万一点了,拿到的话是真的、并且指向一条走得通的路**。

相关:sleep2agi/agent-network-app#196

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
