### PR TITLE
test(server): 给 19 个跑 KDF+bootServer 的 beforeAll 显式 30s 超时（bun 默认 5s）

### DIFF
--- a/server/src/admin-networks-http.test.ts
+++ b/server/src/admin-networks-http.test.ts
@@ -25,6 +25,10 @@ async function listNetworks(token: string): Promise<any[]> {
   return body.networks;
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   const { db } = await import("./db.js");
   const { createNetworkTokenForNode, register } = await import("./auth.js");
@@ -51,7 +55,7 @@ beforeAll(async () => {
   const mod = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch {}

--- a/server/src/api-host-supervisors-fallback.test.ts
+++ b/server/src/api-host-supervisors-fallback.test.ts
@@ -38,6 +38,10 @@ let soloNetworkId = "";
 let multiNetworkA = "", multiNetworkB = "";
 let soloDaemonAlias = "";
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.HOST = "127.0.0.1";
 
@@ -116,7 +120,7 @@ beforeAll(async () => {
   server = bootServer({ port: 0, hostname: "127.0.0.1" });
   BASE = `http://127.0.0.1:${server.port}`;
   await new Promise((r) => setTimeout(r, 100));
-});
+}, 30_000);
 
 // Insert a minimal `nodes` row + `api_tokens` row so the daemon shows up
 // in /api/host-supervisors' JOIN-then-role-filter query (index.ts

--- a/server/src/auth-validate.test.ts
+++ b/server/src/auth-validate.test.ts
@@ -10,13 +10,17 @@ import { register } from "./auth.js";
 
 // First user gets RELAXED rules (admin bootstrap allows 4-char "anethub" etc.)
 // To test full-strength rules, seed a dummy admin first.
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(() => {
   // Idempotent: if DB file already has users (from a previous run on the
   // same temp path), this errors with "username already taken" → that's
   // fine, the goal is just "ensure at least one user exists so subsequent
   // registers hit the strict path".
   register("_seed_admin", "BootstrapPw1", undefined, "seed");
-});
+}, 30_000);
 
 describe("register — username rules", () => {
   it("rejects empty username", () => {

--- a/server/src/dashboard-slash-routing-http.test.ts
+++ b/server/src/dashboard-slash-routing-http.test.ts
@@ -18,6 +18,10 @@ let nodeToken = "";
 let networkId = "";
 let requestSequence = 0;
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
   const username = `dashboard_slash_${Date.now()}`;
@@ -42,7 +46,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/external-schedule-edits-http.test.ts
+++ b/server/src/external-schedule-edits-http.test.ts
@@ -51,6 +51,10 @@ function snapshot(revision: number, extra: Record<string, unknown> = {}) {
   });
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   const admin = register(`b4_admin_${stamp}`, "B4Admin123!", undefined, "B4 Admin");
   const owner = register(`b4_owner_${stamp}`, "B4Owner123!", undefined, "B4 Owner");
@@ -83,7 +87,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -30,6 +30,10 @@ let userNetworkId = "";
 let userName = "";
 let adminToken = "";
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || SERVER_DB;
   process.env.HOST = "127.0.0.1";
@@ -72,7 +76,7 @@ beforeAll(async () => {
   if (res.status !== 200) throw new Error("SSE subscribe failed: " + res.status);
   sseReader = res.body!.getReader();
   await sseReader.read(); // consume the connected frame → registration done
-});
+}, 30_000);
 
 afterAll(() => {
   try { sseReader?.cancel(); } catch {}

--- a/server/src/network-name-http.test.ts
+++ b/server/src/network-name-http.test.ts
@@ -13,6 +13,10 @@ let nodeToken = "";
 let networkId = "";
 let username = "";
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
   username = `network_name_${Date.now()}_${process.pid}`;
@@ -30,7 +34,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/node-attrs.test.ts
+++ b/server/src/node-attrs.test.ts
@@ -45,6 +45,10 @@ const LEGACY_ALIAS = "attrs-legacy-node";
 let token = "";
 let server: { stop: (force?: boolean) => void } | null = null;
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   db.run(`INSERT INTO users (user_id, username, password_hash, role) VALUES (?1, 'attrs-user', 'x', 'user')`, [USER]);
   db.run(`INSERT INTO networks (network_id, network_name, owner_id) VALUES (?1, 'attrs-net', ?2)`, [NET, USER]);
@@ -58,7 +62,7 @@ beforeAll(async () => {
   token = issueUserToken(USER, "attrs-test").token;
   server = bootServer({ port: PORT, hostname: "127.0.0.1" }) as never;
   await new Promise((r) => setTimeout(r, 120));
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch { /* already down */ }

--- a/server/src/observer-avatar-http.test.ts
+++ b/server/src/observer-avatar-http.test.ts
@@ -36,6 +36,10 @@ let outsiderUserId = "";
 const TARGET_ALIAS = "obs-target-agent";
 const AVATAR_NODE_ID = "node_avatar_test_1";
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   // Kept for per-file runs launched without an external COMMHUB_DB (the
   // documented contract still is to set it externally; see db-adapter.ts).
@@ -88,7 +92,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   privateServer = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   BASE = `http://127.0.0.1:${privateServer.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { privateServer?.stop?.(true); } catch {}

--- a/server/src/rest-explicit-columns-http.test.ts
+++ b/server/src/rest-explicit-columns-http.test.ts
@@ -82,6 +82,10 @@ async function api(path: string): Promise<any> {
   return response.json();
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   ({ db } = await import("./db.js"));
   const { register } = await import("./auth.js");
@@ -135,7 +139,7 @@ beforeAll(async () => {
   const mod = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch {}

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -26,6 +26,10 @@ async function api(token: string, path: string, init?: RequestInit) {
   return { status: res.status, body: await res.json() as any };
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   const owner = register(`scheduler_owner_${Date.now()}`, "SchedulerOwner123!", undefined, "seed");
   expect(owner.ok).toBe(true);
@@ -53,7 +57,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/side-thread-http-integration.test.ts
+++ b/server/src/side-thread-http-integration.test.ts
@@ -56,6 +56,10 @@ function headers(token = ownerToken) {
   };
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.NODE_ENV = "test";
   process.env.COMMHUB_DB = dbPath;
@@ -100,7 +104,7 @@ beforeAll(async () => {
   detachPort = serverModule.installSideThreadExecutionPort(new HttpFakePort());
   hub = serverModule.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${hub.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   detachPort();

--- a/server/src/skillhub-http.test.ts
+++ b/server/src/skillhub-http.test.ts
@@ -28,6 +28,10 @@ async function tool(token: string, name: string, args: Record<string, unknown>) 
   return JSON.parse(payload.result.content[0].text);
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB ||= join(dir, "hub.db");
   const owner = register(`skill_owner_${Date.now()}`, "SkillHubOwner123!", undefined, "seed");
@@ -41,7 +45,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => { try { server?.stop?.(true); } catch {} try { rmSync(dir, { recursive: true, force: true }); } catch {} });
 

--- a/server/src/task-auth-origin-http.test.ts
+++ b/server/src/task-auth-origin-http.test.ts
@@ -15,6 +15,10 @@ const TARGET = `auth-origin-http-target-${process.pid}`;
 const TARGET_NODE_ID = `node_auth_origin_target_${process.pid}`;
 const TARGET_RESUME_ID = `resume_auth_origin_target_${process.pid}`;
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
   const username = `auth_origin_${Date.now()}`;
@@ -39,7 +43,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/task-diagnostic-http.test.ts
+++ b/server/src/task-diagnostic-http.test.ts
@@ -49,6 +49,10 @@ async function openSse(token: string, networkId: string): Promise<ReadableStream
   return reader;
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   ({ db } = await import("./db.js"));
   const { register } = await import("./auth.js");
@@ -79,7 +83,7 @@ beforeAll(async () => {
   const mod = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch {}

--- a/server/src/task-lifecycle-watcher.test.ts
+++ b/server/src/task-lifecycle-watcher.test.ts
@@ -23,6 +23,10 @@ function sqliteUtcTimestamp(date: Date): string {
   return date.toISOString().slice(0, 19).replace("T", " ");
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   const { register } = await import("./auth.js");
   const auth = register(`watcher_owner_${Date.now()}`, "WatcherOwner-Strong-1!", undefined, "watcher");
@@ -39,7 +43,7 @@ beforeAll(async () => {
   const mod = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch {}

--- a/server/src/task-network-resolution-http.test.ts
+++ b/server/src/task-network-resolution-http.test.ts
@@ -46,6 +46,10 @@ function seedTarget(principal: Principal): void {
   );
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
   adminSingle = registerPrincipal("admin_single", true);
@@ -70,7 +74,7 @@ beforeAll(async () => {
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}

--- a/server/src/tasks-pagination-http.test.ts
+++ b/server/src/tasks-pagination-http.test.ts
@@ -28,6 +28,10 @@ function seedTask(
   );
 }
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   ({ db } = await import("./db.js"));
   ({ register } = await import("./auth.js"));
@@ -54,7 +58,7 @@ beforeAll(async () => {
   const mod = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
   base = `http://127.0.0.1:${server.port}`;
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop(true); } catch {}

--- a/server/src/uploads-http.test.ts
+++ b/server/src/uploads-http.test.ts
@@ -24,6 +24,10 @@ let server: any;
 let userToken = "";
 let userNetworkId = "";
 
+// 30s 而不是 bun 默认的 5s:这个 hook 跑 register()(KDF)+bootServer(),
+// 本机空载基线 ~620ms,而 2026-08-17 与 2026-08-31 两次 CI 上它被 5s 上限打死
+// (0 pass / 1 fail / Ran 1 test —— 见 #928、#1627)。5247ms 是**被截断的下界**,
+// 不是测量值,所以余量按基线的 ~48x 取,而不是按那个数取。
 beforeAll(async () => {
   // Bootstrap a real admin + token on the temp DB so the server can
   // resolve it via requireAuth (we don't want to short-circuit auth —
@@ -58,7 +62,7 @@ beforeAll(async () => {
   BASE = `http://127.0.0.1:${server.port}`;
   // Tiny settle so the listener is ready.
   await new Promise((r) => setTimeout(r, 100));
-});
+}, 30_000);
 
 afterAll(() => {
   try { server?.stop?.(true); } catch {}


### PR DESCRIPTION
## 为什么

bun 的 lifecycle hook 默认上限是 **5s**。`server/src` 下 **19 个**测试文件的 `beforeAll` 里跑 `register()`(KDF 密码哈希) + `bootServer()`，本机空载基线 **~620ms** —— 余量只有 8x。CI 已经两次撞穿：

| 时间 | 现场 |
|---|---|
| 2026-08-17 (#928) | `^ a beforeEach/afterEach hook timed out` · `0 pass 1 fail` · `Ran 1 test across 1 file. [5.47s]` |
| 2026-08-31 (#1627) | `test686-rest-shape-golden` 同一形状；该次 L1 总耗时 **1724s**（常态 ~900s） |

这个失败特别难读：摘要写 `0 pass 1 fail / Ran 1 test`，而该文件本该注册 **6** 个测试 —— **没有任何一行说本该跑 6 个**。`test686` 的 `GOLDEN_MIN_TESTS` 下限门就是为此而加，今天它正常工作并抓住了这次。

## 为什么是 30s，而不是照着 5247ms 加一点

🔴 **`5247ms` 是被 5s 上限截断的下界，不是那个 hook 真实耗时的测量值** —— 它究竟要多久无从得知。所以按本机基线取 ~48x。

也不取 60s：L1 当前总耗时已顶到 900s 软预算（见 #1627 的 `L1-TIMING v1`），真出现卡死时 30s 比 60s 便宜。

## 见证

在**真实文件** `rest-explicit-columns-http.test.ts` 上注入 6.5s 延迟，两向：

| | 结果 |
|---|---|
| 带 `30_000` | `6 pass  0 fail` · `Ran 6 tests across 1 file. [7.09s]` |
| 去掉 | `hook timed out` · `0 pass 1 fail` · `Ran 1 test [5.02s]` ← **逐字复现 CI** |

**单变量对照**（改动前 / 后各跑这 19 个文件）：两侧均为 `绿 6 / 非绿 13`，且 13 个文件名逐字相同 —— 那些是独立跑时的存量失败（需套件夹具），与本改动无关。

## 取集

19 个是扫全 `server/src`、`agent-node/src`、`agent-network/src` 的 `.test.ts` 后，筛"hook 体内含 `register(` / `bootServer(` / `Bun.serve(`"得到的**全集**，其中显式 timeout 的为 **0** 个。只修 test686 那一个等于把 flake 挪给下一个文件。

Refs #1627, #928