### PR TITLE
docs(index): 首页桌面端下载从 desktop-v0.2.36 更到 v0.2.41(中英同步) (#1639)

### DIFF
--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -9,10 +9,10 @@ hero:
   actions:
     - theme: brand
       text: Download for macOS
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_aarch64.dmg
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_aarch64.dmg
     - theme: alt
       text: Download for Windows
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_x64-setup.exe
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_x64-setup.exe
     - theme: alt
       text: Read the docs
       link: /en/guide/getting-started
@@ -31,16 +31,16 @@ features:
 
 <section class="desktop-download" aria-labelledby="desktop-download-title">
   <div class="desktop-download-copy">
-    <span class="eyebrow">DESKTOP APP · v0.2.36</span>
+    <span class="eyebrow">DESKTOP APP · v0.2.41</span>
     <h2 id="desktop-download-title">Download and start collaborating</h2>
     <p>A signed native desktop experience. Mac and Windows connect to the same Hubs, accounts, and conversations.</p>
     <div class="download-note">The current Mac build supports Apple Silicon. The Windows build supports 64-bit Windows 10/11.</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_aarch64.dmg"><span class="download-platform">macOS</span><strong>Download .dmg</strong><small>Apple Silicon · 36.6 MB</small><span class="download-arrow">↓</span></a>
-    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_x64-setup.exe"><span class="download-platform">Windows</span><strong>Download installer</strong><small>Windows x64 · 35.2 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_aarch64.dmg"><span class="download-platform">macOS</span><strong>Download .dmg</strong><small>Apple Silicon · 36.6 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_x64-setup.exe"><span class="download-platform">Windows</span><strong>Download installer</strong><small>Windows x64 · 35.2 MB</small><span class="download-arrow">↓</span></a>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">All releases</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">All releases</a></p>
 </section>
 
 <section class="mobile-download" aria-labelledby="mobile-download-title">
@@ -61,7 +61,7 @@ features:
 <section class="product-path">
   <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>Desktop simplicity, full CLI power</h2></div>
   <div class="product-path-grid">
-    <article class="product-path-card"><span class="path-number">01</span><h3>Desktop app</h3><p>For everyday work: manage agents, conversations, files, schedules, and servers visually.</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">Get the latest release →</a></article>
+    <article class="product-path-card"><span class="path-number">01</span><h3>Desktop app</h3><p>For everyday work: manage agents, conversations, files, schedules, and servers visually.</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">Get the latest release →</a></article>
     <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>For developers and servers: control Hubs, nodes, runtimes, and automation precisely.</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/en/guide/getting-started">Read the install guide →</a></article>
   </div>
 </section>
@@ -69,5 +69,5 @@ features:
 <section class="final-cta">
   <h2 class="final-cta-title">Turn your agents into a real team</h2>
   <p class="final-cta-sub">Start with the desktop app or build your own network with anet CLI.</p>
-  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">Download desktop</a><a class="cta-ghost" href="/en/guide/getting-started">Developer docs</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">Download desktop</a><a class="cta-ghost" href="/en/guide/getting-started">Developer docs</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
 </section>

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -9,10 +9,10 @@ hero:
   actions:
     - theme: brand
       text: 下载 macOS 版
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_aarch64.dmg
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_aarch64.dmg
     - theme: alt
       text: 下载 Windows 版
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_x64-setup.exe
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_x64-setup.exe
     - theme: alt
       text: 查看文档
       link: /guide/getting-started
@@ -31,20 +31,20 @@ features:
 
 <section class="desktop-download" aria-labelledby="desktop-download-title">
   <div class="desktop-download-copy">
-    <span class="eyebrow">DESKTOP APP · v0.2.36</span>
+    <span class="eyebrow">DESKTOP APP · v0.2.41</span>
     <h2 id="desktop-download-title">下载后，直接开始协作</h2>
     <p>原生桌面体验，已签名发布。Mac 与 Windows 使用同一套 Hub、账号和会话。</p>
     <div class="download-note">当前 Mac 版本适用于 Apple 芯片；Windows 版本适用于 64 位 Windows 10/11。</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_aarch64.dmg">
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_aarch64.dmg">
       <span class="download-platform">macOS</span><strong>下载 .dmg</strong><small>Apple Silicon · 36.6 MB</small><span class="download-arrow">↓</span>
     </a>
-    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.36/Agent.Network_0.2.36_x64-setup.exe">
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.41/Agent.Network_0.2.41_x64-setup.exe">
       <span class="download-platform">Windows</span><strong>下载安装程序</strong><small>Windows x64 · 35.2 MB</small><span class="download-arrow">↓</span>
     </a>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">全部历史版本</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">全部历史版本</a></p>
 </section>
 
 <section class="mobile-download" aria-labelledby="mobile-download-title">
@@ -69,7 +69,7 @@ features:
 <section class="product-path">
   <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>桌面端开箱即用，CLI 保留全部能力</h2></div>
   <div class="product-path-grid">
-    <article class="product-path-card"><span class="path-number">01</span><h3>桌面应用</h3><p>适合日常使用。图形化管理 Agent、会话、文件、定时任务和服务器。</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">获取最新版 →</a></article>
+    <article class="product-path-card"><span class="path-number">01</span><h3>桌面应用</h3><p>适合日常使用。图形化管理 Agent、会话、文件、定时任务和服务器。</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">获取最新版 →</a></article>
     <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>适合开发者与服务器部署。精确控制 Hub、节点、Runtime 和自动化流程。</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/guide/getting-started">阅读安装指南 →</a></article>
   </div>
 </section>
@@ -77,5 +77,5 @@ features:
 <section class="final-cta">
   <h2 class="final-cta-title">让你的 Agent 真正组成团队</h2>
   <p class="final-cta-sub">从桌面应用开始，或使用 anet CLI 构建自己的协作网络。</p>
-  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.36">下载桌面版</a><a class="cta-ghost" href="/guide/getting-started">开发者文档</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.41">下载桌面版</a><a class="cta-ghost" href="/guide/getting-started">开发者文档</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
 </section>


### PR DESCRIPTION
docs(index): 首页桌面端下载从 desktop-v0.2.36 更到 v0.2.41(中英同步) (#1639)

## 用户拿到的是什么

线上实测(2026-08-31):

```
$ curl -sL https://anet.sh/ | grep -oE "desktop-v[0-9.]+" | sort -u
desktop-v0.2.36           ← 首页下载按钮
```

而实际 Latest 是 **`desktop-v0.2.41`** —— **落后 5 个版本**。

`v0.2.36` 早于:`app#197`(按钮置灰)、**`app#199`(建节点向导里根本没有共存 runtime ——
/goal 第一优先级那几个在 App 里建不出来)**、`app#203`(未读数写盘失败静默吞)、
以及 v0.2.41 才带的 bundled hub。**首页是新用户的第一个入口。**

## 改了什么

中英两份 `index.md` 各 12 处:

```
desktop-v0.2.36              → desktop-v0.2.41    (7 处/份:2 个 frontmatter link + 2 个下载卡 + tag 链接等)
Agent.Network_0.2.36_…       → Agent.Network_0.2.41_…   (4 处/份)
<span class="eyebrow">DESKTOP APP · v0.2.36</span> → v0.2.41   (1 处/份)
```

最后那一处是**显示给用户看的版本号** —— 我第一次替换只覆盖了 tag 与资产名,
复查 `grep -c "0.2.36"` 时每份还剩 1 处,才发现它。**现在两份都是 0。**

## 🔴 改之前先验了资产文件名(版本号盲改会产生 404)

```
$ gh release view desktop-v0.2.41 --json assets
  Agent.Network_0.2.41_aarch64.dmg        ← 对应 macOS 卡
  Agent.Network_0.2.41_x64-setup.exe      ← 对应 Windows 卡
  Agent.Network_0.2.41_android.apk
  Agent.Network_0.2.41_ios.ipa
  …
```

命名规则与 `0.2.36` 一致(`Agent.Network_<ver>_<arch>.<ext>`),所以只换版本号是安全的。

## ⚠️ 移动端**没有动**,因为它是一个需要维护者判断的分叉

首页移动端指向 `mobile-v0.2.34/AgentNetwork-0.2.34-android.apk`。查下来是两条不同的产物线:

| tag | 状态 | 资产 |
|---|---|---|
| `mobile-v0.2.34`(08-25) | **Pre-release** | 只有 `AgentNetwork-0.2.34-android.apk` |
| `desktop-v0.2.41`(08-27) | **Latest** | 含 `Agent.Network_0.2.41_android.apk` **和** `_ios.ipa` |

**命名规则都不同**(`AgentNetwork-0.2.34-android.apk` vs `Agent.Network_0.2.41_android.apk`)。
哪条是移动端的正统发布通道,我没有依据判断 —— **留给维护者**。
(#1639 里记了这一格。)

## 这只是治标

#1639 的第 2 条建议是**让首页按钮走已有的动态版本解析** ——
`docs-site/api/desktop-update-latest.mjs` 里已经有 `parseVersion` /
`compareDesktopVersions`,在给自动更新端点用。**本 PR 没有做那件事**,
所以**下次发版这几个数字还会漂**。

## ⚠️ 合并之后它也不会立刻上线

`deploy-anet-sh.yml` 在 `VERCEL_TOKEN` 未配时**静默跳过且仍报 success**(#1619,今天实测过一次)。
**本 PR 的价值是:让 main 处于正确状态,这样 token 一配上,部署出去的就是对的** ——
而不是配好 token 之后再发现首页还指着 v0.2.36。

## 提交前跑过的门

```
check-doc-symbol-pins.py . --doc-root docs-site   rc=0
check-docs-integrity.py                            rc=0
check-release-channel-assertions.py                rc=0
check-doc-version-claims.py                        rc=0  (4 条版本断言 / 2 个文档,全部指向正在发的版本)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
