### PR TITLE
feat(#1648): anet status 说清 offline 是「刚停」还是「掉了三天」

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -36,6 +36,7 @@ import {
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { classifySessionStatus, summarizeSessions } from "../src/session-status-class";
+import { formatOfflineAges, summarizeOfflineAges } from "../src/offline-age";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
@@ -11996,6 +11997,14 @@ async function statusCommand() {
     console.log(`  Agents: ${summary.idle || 0} idle, ${summary.working || 0} working`
       + (attnCount > 0 ? `, ${attnCount} needs attention` : "")
       + `, ${summary.offline || 0} offline`);
+    // 🔴 #1648 —— 「刚停的」和「掉了三天没人发现的」原先渲染成同一个数字。
+    //    实测(84 台 TM 相关节点):45 台 offline 里 27 台 >3 天、18 台 1-3 天、
+    //    近 6 小时内 **0 台** —— 「当前没有活故障」和「有 45 台掉了」是完全
+    //    不同的两个结论,而屏幕上只有后者。
+    //    与 blocked 不同,这一格是**算得出来的**:offline 节点的 last_seen_at
+    //    就是它最后一次心跳,不像「何时变成 blocked」那样根本没有字段。
+    const offlineDetail = formatOfflineAges(summarizeOfflineAges(offline, Date.now()));
+    if (offlineDetail) console.log(`          └─ ${offlineDetail}`);
     console.log(`  SSE:    ${sseCount === null ? "unknown" : `${sseCount} connected`}`);
     console.log(`  Tasks:  ${tasks.length} recent\n`);
 

--- a/agent-network/src/offline-age.test.ts
+++ b/agent-network/src/offline-age.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { formatOfflineAges, parseHubTimestamp, summarizeOfflineAges } from "./offline-age";
+
+// 2026-08-30T21:11:24Z —— 实测取到的一条真实 last_seen_at(去掉了时区标记,hub 就是这么存的)
+const RAW = "2026-08-30 21:11:24";
+const TRUE_UTC = Date.UTC(2026, 7, 30, 21, 11, 24);
+
+describe("parseHubTimestamp", () => {
+  test("🔴 无时区标记的串必须按 UTC 解析,不能按本地时区", () => {
+    // 这条是整个模块存在的理由:`new Date("2026-08-30 21:11:24")` 在 UTC+8 上
+    // 会解析成早 8 小时的那一刻,且不报错。若有人把 "Z" 拿掉,这条必须红。
+    expect(parseHubTimestamp(RAW)).toBe(TRUE_UTC);
+  });
+
+  test("🔴 在非 UTC 时区下也必须解出同一个 UTC 时刻", () => {
+    // `bun test` 把测试进程的时区固定成 UTC(getTimezoneOffset() === 0)。
+    // 在 UTC 下,「补 Z」和「不补 Z」解析出的是**同一个数** —— 也就是说这个模块
+    // 存在的那个缺陷,在测试进程里**结构上不可见**。
+    // 实测:把 `+ (hasZone ? "" : "Z")` 改成 `+ ""`,本文件 11 条测试**全绿**。
+    // 所以这一条必须开一个 TZ≠UTC 的子进程,在那里才观察得到。
+    const child = `import { parseHubTimestamp } from ${JSON.stringify(import.meta.dir + "/offline-age.ts")};
+process.stdout.write(new Date().getTimezoneOffset() + "," + parseHubTimestamp(${JSON.stringify(RAW)}));`;
+    const r = Bun.spawnSync(["bun", "-e", child], { env: { ...process.env, TZ: "Asia/Shanghai" } });
+    const [offset, parsed] = r.stdout.toString().trim().split(",");
+    // 🔴 先断言**控制生效了**:子进程真的不在 UTC。否则 TZ 被忽略时,
+    //    下面那条断言会在 UTC 下轻松通过,这个测试又变成空的。
+    expect(Number(offset)).not.toBe(0);
+    expect(parsed).toBe(String(TRUE_UTC));
+  });
+
+  test("已带 Z 或 ±HH:MM 的串不再追加时区", () => {
+    expect(parseHubTimestamp("2026-08-30T21:11:24Z")).toBe(TRUE_UTC);
+    expect(parseHubTimestamp("2026-08-30T22:11:24+01:00")).toBe(TRUE_UTC);
+  });
+
+  test("拿不到就返回 null,不返回一个看起来合理的数", () => {
+    for (const bad of [undefined, null, "", "   ", 12345, {}, "not a date", "2026-08-30"]) {
+      expect(parseHubTimestamp(bad as unknown)).toBeNull();
+    }
+  });
+});
+
+describe("summarizeOfflineAges", () => {
+  const now = TRUE_UTC + 4 * 60_000; // 那条 last_seen 之后 4 分钟
+  const at = (hoursAgo: number) => ({ last_seen_at: new Date(now - hoursAgo * 3600_000).toISOString() });
+
+  test("按档分桶,且总数守恒", () => {
+    const a = summarizeOfflineAges(
+      [at(0.5), at(0.9), at(3), at(23), at(30), at(71), at(73), at(500), { last_seen_at: null }],
+      now,
+    );
+    expect(a).toEqual({ under1h: 2, h1to24: 2, d1to3: 2, over3d: 2, unknown: 1, total: 9 });
+    expect(a.under1h + a.h1to24 + a.d1to3 + a.over3d + a.unknown).toBe(a.total);
+  });
+
+  test("🔴 无时间戳落在 unknown,绝不落进 under1h", () => {
+    const a = summarizeOfflineAges([{ last_seen_at: null }, { last_seen_at: "垃圾" }, {}], now);
+    expect(a.unknown).toBe(3);
+    expect(a.under1h).toBe(0);
+  });
+
+  test("边界用边界值校准,不用生产值:1h / 24h / 72h 各自落在哪一侧", () => {
+    expect(summarizeOfflineAges([at(0.999)], now).under1h).toBe(1);
+    expect(summarizeOfflineAges([at(1.001)], now).h1to24).toBe(1);
+    expect(summarizeOfflineAges([at(23.999)], now).h1to24).toBe(1);
+    expect(summarizeOfflineAges([at(24.001)], now).d1to3).toBe(1);
+    expect(summarizeOfflineAges([at(71.999)], now).d1to3).toBe(1);
+    expect(summarizeOfflineAges([at(72.001)], now).over3d).toBe(1);
+  });
+
+  test("用那条真实 last_seen_at:4 分钟前 ⇒ under1h(而不是 8 小时前的 h1to24)", () => {
+    // 若解析退回本地时区(UTC+8),它会变成 ~8 小时前 ⇒ 落进 h1to24,这条就红。
+    const a = summarizeOfflineAges([{ last_seen_at: RAW }], now);
+    expect(a.under1h).toBe(1);
+    expect(a.h1to24).toBe(0);
+  });
+
+  test("空集返回全 0,不抛", () => {
+    expect(summarizeOfflineAges([], now)).toEqual({ under1h: 0, h1to24: 0, d1to3: 0, over3d: 0, unknown: 0, total: 0 });
+  });
+});
+
+describe("formatOfflineAges", () => {
+  test("空集返回空串 —— 调用方据此不印那一行", () => {
+    expect(formatOfflineAges(summarizeOfflineAges([], Date.now()))).toBe("");
+  });
+
+  test("只列非零的档", () => {
+    const s = formatOfflineAges({ under1h: 0, h1to24: 0, d1to3: 18, over3d: 27, unknown: 0, total: 45 });
+    expect(s).toBe("18 掉线 1-3 天, 27 掉线超过 3 天");
+    expect(s).not.toContain("1 小时");
+  });
+
+  test("无时间戳那一档要说出「不知道」,不能沉默", () => {
+    expect(formatOfflineAges({ under1h: 0, h1to24: 0, d1to3: 0, over3d: 0, unknown: 4, total: 4 }))
+      .toContain("不知道掉了多久");
+  });
+});

--- a/agent-network/src/offline-age.ts
+++ b/agent-network/src/offline-age.ts
@@ -1,0 +1,64 @@
+/**
+ * #1648 — 名册上「刚停的节点」和「掉了三天没人发现的节点」渲染成同一个数字。
+ *
+ * `anet status` 原先只印 `N offline`。实测（2026-08-31，84 台 TM 相关节点）:
+ * 45 台 offline 里 27 台 >3 天、18 台 1–3 天、**近 6 小时内 0 台** ——
+ * 「当前没有活故障」和「有 45 台掉了」是完全不同的两个结论，而屏幕上只有后者。
+ */
+
+/**
+ * 🔴 hub 存的 `last_seen_at` 是 **UTC**，但字符串里**没有时区标记**
+ * （形如 `2026-08-30 21:11:24`）。直接 `new Date(raw)` 会被当成**本地时间**：
+ * 在 UTC+8 上就是整整 8 小时的偏差，而且它**不会报错** —— 只会把「4 分钟前」
+ * 读成「8 小时前」。这个错本人在 2026-08-31 亲自犯过一次，差点把
+ * 「舰队心跳陈旧」报出去。
+ */
+export function parseHubTimestamp(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  if (!/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/.test(t)) return null;
+  const hasZone = /([Zz]|[+-]\d{2}:?\d{2})$/.test(t);
+  const ms = Date.parse(t.replace(" ", "T") + (hasZone ? "" : "Z"));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export type OfflineAges = {
+  under1h: number; h1to24: number; d1to3: number; over3d: number;
+  /** 🔴 没有可用时间戳的那些必须单独一格,不能并进任何一档 —— 见下 */
+  unknown: number;
+  total: number;
+};
+
+const H = 3600_000;
+
+export function summarizeOfflineAges(
+  offline: ReadonlyArray<{ last_seen_at?: unknown }>,
+  nowMs: number,
+): OfflineAges {
+  const a: OfflineAges = { under1h: 0, h1to24: 0, d1to3: 0, over3d: 0, unknown: 0, total: 0 };
+  for (const s of offline) {
+    a.total++;
+    const ms = parseHubTimestamp(s?.last_seen_at);
+    // 🔴 兜底必须落在 `unknown`,不能落在任何一个具体档位。「我不知道它掉了多久」
+    //    和「它刚掉」是两件事,把前者算进 under1h 会让一台失联很久的节点看起来最新鲜。
+    if (ms === null) { a.unknown++; continue; }
+    const h = (nowMs - ms) / H;
+    if (h < 1) a.under1h++;
+    else if (h < 24) a.h1to24++;
+    else if (h < 72) a.d1to3++;
+    else a.over3d++;
+  }
+  return a;
+}
+
+/** 返回空串表示「没有值得多说一句的东西」，调用方据此决定印不印。 */
+export function formatOfflineAges(a: OfflineAges): string {
+  if (a.total === 0) return "";
+  const parts: string[] = [];
+  if (a.under1h) parts.push(`${a.under1h} 掉线不到 1 小时`);
+  if (a.h1to24) parts.push(`${a.h1to24} 掉线 1-24 小时`);
+  if (a.d1to3) parts.push(`${a.d1to3} 掉线 1-3 天`);
+  if (a.over3d) parts.push(`${a.over3d} 掉线超过 3 天`);
+  if (a.unknown) parts.push(`${a.unknown} 无时间戳(不知道掉了多久)`);
+  return parts.join(", ");
+}


### PR DESCRIPTION
## 问题

`anet status` 原先只印 `N offline`。而实测（2026-08-31，84 台 TM 相关节点）：

| 离线时长 | 台数 |
|---|---|
| **< 6 小时** | **0** |
| 1–3 天 | 18 |
| > 3 天 | 27 |

**「当前没有活故障」和「有 45 台掉了」是完全不同的两个结论，而屏幕上只有后者。**

与 `#1548` 的 `blocked` 不同，这一格是**算得出来的**：offline 节点的 `last_seen_at` 就是它最后一次心跳；而「何时变成 blocked」根本没有字段 —— 所以 `#1644` 里明确**没有**给 blocked 加时长。

新输出：

```
  Agents: 127 idle, 0 working, 1 needs attention, 143 offline
          └─ 18 掉线 1-3 天, 27 掉线超过 3 天
```

## 🔴 本次最值钱的一条：`bun test` 强制 UTC，让这个模块的缺陷结构上不可见

hub 存的 `last_seen_at` 是 **UTC 但不带时区标记**（`2026-08-30 21:11:24`）。`new Date()` 会当**本地时间**解析 —— 在 UTC+8 上整整差 8 小时，**且不报错**。

而：

| 环境 | `getTimezoneOffset()` | 无 `Z` vs 有 `Z` |
|---|---|---|
| `bun test` | **0（强制 UTC）** | **差 0 小时** |
| 普通进程（生产） | `-480` | **差 8 小时** |

⇒ **补 Z 与不补，在测试进程里解析出同一个数。** 实测：把 `+ (hasZone ? "" : "Z")` 改成 `+ ""`，**11 条测试全绿**。

这是"测试写成了观察不到缺陷的形状"，**只有变异见证能发现**。

**修法**：那一条断言改为开一个 `TZ=Asia/Shanghai` 的子进程，并且**先断言子进程真的不在 UTC**（`offset !== 0`）—— 否则 TZ 被忽略时它又变成空测试。

**变异见证**：`12 pass` → 变异后 `11 pass 1 fail` → 还原 `12 pass`。

> 这个错本人当天亲自犯过一次（把 UTC 读成本地，得出「舰队心跳陈旧 8.3 小时」，实际 **4 分钟**），所以判据写死在测试里。

## 其他

- 无时间戳的 offline 节点单独归入 `unknown` 并明说「不知道掉了多久」，**不并进 `under1h`** —— 兜底不能朝好的一侧。
- 边界用 `0.999h / 1.001h / 23.999h / 24.001h / 71.999h / 72.001h` 校准，不用生产值。
- 已核 `/api/status`（非 `light=1`）确实返回 `last_seen_at`：它在 `SESSION_REST_COLUMNS`（`server/src/rest-projections.ts:21`），不在 `AUDIT_LOG_*` 等同名邻居里。
- `check-doc-symbol-pins.py` `rc=0`（cli.ts 加了行）。

Refs #1648