### PR TITLE
docs(cli): anet status 的 offline 分档 + daemon 的停/删/看去哪找

### DIFF
--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -199,6 +199,7 @@ See the [Upgrade guide](/en/guide/upgrade) for upgrade details.
 ```
   CommHub: http://127.0.0.1:9200
   Agents: 127 idle, 0 working, 1 needs attention, 143 offline
+          └─ 18 offline for 1-3 days, 27 offline for more than 3 days
   SSE:    12 connected
   Tasks:  10 recent
 ```
@@ -209,6 +210,23 @@ See the [Upgrade guide](/en/guide/upgrade) for upgrade details.
 | `working` | **Actively progressing** a turn (includes `waiting_input` — the turn is alive, just waiting on a human) |
 | `needs attention` | **Someone should look**: `blocked` / `error`, plus any status this version does not recognise |
 | `offline` | Heartbeat expired, or stopped cleanly |
+
+### The line under `offline`: how long have they been gone
+
+When there are offline nodes, a breakdown line is printed. **"Just stopped" and "gone for three days
+and nobody noticed" used to be the same number.** Measured once over 84 nodes: of 45 offline, 27 had
+been gone more than 3 days, 18 for 1-3 days, and **none within the last 6 hours** — "there is no live
+outage right now" and "45 nodes are down" are two completely different conclusions, and only the
+second one was on screen.
+
+Nodes with no usable timestamp go into their own "no timestamp (we do not know how long)" bucket and
+are **not** folded into the freshest one — "I do not know how long it has been gone" and "it just went
+down" are different things.
+
+🔴 **`blocked` has no matching duration, and should not have one.** The roster has no "when did it
+become blocked" field; `updated_at` keeps being refreshed by the heartbeat, so using it as a
+blocked-duration prints "4 minutes ago" for a node stuck for hours — worse than showing nothing.
+See [Is this node still alive](/en/troubleshooting/is-this-node-alive).
 
 The four add up to the node total. The `needs attention` slot is hidden when it is 0.
 
@@ -230,9 +248,15 @@ The following commands exist in the current preview and must not be presented as
 | Command | Purpose |
 |---|---|
 | `anet daemon up [name]` | Create and start a `host_supervisor` — **preview channel only** |
-| `anet daemon init <name>` / `start <name>` / `list` | Manage local daemons — **preview channel only** |
+| `anet daemon init <name>` / `start <name>` / `restart <name>` / `list` | Manage local daemons — **preview channel only** |
 | `anet node start <name> --copresence` | Start Codex app-server, bridge, and shared TUI |
 | `anet opencode ...` | Manage the preview OpenCode integration |
+
+🔴 **There is no daemon-level stop / delete / status.** A daemon is just an agent-node with
+`role=host_supervisor`, so use the node-level commands: `anet node stop <name>` to stop it,
+`anet node delete <name>` to remove it, `anet node ls` to see whether it is running
+(`anet daemon list` only lists locally configured daemons and carries no liveness).
+`anet daemon restart` calls that same stop internally.
 
 `--copresence` only applies to `runtime=codex-app-server`. Its default sandbox is read-only. Full filesystem and network access requires `--dangerously-allow-full-access`; a TTY requires typing `yes`, and a non-TTY caller must also pass `--yes-danger-full-access`.
 

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -199,6 +199,7 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 ```
   CommHub: http://127.0.0.1:9200
   Agents: 127 idle, 0 working, 1 needs attention, 143 offline
+          └─ 18 掉线 1-3 天, 27 掉线超过 3 天
   SSE:    12 connected
   Tasks:  10 recent
 ```
@@ -211,6 +212,21 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 | `offline` | 心跳过期,或已正常停止 |
 
 四个数相加等于节点总数。`needs attention` 为 0 时那一格不显示。
