### PR TITLE
perf(#1342): Windows 归属探测的整张进程表只枚举一次 —— 实测单次调用占 waited 的 96%

### DIFF
--- a/agent-network/src/windows-codex-copresence.test.ts
+++ b/agent-network/src/windows-codex-copresence.test.ts
@@ -104,3 +104,41 @@ describe.skipIf(process.platform !== "win32")("Windows native process/ACL smoke"
     expect(output.stdout.toString()).not.toContain("(I)");
   });
 });
+
+describe("#1342 —— 整张进程表只枚举一次", () => {
+  // 🔴 为什么值得一条测试:这是一次**性能**改动,而性能回归不会让任何断言变红。
+  //    把 `Get-CimInstance Win32_Process` 挪回 `do{…}while` 里面,
+  //    功能完全正确、所有现有测试照样绿 —— 只是每次探测又变回 ~10 秒。
+  //    实测那 10 秒占了 `waited` 的 96%(#1628 的 probeMs 量到的)。
+  const script = (() => {
+    let captured = "";
+    probeWindowsOwnedLoopbackConnection(303, "638000000000000000", 24700, (s) => {
+      captured = s; return "true\n";
+    });
+    return captured;
+  })();
+
+  test("枚举被提到闭包循环之外", () => {
+    expect(script).toContain("$procs=Get-CimInstance Win32_Process");
+  });
+
+  test("🔴 do{…}while 的**循环体里**不再有 Get-CimInstance", () => {
+    const doStart = script.indexOf("do{");
+    const whileEnd = script.indexOf("while($n-gt 0)");
+    expect(doStart).toBeGreaterThan(-1);
+    expect(whileEnd).toBeGreaterThan(doStart);
+    expect(script.slice(doStart, whileEnd)).not.toContain("Get-CimInstance");
+  });
+
+  test("整个脚本里 Get-CimInstance 恰好出现一次", () => {
+    expect(script.split("Get-CimInstance").length - 1).toBe(1);
+  });
+
+  // 反向见证:归属判定的三段仍在(提取不能把它们弄丢)
+  test("birth 前后校验与 NetTCPConnection 归属都还在", () => {
+    expect(script).toContain("$before-ne$birth");
+    expect(script).toContain("$after-eq$birth");
+    expect(script).toContain("Get-NetTCPConnection");
+    expect(script).toContain("$ids.Contains([int]$_.OwningProcess)");
+  });
+});

