### PR TITLE
fix(#1650): 服务端两处按 UTC 解析 hub 的无时区时间戳

### DIFF
--- a/server/src/hub-timestamp.test.ts
+++ b/server/src/hub-timestamp.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseHubTimestamp } from "./hub-timestamp";
+
+const RAW = "2026-08-30 21:11:24";                    // sessions.last_seen_at 的真实取值
+const TRUE_UTC = Date.UTC(2026, 7, 30, 21, 11, 24);
+
+describe("parseHubTimestamp (#1650)", () => {
+  test("🔴 非 UTC 时区下也必须解出同一个 UTC 时刻", () => {
+    // `bun test` 把测试进程时区固定成 UTC(getTimezoneOffset() === 0)。
+    // 在 UTC 下,「补 Z」和「不补 Z」解析出**同一个数** —— 这个函数存在的那个
+    // 缺陷在测试进程里**结构上不可见**。所以这一条必须开 TZ≠UTC 的子进程。
+    // 实测:去掉补 Z,本文件其余各条**全绿**。
+    const child = `import { parseHubTimestamp } from ${JSON.stringify(import.meta.dir + "/hub-timestamp.ts")};
+process.stdout.write(new Date().getTimezoneOffset() + "," + parseHubTimestamp(${JSON.stringify(RAW)}));`;
+    const r = Bun.spawnSync(["bun", "-e", child], { env: { ...process.env, TZ: "Asia/Shanghai" } });
+    const [offset, parsed] = r.stdout.toString().trim().split(",");
+    // 🔴 先断言控制生效:子进程真的不在 UTC。否则 TZ 被忽略时这条又变成空测试。
+    expect(Number(offset)).not.toBe(0);
+    expect(parsed).toBe(String(TRUE_UTC));
+  });
+
+  test("已带 Z / ±HH:MM 的串不再追加时区", () => {
+    expect(parseHubTimestamp("2026-08-30T21:11:24Z")).toBe(TRUE_UTC);
+    expect(parseHubTimestamp("2026-08-30T22:11:24+01:00")).toBe(TRUE_UTC);
+  });
+
+  test("拿不到就返回 null,不返回一个看起来合理的数", () => {
+    for (const bad of [undefined, null, "", "  ", 0, 1788124284000, {}, [], "2026-08-30", "垃圾"]) {
+      expect(parseHubTimestamp(bad as unknown)).toBeNull();
+    }
+  });
+
+  test("🔴 INTEGER 列(epoch 毫秒)不归它管 —— 传数字必须返回 null,而不是悄悄接受", () => {
+    // external_schedule_edits.* 是 INTEGER。如果有人把本函数用在那儿,
+    // 应当立刻拿到 null 而不是一个错的时刻。
+    expect(parseHubTimestamp(TRUE_UTC)).toBeNull();
+  });
+});

