### PR TITLE
fix(#1650): 重启后的心跳新鲜度校验按 UTC 解析 —— 三处里错向最坏的一处

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -36,7 +36,7 @@ import {
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { classifySessionStatus, summarizeSessions } from "../src/session-status-class";
-import { formatOfflineAges, summarizeOfflineAges } from "../src/offline-age";
+import { formatOfflineAges, parseHubTimestamp, summarizeOfflineAges } from "../src/offline-age";
 import { formatCliVersion } from "../src/cli-version-display";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
@@ -9187,7 +9187,12 @@ async function verifyNodeRestarted(
         const res = await fetch(url, { headers: authHeaders(token) }).then(r => r.json() as any);
         const node = (res.sessions || []).find((s: any) => s.alias === newName || s.node_name === newName);
         if (node) {
-          const ts = Date.parse(node.last_seen_at || node.updated_at || "") || 0;
+          // 🔴 #1650 —— 这两列是 hub 的 TEXT 时间戳(`datetime('now')`),UTC 但**不带
+          //   时区标记**。`Date.parse` 会按本机时区解析,误差 = 主机偏移,而且不报错:
+          //     TZ=Asia/Shanghai  -8h → ts 偏早 → fresh 恒 false(只是拿不到强信号)
+          //     TZ=America/*      +7h → ts 偏晚 → **fresh 恒 true** ← 这道校验被静默放行
+          //   西于 UTC 的主机上,「重启后 hub 心跳有没有刷新」这一格等于没在判。
+          const ts = parseHubTimestamp(node.last_seen_at) ?? parseHubTimestamp(node.updated_at) ?? 0;
           fresh = ts >= restartStartedAt;
         }
       } catch {}

--- a/agent-network/src/offline-age.test.ts
+++ b/agent-network/src/offline-age.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 import { formatOfflineAges, parseHubTimestamp, summarizeOfflineAges } from "./offline-age";
 
@@ -94,5 +95,23 @@ describe("formatOfflineAges", () => {
   test("无时间戳那一档要说出「不知道」,不能沉默", () => {
     expect(formatOfflineAges({ under1h: 0, h1to24: 0, d1to3: 0, over3d: 0, unknown: 4, total: 4 }))
       .toContain("不知道掉了多久");
+  });
+});
+
+describe("接线守卫 (#1650)", () => {
+  // 🔴 今天的教训:纯函数的单测**看不见调用点**。这一条读 cli.ts 的字节,
+  //    确保没人把那两个 hub TEXT 时间戳换回裸 Date.parse ——
+  //    换回去在 UTC 的 CI 上照样全绿,只在非 UTC 主机上错,且不报错。
+  //    范围只限这一个文件:全仓级的门在 #1650 里量过,11 命中 / 3 真缺陷,
+  //    73% 误报,不该做;单文件这一格当前是 0 误报。
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8");
+
+  test("cli.ts 不再对 last_seen_at / updated_at 用裸 Date.parse", () => {
+    expect(cli).not.toContain("Date.parse(node.last_seen_at");
+    expect(cli).not.toContain("Date.parse(node.updated_at");
+  });
+
+  test("而且它确实调用了 parseHubTimestamp —— 「没有裸解析」也可能是整段被删了", () => {
+    expect(cli).toContain("parseHubTimestamp(node.last_seen_at)");
   });
 });


### PR DESCRIPTION
## 这一处的错向最坏：**西半球主机上校验恒真**

```ts
const ts = Date.parse(node.last_seen_at || node.updated_at || "") || 0;
fresh = ts >= restartStartedAt;
```

这两列是 hub 的 TEXT 时间戳（SQLite `datetime('now')`），**UTC 但不带时区标记**。`Date.parse` 按本机时区解析，误差 = 主机偏移，**且不报错**：

| TZ | 误差 | `fresh` |
|---|---|---|
| `Asia/Shanghai` | −8h → ts 偏早 | 恒 `false`（只是拿不到强信号） |
| `America/*` | +7h → ts 偏晚 | **恒 `true`** ← **这道校验被静默放行** |

**西于 UTC 的主机上，「重启后 hub 心跳有没有刷新」这一格等于没在判。** 兜底朝好的一侧，是 `#1650` 三处真缺陷里错向最坏的。

**行为保持**：两列都解不出时 `ts = 0`（原来是 `NaN || 0 → 0`），`0 >= restartStartedAt` 仍为 `false`。

## 顺带加了一条接线守卫

纯函数的单测**看不见调用点** —— 我今天在 `#1646` 上栽过一次（改动根本没落地，而新模块的测试照样全绿）。

守卫读 `cli.ts` 的字节，**同时**断言两件事：

```ts
expect(cli).not.toContain("Date.parse(node.last_seen_at");   // 没有裸解析
expect(cli).toContain("parseHubTimestamp(node.last_seen_at)"); // 而且确实调用了
```

🔴 只断言前者的话，**整段被删掉也是绿的**。

**范围只限这一个文件**：全仓级的门在 `#1650` 里量过 —— 11 命中 / 3 真缺陷 = **73% 误报**，不该做；单文件这一格当前 **0 误报**。

## 变异见证

把调用点换回裸 `Date.parse` → `14 pass` 变 **`12 pass 2 fail`**；还原 → `14 pass`（`cli.ts` 逐字还原）。

`check-doc-symbol-pins.py` `rc=0`。

---

至此 **`#1650` 的三处全部修完**（`tools.ts` / `server.ts` 在 `#1651`）。

Refs #1650