+
+### `offline` 下面那一行:它掉了多久
+
+有 offline 节点时会多印一行分档。**「刚停的」和「掉了三天没人发现的」原先是
+同一个数字。**实测过一次(84 台节点):45 台 offline 里 27 台超过 3 天、
+18 台 1-3 天、**近 6 小时内 0 台** —— 「当前没有活故障」和「有 45 台掉了」
+是完全不同的两个结论,而屏幕上原本只有后者。
+
+拿不到时间戳的节点单独归入「无时间戳(不知道掉了多久)」,**不并进最新那一档**
+—— 「我不知道它掉了多久」和「它刚掉」是两件事。
+
+🔴 **`blocked` 没有对应的时长,而且不该有。** 名册里没有「何时变成 blocked」
+这个字段;`updated_at` 被心跳一直刷,拿它当已 blocked 时长,会给一个卡了很久的
+节点印出「4 分钟前」—— 比不显示更糟。详见
+[这个节点还活着吗](/troubleshooting/is-this-node-alive)。
 
 🔴 **`blocked` / `error` 不算在 `working` 里。** 它们的含义是「卡住了」而不是
 「在干活」—— 一个卡住的节点如果被算进 `working`,运维看到「N working」会以为
@@ -229,9 +245,14 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 | 命令 | 作用 |
 |---|---|
 | `anet daemon up [name]` | 创建并启动 `host_supervisor` —— **仅 preview 通道** |
-| `anet daemon init <name>` / `start <name>` / `list` | 管理本机 daemon —— **仅 preview 通道** |
+| `anet daemon init <name>` / `start <name>` / `restart <name>` / `list` | 管理本机 daemon —— **仅 preview 通道** |
 | `anet node start <name> --copresence` | 启动 Codex app-server、桥和共享 TUI |
 | `anet opencode ...` | 管理 OpenCode preview 集成 |
+
+🔴 **停 / 删 / 看没有 daemon 版。** daemon 就是一个 `role=host_supervisor` 的 agent-node,
+所以用 node 级命令:`anet node stop <name>` 停、`anet node delete <name>` 删、
+`anet node ls` 看它在不在跑(`anet daemon list` 只列本机配置过的 daemon,不含活性)。
+`anet daemon restart` 内部调的正是 `anet node stop` 用的那个 stop。
 
 `--copresence` 只适用于 `runtime=codex-app-server`。默认沙箱为只读；开启完整文件系统和网络访问需要 `--dangerously-allow-full-access`。TTY 会要求输入 `yes`，非 TTY 还必须同时提供 `--yes-danger-full-access`。
 


### PR DESCRIPTION
两处，中英双份。

## ① `anet status` 的 offline 分档（跟进已合的 #1649）

```
  Agents: 127 idle, 0 working, 1 needs attention, 143 offline
          └─ 18 掉线 1-3 天, 27 掉线超过 3 天
```

文档说明「**刚停的**」和「**掉了三天没人发现的**」原先是同一个数字。实测（84 台节点）：45 台 offline 里 **27 台 >3 天、18 台 1–3 天、近 6 小时内 0 台** —— 「当前没有活故障」和「有 45 台掉了」是完全不同的两个结论。

并写明：

- 拿不到时间戳的**单独归入**「不知道掉了多久」，**不并进最新那一档**；
- 🔴 **`blocked` 没有对应时长，而且不该有** —— 名册里没有「何时变成 blocked」这个字段，`updated_at` 被心跳一直刷，拿它当已 blocked 时长会给卡了很久的节点印出「4 分钟前」。

## ② Preview 表里 daemon 那一行漏了 `restart`

`main` 上确实有 `anet daemon restart`，表里没列。补上，并在表下加一段：

> **停 / 删 / 看没有 daemon 版。** daemon 就是一个 `role=host_supervisor` 的 agent-node，所以用 node 级命令 —— `anet daemon restart` 内部调的正是 `anet node stop` 用的那个 stop。

这和 `#1652` 在 CLI 里修的是同一件事（用户敲 `anet daemon stop` 原先什么提示都没有），文档这边同步。

## 一个写法上的选择

避开了在反引号内用转义竖线：表格里 `\|` 在代码段内是否被还原**取决于解析器顺序**，改成表下的一段说明，不依赖它。

文档门：`docs-integrity` / `doc-version-claims` / `no-memory-slugs` / `doc-symbol-pins` 全 `rc=0`。

> ⚠️ 合入后**用户仍看不到** —— anet.sh 的自动部署因 `VERCEL_TOKEN` 未配一直静默跳过（#1619）。

Refs #1648, #1649, #1652