### PR TITLE
fix(cli): `anet status` 不再把 blocked 节点说成 "not progressing"

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -12000,13 +12000,19 @@ async function statusCommand() {
     console.log(`  Tasks:  ${tasks.length} recent\n`);
 
     if (attention.length > 0) {
-      console.log("  Needs attention (blocked / error / 未知状态 — not progressing):");
+      console.log("  Needs attention (blocked / error / 未知状态 — 需要有人看一眼):");
       for (const s of attention) {
         console.log(`    ${String(s.alias).padEnd(16)} ${String(s.status || "").padEnd(8)} ${(s.task || "").slice(0, 48)}`);
       }
       // 🔴 状态是**自报**的:它只在 agent 显式上报时才变。一个 `blocked` 可能是
       //    3 秒前报的,也可能是三周前报的 —— 这里不假装知道哪一种。
-      console.log("    (状态由 agent 自报,不含活性成分;要确认它还在不在,发一条任务试试)");
+      // 🔴 不要写「not progressing」:#1548 的实测证据正好相反 —— 一个 blocked 节点
+      //    22 秒答完了一条任务。blocked 说的是「没有出口」(只有 report_completion
+      //    会把它清回 idle),不是「它停了」。这两句话对用户的含义完全不同。
+      console.log("    (🔴 blocked ≠ 停了 —— 实测 blocked 节点仍能秒回任务;它只是没有出口:");
+      console.log("     只有 report_completion 会把 status 清回 idle。状态由 agent 自报,");
+      console.log("     不含活性成分,名册里也没有「何时变成 blocked」这个字段 —— updated_at");
+      console.log("     被心跳一直刷,不是它。要确认它还在不在,发一条任务试试。)");
       console.log();
     }
 


### PR DESCRIPTION
## 用户看到的那句是错的

```
Needs attention (blocked / error / 未知状态 — not progressing)
```

而 **#1548 的实测证据正好相反**。今天在生产 hub 上又复现一次：

| | |
|---|---|
| 节点 | `grok-v1`（`agent-node:grok-build-cli`） |
| 名册状态 | `blocked` |
| 心跳 | **4 分钟前**（`last_seen_at` 是 UTC） |
| 我 dispatch 一条任务 → 它回复 | **22 秒** |

`#1548` 里的另一个例子是 `Mac打包狗` —— 负责 exe/dmg 且没有替补，显示 `blocked` 8.3 小时，**实际一直是活的**。

## `blocked` 真正的含义是「没有出口」，不是「它停了」

只有 `report_completion` 会把 `status` 清回 `idle`（`server/src/tools.ts:904`），而靠 `send_task` / `commhub_reply` 干活的 agent **永远不走那条路径**。

这两句话对用户的含义完全不同，而屏幕上印的是后者 —— 一个正在秒回任务的节点被写成"停止推进"。

## 🔴 为什么这条不是 #1548 的重复

`#1548` 的三条建议全在**服务端和 dashboard**（成功 reply 也清状态 / 最长停留降级为 unknown / 显示状态时长），**没有一条提到 CLI 这句字符串**。

代码里那条注释（「`blocked` 是一个没有出口的状态」）**是对的** —— 错的是用户实际撞上的那句。修了注释、留下了用户读的那句，是两回事。

## 也**没有**顺手加「blocked 多久了」

名册里**没有**「何时变成 blocked」这个字段。`updated_at` 被心跳一直刷（`grok-v1` 的是 4 分钟前），拿它当"已 blocked 时长"，会给一个卡了 8 小时的节点印出「4 分钟前」—— **比不显示更糟**。这一格要等 `#1548` 的服务端改动。

## 验证

- `check-doc-symbol-pins.py` → `OK（判定 7 个，漂移 0）`（cli.ts 加了行，行号 pin 必跑）
- 纯语法构建 `rc=0`
- 全仓 `grep "not progressing"` 只有这一处（无测试钉它）

Refs #1548