--- a/agent-network/src/windows-codex-copresence.ts
+++ b/agent-network/src/windows-codex-copresence.ts
@@ -77,7 +77,24 @@ export function probeWindowsOwnedLoopbackConnection(
       `$before=try{[Diagnostics.Process]::GetProcessById(${rootPid}).StartTime.ToUniversalTime().Ticks.ToString()}catch{''}`,
       "if($before-ne$birth){'false';exit 0}",
       `$ids=[Collections.Generic.HashSet[int]]::new();[void]$ids.Add(${rootPid})`,
-      "do{$n=0;Get-CimInstance Win32_Process|%{if($ids.Contains([int]$_.ParentProcessId)-and $ids.Add([int]$_.ProcessId)){$n++}}}while($n-gt 0)",
+      // 🔴 #1342 —— 整张进程表**只枚举一次**,提到闭包循环之外。
+      //
+      //    原先 `Get-CimInstance Win32_Process` 写在 `do{…}while` **里面**,
+      //    于是每一轮都重新枚举一次整张进程表(至少 2 轮:一轮找到子孙、
+      //    一轮确认不再增长)。这是这次探测的主要成本。
+      //
+      //    实测(2026-08-31,main @ 82820594 的一次真实失败,由 #1628 加的
+      //    `probeMs` 量到):**单次探测 9963ms,占 `waited=10363ms` 的 96%**,
+      //    而那一跑的 job 本身只用了 106 秒 —— **不是机器慢,是这次调用本来就慢**。
+      //    按 ~10 秒/次,`TUI_HEALTH_MS = 25_000` 实际只够 2 次多一点的探测,
+      //    而调用方按 400ms 间隔写的循环期望的是几十次。
+      //
+      //    ⚠️ 语义上有一处**有意的**改变:原先每轮重读进程表,因此循环期间
+      //    **新产生**的子孙会被看见;现在用的是一份快照。对这个用途这是更好的
+      //    性质 —— 它是一次**归属判定**,一份一致的快照比跨轮拼接的视图更难被
+      //    时序戏弄(root 的身份本来就由前后两次 birth 校验夹住)。
+      "$procs=Get-CimInstance Win32_Process|Select-Object ProcessId,ParentProcessId",
+      "do{$n=0;$procs|%{if($ids.Contains([int]$_.ParentProcessId)-and $ids.Add([int]$_.ProcessId)){$n++}}}while($n-gt 0)",
       `$hit=Get-NetTCPConnection -State Established -RemoteAddress 127.0.0.1 -RemotePort ${port} -ErrorAction SilentlyContinue|?{$ids.Contains([int]$_.OwningProcess)}`,
       `$after=try{[Diagnostics.Process]::GetProcessById(${rootPid}).StartTime.ToUniversalTime().Ticks.ToString()}catch{''}`,
       "if($hit-and$after-eq$birth){'true'}else{'false'}",


### PR DESCRIPTION
perf(#1342): Windows 归属探测的整张进程表只枚举一次 —— 实测单次调用占 waited 的 96%

## 这不是猜的:#1628 的 probeMs 昨天上线,今天就量到了

main(`82820594`)上的一次真实失败:

```
TUI second-client health failed: the launched Codex TUI exited (code=0) before it connected
[pid=4900 birth=… port=24700 probes=1 waited=10363ms probeMsLast=9963 probeMsMax=9963]
```

**单次 `probeWindowsOwnedLoopbackConnection` 花了 9963ms,占 `waited=10363ms` 的 96%。**

而那一跑的 job 本身只用了 **106 秒** —— **不是机器慢,是这次调用本来就慢。**
(这条同时**证伪了我自己此前的假说**:我曾把它归到 #1627 的「runner 慢 1.8–5.0 倍」。
 数据不支持 —— job 不慢,探测照样 ~10 秒。)

## 成本在哪

```powershell
do{ $n=0; Get-CimInstance Win32_Process | %{…} } while($n -gt 0)
       ↑ 每一轮都重新枚举**整张进程表**
```

闭包循环至少跑 2 轮(一轮找到子孙、一轮确认不再增长),所以整张进程表
**至少被枚举两次**,常常三次。

## 改了什么

```diff
+      "$procs=Get-CimInstance Win32_Process|Select-Object ProcessId,ParentProcessId",
-      "do{$n=0;Get-CimInstance Win32_Process|%{…}}while($n-gt 0)",
+      "do{$n=0;$procs|%{…}}while($n-gt 0)",
```

枚举提到循环外,并只取需要的两个字段。**归属判定的逻辑一个字没动。**

## ⚠️ 一处**有意的**语义改变

原先每轮重读进程表,因此循环期间**新产生**的子孙会被看见;现在用一份快照。

对这个用途这是**更好的**性质 —— 它是一次**归属判定**,
一份一致的快照比跨轮拼接的视图更难被时序戏弄
(root 的身份本来就由前后两次 birth 校验夹住:`$before-ne$birth` / `$after-eq$birth`)。

**我把它写出来而不是藏在 diff 里**,因为它确实是行为改变,不是纯优化。

## 预算的真实含义(顺带算出来的)

按 ~10 秒/次,`TUI_HEALTH_MS = 25_000` 实际只够 **2 次多一点**的探测,
而调用方按 400ms 间隔写的循环期望的是**几十次**。
**这个预算从写下那天起就没有兑现过。** 本 PR 让它接近兑现,但不改那个常量。

## 见证(4 条新测试 + 变异)

🔴 **为什么性能改动也要钉测试**:把枚举挪回循环里,**功能完全正确、
所有现有测试照样绿** —— 只是每次探测又变回 ~10 秒。性能回归不会让任何断言变红。

| 变异 | 结果 |
|---|---|
| 把 `Get-CimInstance` 挪回 `do{…}while` 里面 | **2 红**(「提到循环之外」+「循环体里不再有」) |
| 还原 | **8 pass / 0 fail**(另 3 个 skip 是 `describe.skipIf(platform !== "win32")` 的 Windows 原生 smoke) |

新增断言还包括「整个脚本里 `Get-CimInstance` 恰好出现一次」
和一条反向见证「birth 前后校验与 `Get-NetTCPConnection` 归属都还在」——
后者防的是「提取时把归属判定弄丢了」。

## 没有钉字节的东西被打断

- `test1220` 变异的是 `if($hit-and$after-eq$birth)`,**不是这一行**;
- 单测原有的三条 `toContain`(`$before-ne$birth` / `$after-eq$birth` /
  `Get-NetTCPConnection`)**全部保留**。
  (改这个文件之前先查这两处 —— #1628 上我正是被字节变异锚咬过一次。)

## 提交前跑过的门

```
check-doc-symbol-pins.py .        rc=0
check-docs-integrity.py           rc=0
check-public-script-safety.py     rc=0
```

## 🔴 我不能验的那一半

**本机没有 Windows,这段 PowerShell 我跑不了。** 单测注入的是假的
`runPowerShell`,只验脚本的**形状**。真正跑它的是 CI 的
`Windows Codex co-presence native smoke` —— 脚本若写坏,那个 job 会
**100% 红**(而不是它平时约 30% 的 flake 率),所以这条改动是 CI 能兜住的。
**合并前请确认那个 job 在本 PR 上是绿的。**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
