### PR TITLE
feat(doctor): CommHub 那一行同时摆出「hub 自报的版本」和「本机钉的版本」

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -41,6 +41,7 @@ import { formatCliVersion } from "../src/cli-version-display";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
+import { formatHubVersionDetail } from "../src/hub-version-skew";
 import { daemonSubcommandRedirect, nodeSubcommandRedirect, projectSubcommandRedirect } from "../src/subcommand-redirect";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
@@ -15771,7 +15772,11 @@ async function doctorCommand() {
   if (gc.hub) {
     try {
       const health = await fetch(`${gc.hub}/health`, { headers: authHeaders() }).then(r => r.json() as any);
-      check("CommHub reachable", health.ok === true, `${gc.hub} v${health.version || "?"}`);
+      // 🔴 #1595 —— 原先只印 hub 自报的版本,读的人看不到自己这台 CLI 钉的是哪个。
+      //   实测:生产 hub 在 .38,而 PINNED_SERVER_VERSION 是 .44,差 6 个版本。
+      //   只并排摆出两个数,**不判断谁对、不给阈值、不发警告** —— hub 比 pin
+      //   老或新都可能完全合理,猜一个「应该一致」的判据会在正常情况下误报。
+      check("CommHub reachable", health.ok === true, formatHubVersionDetail(gc.hub, health.version, PINNED_SERVER_VERSION));
       if (health.api_version) info("API version", health.api_version);
       info("Sessions", `${health.sessions_count || health.sessions || 0} registered`);
       info("SSE connections", `${health.sse_connections ?? 0} active`); // #473: aggregate stayed on /health

--- a/agent-network/src/hub-version-skew.test.ts
+++ b/agent-network/src/hub-version-skew.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { formatHubVersionDetail } from "./hub-version-skew";
+
+const HUB = "http://127.0.0.1:9200";
+const PIN = "0.9.0-preview.44";
+
+describe("formatHubVersionDetail (#1595)", () => {
+  test("一致时不多说一句", () => {
+    expect(formatHubVersionDetail(HUB, PIN, PIN)).toBe(`${HUB} v${PIN}`);
+  });
+
+  test("🔴 不一致时必须把 pin 也摆出来 —— 今天实测的那一对", () => {
+    const s = formatHubVersionDetail(HUB, "0.9.0-preview.38", PIN);
+    expect(s).toContain("v0.9.0-preview.38");
+    expect(s).toContain(PIN);
+  });
+
+  test("hub 比 pin 新也要说 —— 不是只报「旧」", () => {
+    // 判据是「不一致」,不是「更旧」。故意钉在旧版是合理用法。
+    expect(formatHubVersionDetail(HUB, "0.9.0-preview.99", PIN)).toContain(PIN);
+  });
+
+  test("拿不到版本时显示 ? 并仍摆出 pin", () => {
+    for (const bad of [undefined, null, "", "   ", 42, {}]) {
+      const s = formatHubVersionDetail(HUB, bad as unknown, PIN);
+      expect(s).toContain("v?");
+      expect(s).toContain(PIN);
+    }
+  });
+
+  test("🔴 不发警告、不给判定 —— 只有事实", () => {
+    const s = formatHubVersionDetail(HUB, "0.9.0-preview.38", PIN);
+    for (const word of ["警告", "过期", "应当", "必须", "不匹配", "mismatch", "outdated"]) {
+      expect(s).not.toContain(word);
+    }
+  });
+
+  test("空白被裁掉,不产生 v  的双空格", () => {
+    expect(formatHubVersionDetail(HUB, "  0.9.0-preview.38  ", PIN)).toContain("v0.9.0-preview.38；");
+  });
+});
+
+describe("接线守卫", () => {
+  // 剥掉注释行 —— 源码里既有那个东西,也有关于它的说明。
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  test("doctor 的 CommHub reachable 用了这个函数", () => {
+    expect(cli).toContain("formatHubVersionDetail(gc.hub");
+  });
+
+  test("🔴 旧的裸拼接不再存在 —— 「用了新函数」也可能是两处并存", () => {
+    expect(cli).not.toContain("`${gc.hub} v${health.version || \"?\"}`");
+  });
+});

--- a/agent-network/src/hub-version-skew.ts
+++ b/agent-network/src/hub-version-skew.ts
@@ -1,0 +1,29 @@
+/**
+ * #1595 —— `anet doctor` 原先只印 hub 自报的版本:
+ *
+ *   ✅ CommHub reachable (http://127.0.0.1:9200 v0.9.0-preview.38)
+ *
+ * 读的人**看不到自己这台 CLI 钉的是哪个**。实测(2026-08-31):生产 hub 在
+ * `.38`,而 `anet hub start` 的 `PINNED_SERVER_VERSION` 是 `.44` —— 两个数
+ * 差 6 个版本,而屏幕上只有一个。今天有一整条排查(agent→用户消息为什么
+ * 验不了端到端)就卡在这个差上:`.44` 之前 `send_desktop_message` 是
+ * fire-and-forget 且仍返回 `ok:true`,所以在 `.38` 上拿到的 `ok:true`
+ * 不是「用户看到了」的证据。
+ *
+ * 🔴 **只并排摆出两个数,不判断谁对、不给阈值、不发警告。**
+ *    hub 比 CLI 的 pin 老或新都可能完全合理 —— 连的是别人运维的 hub、
+ *    本机 hub 还没重启、或者故意钉在旧版。给一个猜出来的「应该一致」
+ *    判据,会在这些正常情况下变成误报,而一个会误报的检查第一周就会被关掉。
+ *    让读的人自己看见差在哪,是这一格能诚实做到的全部。
+ */
+export function formatHubVersionDetail(
+  hubUrl: string,
+  hubVersion: unknown,
+  pinnedVersion: string,
+): string {
+  const v = typeof hubVersion === "string" && hubVersion.trim() ? hubVersion.trim() : "?";
+  const base = `${hubUrl} v${v}`;
+  // 一致就不多说一句 —— 多数人的多数时候不需要看见 pin。
+  if (v === pinnedVersion) return base;
+  return `${base}；本机 anet hub start 钉 ${pinnedVersion}`;
+}


### PR DESCRIPTION
## 原先只印一个数

```
✅ CommHub reachable (http://127.0.0.1:9200 v0.9.0-preview.38)
```

读的人**看不到自己这台 CLI 钉的是哪个**。实测（2026-08-31）：生产 hub 在 `.38`，而 `PINNED_SERVER_VERSION` 是 **`.44`** —— 差 6 个版本，屏幕上只有一个。

**今天有一整条排查卡在这个差上**：agent→用户消息为什么验不了端到端 —— `.44` 之前 `send_desktop_message` 是 fire-and-forget 且**仍返回 `ok:true`**（`#1459`），所以在 `.38` 上拿到的 `ok:true` **不是**「用户看到了」的证据。那条差如果早在 `doctor` 里就摆出来，不需要读源码才发现。

## 🔴 只摆事实，不判断

hub 比 pin 老或新都**可能完全合理**（连的是别人运维的 hub、本机 hub 还没重启、故意钉旧版）。猜一个「应该一致」的判据会在这些正常情况下误报，而**一个会误报的检查第一周就会被关掉**。

- 一致时**不多说一句**；只在不一致时附上 pin
- 测试钉死立论：输出中**不得出现**「警告 / 过期 / 应当 / 必须 / 不匹配 / mismatch / outdated」
- 另一条钉「hub 比 pin **新**也要说」—— 判据是**不一致**，不是「更旧」

（这与我今天在 `#1655` 做的 CLI 版本显示是同一条原则：**摆出实际版本，让读的人自己对上号**。）

## 接线守卫

同时断言两件事：用了新函数 **且** 旧的裸拼接不再存在 —— **只查前者的话，两处并存也是绿的**。
**变异见证**：退回裸拼接 → `8 pass 0 fail` 变 **`6 pass 2 fail`**（两条守卫都红）；还原 → `8 pass`（`cli.ts` 逐字还原）。

## 行号 pin

`cli.ts` 加了 5 行，`check-doc-symbol-pins.py` 报**漂移 2 处**：

- `--fix` 自动改掉 1 处无歧义的
- 另一处 `dashboardReleaseTag` 在该文件有 **4 处命中（1 定义 / 1 调用 / 2 注释）**，门明确拒绝替人消歧，并警告「别直接抄第一个数字 —— 其中很可能有提到该符号的注释行」。**逐行标注后钉到定义处 `L2502`。**

四道文档门现全 `rc=0`（`漂移 0`）。

Refs #1595