### PR TITLE
docs(app-shells): 「Windows 是唯一真正为零的那格」已不成立 —— 与本站首页下载按钮自相矛盾(中英同步)

### DIFF
--- a/docs-site/docs/en/guide/app-shells.md
+++ b/docs-site/docs/en/guide/app-shells.md
@@ -86,13 +86,23 @@ So the answer to "is there a Mac installer" is **yes** — just not from the she
 describes. Both lines currently coexist; this page does not judge which one is the main line.
 See [issue #233](https://github.com/sleep2agi/agent-network/issues/233).
 
-**Windows is the one genuinely empty cell across all three repositories**: no workflow anywhere
-builds for Windows. The Dashboard's `electron-builder.json` does *configure* a `win: nsis`
-target, but no CI runs it — **a configured target is not a produced artifact.**
+🔴 **Before 2026-08-31 this section claimed "Windows is the one genuinely empty cell across all
+three repositories". That is no longer true**, and it contradicted this site's own Windows
+download button. The current facts:
+
+| Platform | `agent-network-app` packaging | Evidence |
+|---|---|---|
+| Windows | **Yes**, built in CI | `desktop-tauri.yml:100` `runs-on: windows-latest`; `:149` `npx tauri build --bundles nsis,msi` |
+| Artifacts | `.exe` (nsis) + `.msi` (WiX), each with a `.sig` | `desktop-v0.2.41` ships `Agent.Network_0.2.41_x64-setup.exe` (35 MB) and `_x64_en-US.msi` (48 MB) |
+
+**The Dashboard shell still has no Windows CI** — its `electron-builder.json` does *configure* a
+`win: nsis` target, but no CI runs it: **a configured target is not a produced artifact.**
+The two facts used to be merged into one sentence, so "the Dashboard shell has none" was read as
+"the project has none".
 :::
 
 ## Which one should I use
 
 - Just want it on your phone → **PWA**, no build step at all;
-- Handing it to people who do not use a terminal → **desktop installer** (only Linux verified so far);
+- Handing it to people who do not use a terminal → **desktop installer** (the `agent-network-app` line produces macOS / Windows artifacts in CI — see the table above; the Dashboard shell is still Linux-only);
 - Need system capabilities (push, files, camera) → **Capacitor**, which is what needs Xcode / Android Studio.

--- a/docs-site/docs/guide/app-shells.md
+++ b/docs-site/docs/guide/app-shells.md
@@ -75,13 +75,21 @@ npm run app:desktop:pack                                                  # 打�
 所以「有没有 Mac 安装包」这个问题的答案是**有**，只是不在本页说的这个壳里。
 两条线目前并存，本页不判断哪条是主线 —— 见 [issue #233](https://github.com/sleep2agi/agent-network/issues/233)。
 
-**Windows 是三个仓里唯一真正为零的那格**：所有 workflow 里都没有 Windows 打包。
-Dashboard 的 `electron-builder.json` 里**配置**了 `win: nsis`，但没有任何 CI 跑它 ——
-**配置存在不等于产物存在。**
+🔴 **上面这段在 2026-08-31 之前写着「Windows 是三个仓里唯一真正为零的那格」——
+那句已经不成立了**，而且它与本站首页的 Windows 下载按钮自相矛盾。现在的事实：
+
+| 平台 | `agent-network-app` 的打包 | 证据 |
+|---|---|---|
+| Windows | **有**，CI 里跑 | `desktop-tauri.yml:100` `runs-on: windows-latest`；`:149` `npx tauri build --bundles nsis,msi` |
+| 产物 | `.exe`(nsis) + `.msi`(WiX)，各带 `.sig` | `desktop-v0.2.41` 里 `Agent.Network_0.2.41_x64-setup.exe`(35 MB)、`_x64_en-US.msi`(48 MB) |
+
+**Dashboard 那个壳仍然没有 Windows CI** —— 它的 `electron-builder.json` 里**配置**了
+`win: nsis` 但没有任何 CI 跑它，**配置存在不等于产物存在**。
+两件事此前被合并成一句话,于是「Dashboard 壳没有」被读成了「整个项目没有」。
 :::
 
 ## 我该用哪一种
 
 - 只是想在手机上看看 → **PWA**，不需要任何构建；
-- 要推给不会用命令行的人 → **桌面安装包**（目前只有 Linux 经过实测）；
+- 要推给不会用命令行的人 → **桌面安装包**（`agent-network-app` 线的 macOS / Windows 产物在 CI 里出，见上表；Dashboard 壳那条仍只有 Linux 实测过）；
 - 要接系统能力（推送、文件、相机等）→ **Capacitor**，那才需要 Xcode / Android Studio。


### PR DESCRIPTION
docs(app-shells): 「Windows 是唯一真正为零的那格」已不成立 —— 它与本站首页的下载按钮自相矛盾(中英同步)

## 这一页在说假话,而同一个站点的首页在反驳它

`docs-site/docs/guide/app-shells.md` 写着:

> **Windows 是三个仓里唯一真正为零的那格**:所有 workflow 里都没有 Windows 打包。

而 **anet.sh 首页的 Windows 下载按钮**直接链着
`Agent.Network_0.2.41_x64-setup.exe`。**一个用户在同一个站点里会读到两个相反的说法。**

## 事实(逐条可复核)

| | 证据 |
|---|---|
| CI 里有 Windows 打包 | `desktop-tauri.yml:100` `runs-on: windows-latest` |
| 产两种安装包 | `desktop-tauri.yml:149` `npx tauri build --bundles nsis,msi`;发版流水线 `release-desktop-auto-update.yml:28` 同 |
| 产物真的存在 | `desktop-v0.2.41`:`Agent.Network_0.2.41_x64-setup.exe`(35,216,610 B)、`_x64_en-US.msi`(48,795,648 B) |
| 带自动更新签名 | 两者各有 `.sig`(428 B) |

## 🔴 原句为什么会错 —— 两件事被合成了一句

原文那段在 `::: tip 上面这句只针对 Dashboard 那个壳` 里,讲的是 **Dashboard 壳**;
但那句话写的是「**三个仓里**唯一真正为零的那格」,把作用域扩到了整个项目。

**「Dashboard 壳没有 Windows CI」是真的,而且现在仍然真。**
**「整个项目没有 Windows 打包」是假的。**
两件事合成一句之后,读者只会取到后一个意思。

本 PR 把它们拆开:表格说 `agent-network-app` 有什么,
后一段保留 Dashboard 壳仍然没有 CI 这个事实(`electron-builder.json` 里
**配置**了 `win: nsis` 但没有任何 CI 跑它 —— **配置存在不等于产物存在**,这句原文是对的)。

## 顺带修的第二处

「要推给不会用命令行的人 → **桌面安装包**(目前只有 Linux 经过实测)」——
同样把 Dashboard 壳的现状说成了全项目的。已改成分开表述。

## 没有改的

- **「实测成功过(最近一次 2026-06-17)」那句没动** —— 它说的是 macOS 那条线的
  一次人工实测记录,我没有更新的实测可以替换它。**一个记录不该被一个我没做过的
  实测覆盖掉。**
- 也没有判断「两条客户端线哪条是主线」—— 原文明确说本页不判断(见 #233),本 PR 保持。

## 提交前跑过的门

```
check-doc-symbol-pins.py . --doc-root docs-site   rc=0
check-docs-integrity.py                            rc=0
check-release-channel-assertions.py                rc=0
check-doc-version-claims.py                        rc=0
check-no-memory-slugs.py .                         rc=0
```

## ⚠️ 合并后不会立刻上线

`VERCEL_TOKEN` 未配 ⇒ `deploy-anet-sh` 静默跳过(#1619)。
本 PR 的价值同 #1640:**让 main 处于正确状态,token 一配上部署出去的就是对的。**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
