### PR TITLE
feat(doctor): 三个 runtime CLI 报出实际版本 —— 「装着但太旧」原先拿到的是 ✅

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -37,6 +37,7 @@ import {
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { classifySessionStatus, summarizeSessions } from "../src/session-status-class";
 import { formatOfflineAges, summarizeOfflineAges } from "../src/offline-age";
+import { formatCliVersion } from "../src/cli-version-display";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
@@ -15889,9 +15890,15 @@ async function doctorCommand() {
   }
 
   // 4. Dependencies
-  try { execSync("claude --version", { stdio: "pipe" }); check("Claude Code CLI", true); } catch { warning("Claude Code CLI", "not found (needed for claude-code-cli runtime)"); }
-  try { execSync("codex --version", { stdio: "pipe" }); check("Codex CLI", true); } catch { warning("Codex CLI", "not found (needed for codex-sdk runtime)"); }
-  try { execSync("bun --version", { stdio: "pipe" }); check("Bun runtime", true); } catch { warning("Bun", "not found (needed for commhub-server)"); }
+  // 🔴 #1645 —— 原先这三行只检查「在不在」,一个**装着但太旧**的 CLI 会拿到 ✅。
+  //    实测:`codex-cli 0.149.1` 解不动上游 models 响应(`unknown variant \`max\``),
+  //    rmcp worker 致命退出,用户看到的是 300s 超时 —— 而 doctor 说一切正常。
+  //    这里把实际版本摆出来。**不做最低版本判定**:够不够由上游返回什么决定,
+  //    不是我们能钉死的常量,猜一个下限会在别人升级后变成误报。
+  const cliVer = (cmd: string) => formatCliVersion(String(execSync(cmd, { stdio: "pipe" })));
+  try { check("Claude Code CLI", true, cliVer("claude --version")); } catch { warning("Claude Code CLI", "not found (needed for claude-code-cli runtime)"); }
+  try { check("Codex CLI", true, cliVer("codex --version")); } catch { warning("Codex CLI", "not found (needed for codex-sdk runtime)"); }
+  try { check("Bun runtime", true, cliVer("bun --version")); } catch { warning("Bun", "not found (needed for commhub-server)"); }
 
   // 5. .mcp.json
   const mcpPath = join(process.cwd(), ".mcp.json");

--- a/agent-network/src/cli-version-display.test.ts
+++ b/agent-network/src/cli-version-display.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { formatCliVersion } from "./cli-version-display";
+
+describe("formatCliVersion (#1645)", () => {
+  test("三家真实输出原样保留 —— 不解析、不归一", () => {
+    expect(formatCliVersion("codex-cli 0.149.1\n")).toBe("codex-cli 0.149.1");
+    expect(formatCliVersion("1.4.0")).toBe("1.4.0");
+    expect(formatCliVersion("2.0.1 (Claude Code)\n")).toBe("2.0.1 (Claude Code)");
+  });
+
+  test("多行只取第一行非空", () => {
+    expect(formatCliVersion("\n\n  codex-cli 0.149.1  \nsome banner\n")).toBe("codex-cli 0.149.1");
+  });
+
+  test("🔴 拿不到就说「版本未输出」,不返回空串", () => {
+    // 空串会让输出变成 `✅ Codex CLI ()` —— 一个看起来像有值的空括号。
+    for (const bad of ["", "   \n \n", undefined, null, 123, {}]) {
+      expect(formatCliVersion(bad as unknown)).toBe("版本未输出");
+    }
+  });
+
+  test("超长输出截断并带省略号(有些 CLI 会打一整段横幅)", () => {
+    const long = "x".repeat(200);
+    const out = formatCliVersion(long);
+    expect(out.length).toBe(60);
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  test("边界用边界值校准:60 不截断,61 截断", () => {
+    expect(formatCliVersion("y".repeat(60))).toBe("y".repeat(60));
+    expect(formatCliVersion("y".repeat(61))).toBe(`${"y".repeat(57)}...`);
+  });
+});
+
+describe("接线守卫", () => {
+  // 🔴 纯函数的单测看不见调用点。剥掉注释行再断言 —— 源码里既有那个东西,
+  //    也有关于它的说明(今天在别的 PR 上因为这个基线直接红过一次)。
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  test("doctor 里三个 CLI 都带版本 detail", () => {
+    for (const cmd of ["claude --version", "codex --version", "bun --version"]) {
+      expect(cli).toContain(`cliVer("${cmd}")`);
+    }
+  });
+
+  test("🔴 而且确实用了 formatCliVersion —— 「带 detail」也可能是塞了个别的串", () => {
+    expect(cli).toContain("formatCliVersion(String(execSync(cmd");
+  });
+
+  test("🔴 不再有「只检查在不在」的旧写法", () => {
+    expect(cli).not.toContain('execSync("codex --version", { stdio: "pipe" }); check');
+  });
+});

--- a/agent-network/src/cli-version-display.ts
+++ b/agent-network/src/cli-version-display.ts
@@ -1,0 +1,23 @@
+/**
+ * #1645 —— `anet doctor` 原先对三个 runtime CLI **只检查「在不在」**:
+ *
+ *   try { execSync("codex --version", …); check("Codex CLI", true); } catch { … }
+ *
+ * 于是一个**装着、但太旧**的 CLI 会拿到一个 ✅。实测过一次:`codex-cli 0.149.1`
+ * 解不动上游 models 响应(`unknown variant \`max\``,它只认到 `xhigh`),
+ * rmcp worker 致命退出,用户看到的是 300s 超时 —— 而 doctor 说一切正常。
+ *
+ * 🔴 **这里只把版本摆出来,不做最低版本判定。**
+ *    「多少版本才够」由上游返回什么决定,不是我们能钉死的常量;猜一个下限,
+ *    会在别人升级 CLI、上游又改动之后变成误报。而一个会误报的检查,
+ *    第一周就会被人关掉。摆出实际版本,让读的人自己对得上号,是这一格
+ *    现在能诚实做到的全部。
+ */
+export function formatCliVersion(raw: unknown): string {
+  if (typeof raw !== "string") return "版本未输出";
+  // 各家格式不同:`codex-cli 0.149.1` / `1.4.0` / `2.0.1 (Claude Code)`。
+  // 不解析、不比较 —— 原样取第一行非空内容。
+  const first = raw.split("\n").map(l => l.trim()).find(l => l.length > 0);
+  if (!first) return "版本未输出";
+  return first.length > 60 ? `${first.slice(0, 57)}...` : first;
+}


### PR DESCRIPTION
## 问题

`anet doctor` 对三个 runtime CLI **只检查「在不在」**：

```ts
try { execSync("codex --version", …); check("Codex CLI", true); } catch { … }
```

于是一个**装着、但太旧**的 CLI 会拿到一个 ✅。实测过一次（`#1645`）：`codex-cli 0.149.1` 解不动上游 models 响应（`unknown variant \`max\``，它只认到 `xhigh`），rmcp worker 致命退出，**用户看到的是 300s 超时 —— 而 `anet doctor` 说一切正常**。

## 真机跑出来

```
✅ Claude Code CLI (2.1.251 (Claude Code))
✅ Codex CLI (codex-cli 0.149.1)      ← 正是 #1645 里那个版本
✅ Bun runtime (1.4.0)
```

**诊断 300s 超时的人，现在一眼就能看到它。**

## 🔴 只打印版本，不做最低版本判定

够不够**由上游返回什么决定**，不是我们能钉死的常量。猜一个下限，会在别人升级 CLI、上游又改动之后变成误报 —— 而一个会误报的检查第一周就会被关掉。

摆出实际版本、让读的人自己对上号，是这一格现在**能诚实做到的全部**。

## 格式化的几个决定

各家格式不同（`codex-cli 0.149.1` / `1.4.0` / `2.0.1 (Claude Code)`），所以**不解析、不比较**，原样取第一行非空：

- 拿不到时返回「版本未输出」**而不是空串** —— 空串会印成 `✅ Codex CLI ()`，一个看起来像有值的空括号
- 超长截断带省略号，边界用 **60 / 61** 校准（不用生产值）

## 接线守卫

同时断言三件事：三个命令都带 detail、**确实用了 `formatCliVersion`**（只查「带 detail」的话，塞个写死的串也是绿的）、旧写法残留为 0。

守卫读源码前**先剥掉注释行** —— 源码里既有那个东西，也有关于它的说明（今天因为这个基线直接红过一次）。

**变异见证**：把 detail 换成写死的 `"installed"` → `8 pass 0 fail` 变 **`7 pass 1 fail`**；还原 → `8 pass`（`cli.ts` 逐字还原）。

`check-doc-symbol-pins.py` `rc=0`。

Refs #1645