### PR TITLE
fix(test): 两条造 2000+ 行的测试从 20_000 提到 60_000 —— 历史基线 4196/7809ms,今天实测 21018/20832ms (#1627)

### DIFF
--- a/agent-node/src/runtime/commhub-poll-compensator.test.ts
+++ b/agent-node/src/runtime/commhub-poll-compensator.test.ts
@@ -184,7 +184,7 @@ describe("CommHub durable poll compensation", () => {
       outbound_terminal_watermark: 2_001,
       outbound_deliveries: [],
     });
-  }, 20_000);
+  }, 60_000);  // #1627 —— 原 20_000。历史基线 7809/8481ms;2026-08-31 实测 20832ms(2.7×),撞上限。
 
   test("terminal sequence handles out-of-order completion independent of task creation order", async () => {
     const h = harness();

--- a/server/src/task-consumption.test.ts
+++ b/server/src/task-consumption.test.ts
@@ -166,7 +166,7 @@ describe("task consumed_at identity and lifecycle", () => {
       after_terminal_seq: after, limit: 100,
     });
     expect(late.tasks.map((task: any) => task.task_id)).toEqual(["old-open-task"]);
-  }, 20_000);
+  }, 60_000);  // #1627 —— 原 20_000。历史基线 4196ms;2026-08-31 实测 21018ms(5.0×),撞上限。
   test("enqueue and process-level ack keep consumed_at null", async () => {
     const content = "connected process has not started a model turn";
     const before = db.get<{ last_seen_at: string; task: string | null }>(


### PR DESCRIPTION
fix(test): 两条造 2000+ 行的测试从 20_000 提到 60_000 —— 它们已经贴着上限了 (#1627)

## 不是「加超时」,是「一个当年合理的值现在不够了」

两条测试**本来就有**显式 per-test timeout,都是 `20_000`。今天它们撞上限:

| 测试 | 历史基线(docs/tests/ 里的记录) | 2026-08-31 实测 | 倍数 |
|---|---|---|---|
| `commhub-poll-compensator` → `monotonic terminal watermark garbage-collects more than 2000 delivered rows` | **7809ms / 8481ms** | **20832ms** | **2.7×** |
| `task-consumption` → `terminal sequence paginates beyond 2000 and admits late completion` | **4196ms** | **21018ms** | **5.0×** |

`20_000` 在基线是 7809ms 时有 2.6× 余量 —— 当时是合理的。
今天 runner 慢下来之后,余量归零。

## 为什么这两条特别脆

它们**真的在造 2000+ 行**。`task-consumption` 那条是循环里 **2001 次单条
`db.run` INSERT** 再翻 30 页;`poll-compensator` 那条 GC 2000+ 行。
这类测试的耗时几乎线性跟随 runner 速度,**没有任何缓冲**。

## 为什么选 60_000

- 对齐**本仓既有量级**:per-test timeout 在本仓广泛使用
  (`8_000` 24 处 / `20_000` 22 处 / `15_000` 15 处 / `30_000` 9 处),
  而 **`60_000` 已经存在一处** —— 这不是新引入一个数量级。
- 相对基线:60_000 ≈ 7.7× (7809ms) / 14× (4196ms),能吃下今天观测到的 2.7–5.0× 方差。
- **不动全局默认**。bun 的 20s 默认对其余几百条测试仍然有效 ——
  把默认调大会让真正的挂死也等更久,那是 #1627 明确不建议的。

## 今天这一类的第四次

同一形状今天已经出现四次(#1622 / #1624 / #1626 / #1630),
其中 **#1630 是一个只改了两个 `.md` 文件的纯文档 PR**。
详见 #1627。

## 验证

```
bun test server/src/task-consumption.test.ts                        16 pass / 0 fail
bun test agent-node/src/runtime/commhub-poll-compensator.test.ts    18 pass / 0 fail
```

(⚠ 中途撞了两个与本改动无关的东西,记下免得下一个人误判:
 ① `REFUSING to open the default SQLite database under NODE_ENV=test` ——
    仓库自己的守卫,照它说的加 `COMMHUB_DB=/tmp/…`;
 ② `Cannot find module '@modelcontextprotocol/sdk/...'` —— worktree 里没链 node_modules。
 **两个都不是「我的改动坏了」。**)

## 🔴 我在写这个 PR 的过程中量错过两次,记在这里

1. 先用 `}, [0-9]{4,});` 找 per-test timeout,得出「全仓 0 个」——
   **正则匹配不到带下划线的 `20_000`**。差点把「这是新引入的写法」写进正文。
2. 再之前用 `}, NNNN);` 的松形态,命中的全是 `waitFor(…, 5000)` 和
   `spawnSync(…, {timeout: 20_000})` —— **函数参数,不是 per-test timeout**。

**这两条测试自己就带着 `}, 20_000);`** —— 如果我按第一次的结论去写,
整个 PR 的立论(「引入新写法」)都是错的。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
