### PR TITLE
ux(cli): Quick start 从倒数第 11 行移到第 4 行

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3751,6 +3751,14 @@ function printHelp() {
   console.log(`
 anet — AI Agent Network CLI (V2)
 
+Quick start:
+  anet hub start                  Start local hub
+  anet login                      Log in to the hub
+  anet node create my-agent       Create a node
+  anet node start my-agent        Start the node
+  anet demo                       List demos
+  (连别人已有的 hub: anet init --hub <url>)
+
 Node Management:
   anet node create <name>        Create a new agent node
   anet node start <name>         Start a node
@@ -3862,13 +3870,6 @@ Other:
   anet doctor                   System diagnostic check
   anet run                      Standalone SSE agent
   anet -v                       Version + dependency report
-
-Quick start:
-  anet hub start                  Start local hub
-  anet login                      Log in to the hub
-  anet node create my-agent       Create a node
-  anet node start my-agent        Start the node
-  anet demo                       List demos
 
 Legacy aliases:
   anet create <name>              Alias for anet node create


### PR DESCRIPTION
## 问题

`anet`（不带参数）的帮助共 **126 行**，而 `Quick start` —— **第一次用的人唯一需要的那几行** —— 在**第 116 行**，前面是 115 行详尽的命令参考。**在多数终端里它已经滚出屏幕了。**

## 真跑验证（不是看代码推的）

| | Quick start 位置 | 总行数 | 出现次数 |
|---|---|---|---|
| 改前 | **116** | 126 | 1 |
| 改后 | **4** | 127 | **1**（没有变成复制） |

改后的第一屏：

```
anet — AI Agent Network CLI (V2)

Quick start:
  anet hub start                  Start local hub
  anet login                      Log in to the hub
  anet node create my-agent       Create a node
  anet node start my-agent        Start the node
  anet demo                       List demos
  (连别人已有的 hub: anet init --hub <url>)

Node Management:
```

## 🔴 只做移动，不改内容

**换顺序我能当场验**（跑一遍看输出）；**改步骤序列我没跑过，不能顺手动**。

唯一新增的一行是个指路：`(连别人已有的 hub: anet init --hub <url>)` —— 它**不是我编的新流程**，这句逐字来自本帮助自己的 Setup 段（`anet init [--hub <url>]  Configure hub URL`）。原来的 Quick start 只覆盖「起一个本地 hub」，而连已有 hub 的人在这一屏上找不到入口。

## 取集

查过**没有测试或门钉住帮助的顺序**：全仓 `Quick start` 只出现在 README / CONTRIBUTING / changelog 和 `cli.ts` 自身，没有断言它的行号或位置。

行号 pin 门 `rc=0`、语法 `rc=0`。