### PR TITLE
test(823): 每个用例各自的耗时 —— 把「每加一个 L1 套件多花 1.8s」从估计变成实测 (#1627)

### DIFF
--- a/tests/test823-l1-concurrency-cap/run.sh
+++ b/tests/test823-l1-concurrency-cap/run.sh
@@ -91,8 +91,26 @@ say "source_commit=$SRC"
 say "nproc=$nproc_val"
 say ""
 
+# 🔴 #1627 —— 每个用例各自的耗时,写进文件而不是变量。
+#
+#    起因:`L1-TIMING v1` 的第一份数据显示本套件是 L1 里最慢的一个
+#    (119–120s,占 total 的 13.3%)。而本套件跑的是**真的 qa.sh --l1**,
+#    也就是每次都遍历当前全部 68 个套件 —— `run_case` 被调 5 次,
+#    所以 **L1 每加一个套件,这里要多跑它 5 遍**。
+#    那个「每套件约 +1.8s」的边际成本此前是**从总数反推的估计**,不是实测。
+#    这几行让它变成实测。
+#
+#    ⚠️ 为什么写文件而不是数组:`run_case` 的返回值走 stdout
+#    (调用方 `IFS='|' read -r p eff warned <<< "$(run_case …)"`),
+#    所以它是在**命令替换的子 shell** 里跑的 —— 子 shell 里 `ARR+=(…)` 的
+#    修改出了子 shell 就没了。实测:数组写法拿到长度 0,文件写法拿到 1 行。
+#    (同族:退出码穿过管道那一类 —— 都是「看起来执行了,作用域不对」。)
+T823_TIMING=${T823_TIMING:-/tmp/t823-timing.txt}
+: > "$T823_TIMING"
+
 run_case() {                  # $1=用例名 $2=QA_L1_MAX_PAR 取值(空=不设)
   local name=$1 val=${2-}
+  local _t0; _t0=$(date +%s%N)
   : > "$EV"
   local out=/tmp/t823-$name.log
   if [[ -n "${val:-}" || "${2+set}" == "set" ]]; then
@@ -106,6 +124,7 @@ run_case() {                  # $1=用例名 $2=QA_L1_MAX_PAR 取值(空=不设)
   local eff; eff=$(sed -n 's/.*L1 并发上限 = \([0-9][0-9]*\).*/\1/p' "$out" | head -1)
   [[ -n "$eff" ]] || eff="?"
   local warned=0; grep -q '不是非负整数' "$out" && warned=1
+  printf '%s=%sms\n' "$name" "$(( ($(date +%s%N) - _t0) / 1000000 ))" >> "$T823_TIMING"
   echo "$p|$eff|$warned"
 }
 
@@ -169,4 +188,14 @@ say ""
 say "failures=$fails"
 if [[ "$fails" -eq 0 ]]; then say "RESULT: PASS"; else say "RESULT: FAIL"; fi
 cat "$report"
+# 🔴 #1627 —— 一行固定格式的汇总,和 scripts/qa.sh 的 `L1-TIMING v1` 同族:
+#    让「本套件为什么是 L1 里最慢的」可以跨 run 直接 grep,而不必翻日志。
+#    格式一旦定下别改字段顺序 —— 改了,之前所有 run 的日志就对不上了(所以带 v1)。
+#      gh api …/jobs/<id>/logs | grep -o 'T823-TIMING v1 .*'
+if [[ -s "$T823_TIMING" ]]; then
+  _cases=$(tr '\n' ',' < "$T823_TIMING" | sed 's/,$//')
+  _sum=$(sed 's/[^=]*=//; s/ms$//' "$T823_TIMING" | awk '{s+=$1} END{print s+0}')
+  echo "T823-TIMING v1 cases=$(wc -l < "$T823_TIMING" | tr -d ' ') totalMs=${_sum} ${_cases}"
+fi
+
 [[ "$fails" -eq 0 ]]


### PR DESCRIPTION
test(823): 每个用例各自的耗时 —— 把「每加一个 L1 套件多花 1.8s」从估计变成实测 (#1627)

## 为什么

`L1-TIMING v1`(#1631,今天上线)的第一份数据显示:**本套件是 L1 里最慢的一个**,
119–120s,占 L1 total(900s)的 **13.3%**。

顺着查下去,原因是结构性的:本套件跑的是**真的 `qa.sh --l1`**(docker 桩掉),
也就是每次都遍历当前全部 **68** 个套件;而 `run_case` 被调用 **5 次**。

⇒ **L1 每加一个套件,这里要多跑它 5 遍。**

我据此粗算过「每新增一个 L1 套件,test823 多花约 1.8s」——
**那是从总数反推的估计,不是实测**。这几行让它变成实测。

## 加了什么

1. `run_case` 里记录每个用例的耗时,**写进文件**;
2. 末尾一行固定格式的汇总,和 `L1-TIMING v1` 同族:

```
T823-TIMING v1 cases=5 totalMs=120000 cap2=24100ms,failrc=23800ms,bad=24000ms,octal=23900ms,zero=24200ms
```

拿它是一条命令:`gh api …/jobs/<id>/logs | grep -o 'T823-TIMING v1 .*'`。
(带 `v1`,字段顺序定下就别改 —— 改了之前所有 run 的日志就对不上。)

## 🔴 三个坑,每个都验过而不是想过

**① 为什么写文件而不是数组。**
`run_case` 的返回值走 stdout(调用方 `IFS='|' read -r p eff warned <<< "$(run_case …)"`),
所以它在**命令替换的子 shell** 里跑 —— 子 shell 里 `ARR+=(…)` 出了子 shell 就没了。
实测:

```
数组写法: ARR 长度=0     ← 丢了
文件写法: 文件行数=1     ← 保住
```

**② 汇总行差点把这个套件的退出码毁掉。**
原脚本最后一行 `[[ "$fails" -eq 0 ]]` **就是退出码**。我第一版把汇总块追加在**它后面**,
于是退出码变成了汇总块的状态。实测:

```
追加在后面: fails=3 → rc=0   🔴 失败的测试会返回成功
放在前面:   fails=3 → rc=1   ✅
```

**一个把闸门变成 no-op 的改动,`bash -n` 是绿的、输出也完全正常。**

**③ 移动时差点插错位置。**
`[[ "$fails" -eq 0 ]]` 在文件里出现 **2 次** —— 一次在
`if [[ "$fails" -eq 0 ]]; then say "RESULT: PASS"; else …; fi` 里,
一次是末尾那个裸的退出码行。**不加计数检查的 replace 会插进 `if` 语句中间。**
改成按**整行相等**定位,并断言只命中 1 行。

## 端到端见证

```
fails=0 → rc=0 ✅   输出 T823-TIMING v1 …
fails=3 → rc=1 ✅   输出 T823-TIMING v1 …
```

汇总行在两种情况下都打印(它是诊断,不是判据),而退出码只由 `$fails` 决定。

## 提交前跑过的门(这次分开跑,并据它决定)

```
check-doc-symbol-pins.py .           rc=0
check-public-script-safety.py        rc=0
check-test-suite-registration.py     rc=0
```

(上一个 PR 我把跑门和提交写在同一个命令块里,门红了照样推 ——
 那次的教训在 #1637 的第二个提交里写了。这次分开。)

## 它不改变任何判据

本 PR 只加诊断输出:并发上限的判据、峰值统计、5 个用例的期望值**全部未动**。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