--- a/server/src/hub-timestamp.ts
+++ b/server/src/hub-timestamp.ts
@@ -1,0 +1,27 @@
+/**
+ * #1650 — hub 的 TEXT 时间戳列是 SQLite `datetime('now')` 写的，
+ * 形如 `2026-08-30 21:11:24`：**UTC，但不带任何时区标记**。
+ *
+ * 🔴 `new Date(raw)` / `Date.parse(raw)` 对这种串按**本地时间**解析（ES 规范：
+ *    带时间的形式无偏移时视为本地时间），误差恰好等于主机时区偏移，**而且不报错**：
+ *
+ *      TZ=UTC                   误差  0h
+ *      TZ=Asia/Shanghai         误差 -8h   （看起来更陈旧）
+ *      TZ=America/Los_Angeles   误差 +7h   （看起来更新鲜 ← 朝好的一侧错）
+ *
+ * 🔴 **只对 TEXT 列用它。** 同一个字段名在不同表里可能是不同类型：
+ *      sessions.last_seen_at / licenses.expires_at   → TEXT（要用本函数）
+ *      external_schedule_edits.expires_at 等 4 列     → INTEGER（epoch 毫秒，直接 new Date 就对）
+ *    按字段名判会判错 —— 见 #1650 里的更正。
+ *
+ * 与 agent-network 侧的同名函数是**有意的重复**：server 包不依赖 agent-network，
+ * 仓里也没有共享 lib。两边各自带测试。
+ */
+export function parseHubTimestamp(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  if (!/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/.test(t)) return null;
+  const hasZone = /([Zz]|[+-]\d{2}:?\d{2})$/.test(t);
+  const ms = Date.parse(t.replace(" ", "T") + (hasZone ? "" : "Z"));
+  return Number.isFinite(ms) ? ms : null;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -56,6 +56,7 @@ import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 import { SIDE_THREAD_FEATURE_FLAG, SideThreadCoordinator, SideThreadPortRegistry, SideThreadStore, type SideThreadActor, type SideThreadAttachmentRef, type SideThreadExecutionPort } from "./side-thread.js";
 import { handleSideThreadHttpRequest } from "./side-thread-http.js";
 import { createProductionSideThreadTransport } from "./side-thread-production.js";
+import { parseHubTimestamp } from "./hub-timestamp";
 
 const PORT = resolvePort(process.env.PORT);
 const HOST = process.env.HOST || "127.0.0.1";
@@ -1002,9 +1003,13 @@ return Bun.serve({
       if (!license) return withCors(req, Response.json({ ok: true, status: "no_license" }));
       const now = new Date().toISOString().replace("T", " ").slice(0, 19);
       const expired = license.expires_at && license.expires_at < now;
-      const daysLeft = license.expires_at
-        ? Math.max(0, Math.ceil((new Date(license.expires_at).getTime() - Date.now()) / 86400000))
-        : null;
+      // #1650 — licenses.expires_at 是 TEXT(datetime('now') 家族),UTC 但不带时区
+      //   标记;`new Date()` 会按本机时区解析,边界上差一天。parse 失败时返回 null
+      //   而不是 NaN —— JSON.stringify(NaN) 本来也序列化成 null,线上字节不变。
+      const expiresMs = parseHubTimestamp(license.expires_at);
+      const daysLeft = expiresMs === null
+        ? null
+        : Math.max(0, Math.ceil((expiresMs - Date.now()) / 86400000));
       return withCors(req, Response.json({
         ok: true,
         license: { type: license.type, expires_at: license.expires_at, days_left: daysLeft, expired },

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -61,6 +61,7 @@ import {
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
 import { clientRequestIdFromMeta, idempotentTaskId, idempotentTaskMatches, type StoredIdempotentTask } from "./task-idempotency.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
+import { parseHubTimestamp } from "./hub-timestamp";
 
 function ts(): string {
   return new Date().toTimeString().slice(0, 8);
@@ -3325,8 +3326,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
               "SELECT last_seen_at FROM sessions WHERE node_id = ?1 ORDER BY last_seen_at DESC LIMIT 1",
               daemon_node_id,
             );
-            const t = sess?.last_seen_at ? Date.parse(sess.last_seen_at) : NaN;
-            if (Number.isFinite(t)) heartbeatAgeMs = Math.max(0, Date.now() - t);
+            // #1650 — 这一列是 TEXT(`datetime('now')`),UTC 但不带时区标记。
+            //   Date.parse 会按**本机时区**解析,误差 = 主机偏移(生产 hub 在 UTC+8
+            //   时这个诊断数字整整偏 8 小时)。走 parseHubTimestamp 显式按 UTC 解。
+            const t = parseHubTimestamp(sess?.last_seen_at);
+            if (t !== null) heartbeatAgeMs = Math.max(0, Date.now() - t);
           } catch { /* 取不到就是取不到 —— 下面如实说 unknown,不猜 0 */ }
 
           // 🔴 三种取值,不能塌成两种:


### PR DESCRIPTION
## 问题

hub 的 TEXT 时间戳列由 SQLite `datetime('now')` 写入 —— `2026-08-30 21:11:24`，**UTC 但不带任何时区标记**。`new Date()` 对这种串按**本机时区**解析，误差 = 主机偏移，**且不报错**：

| TZ | 误差 | |
|---|---|---|
| UTC | 0h | |
| Asia/Shanghai | −8h | 看起来更陈旧 |
| America/Los_Angeles | +7h | **看起来更新鲜 ← 朝好的一侧错** |

## 本次改两处（都读 TEXT 列）

| 位置 | 影响 |
|---|---|
| `server/src/tools.ts:3328`（`sessions.last_seen_at` → `heartbeatAgeMs`） | 这个数是「daemon 为什么建不了节点」的**诊断值**，生产 hub 在 UTC+8，它一直偏 **8 小时** |
| `server/src/server.ts:1006`（`licenses.expires_at` → `days_left`） | 边界差一天 |

`days_left` 在 parse 失败时改返回 `null` 而不是 `NaN` —— `JSON.stringify(NaN)` 本来也序列化成 `null`，**线上字节不变**。

## 🔴 只对 TEXT 列用它 —— 同名字段在不同表里类型不同

| 表 | 列 | 类型 |
|---|---|---|
| `sessions` / `licenses` | `last_seen_at` / `expires_at` | **TEXT** → 用本函数 |
| `external_schedule_edits` | `expires_at`/`created_at`/`delivered_at`/`acked_at` | **INTEGER**（epoch 毫秒） → 直接 `new Date` 就对 |

我在 `#1650` 里**按字段名判过一次，判错了 2 处**，已在该 issue 下公开更正。所以本函数**收到数字返回 `null`**，并有测试钉住这一条。

## 🔴 测试必须开 `TZ≠UTC` 的子进程

`bun test` 把测试进程时区固定成 UTC（`getTimezoneOffset() === 0`）。在 UTC 下「补 Z」和「不补 Z」解析出**同一个数** —— 这个缺陷在测试进程里**结构上不可见**。

子进程里还**先断言 `offset !== 0`**，否则 TZ 被忽略时那条又变成空测试。

**变异见证**：

| 变异 | 结果 |
|---|---|
| 不补 Z | `3 pass 1 fail` |
| 悄悄接受数字 | `2 pass 2 fail` |
| 还原 | `4 pass 0 fail`（文件逐字还原） |

## 为什么和 agent-network 侧重复

`server` 包不依赖 `agent-network`（deps 只有 `@modelcontextprotocol/sdk` / `bun-types` / `hono` / `zod`），仓里也没有共享 lib 目录。**有意的重复**，两边各自带测试。

## 单变量对照

`scheduled-tasks-http.test.ts` 改动**前后同为** `0 pass 1 fail`，失败原文是 `REFUSING to open the default SQLite database under NODE_ENV=test` —— 需要套件夹具设 `COMMHUB_DB`，与本改动无关。

Refs #1650