### PR TITLE
ux(doctor): 0 个节点不再报成 error —— 那是全新安装的预期状态

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -42,6 +42,7 @@ import { describeCopresenceStartupFailure } from "../src/copresence-startup-diag
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
 import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
 import { formatHubVersionDetail } from "../src/hub-version-skew";
+import { nodeCountLine } from "../src/doctor-node-count";
 import { daemonSubcommandRedirect, nodeSubcommandRedirect, projectSubcommandRedirect } from "../src/subcommand-redirect";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
@@ -15789,7 +15790,13 @@ async function doctorCommand() {
 
   // 3. Nodes — also detect legacy/broken configs and (with --fix) migrate.
   const ids = listProfileIds();
-  check("Nodes configured", ids.length > 0, `${ids.length} node(s)`);
+  // 🔴 0 个节点**不报 error**:那是全新安装的预期状态,把它算成 error 等于在
+  //   新用户的第一次诊断里制造假警报。但也不报 ok —— 同一个 0 对本来有节点的人
+  //   意味着配置目录不见了,而 doctor 手上只有一个数字,分不出这两种。
+  //   ⇒ 两种现实都说出来,各给一个下一步。
+  const nodeLine = nodeCountLine(ids.length);
+  if (nodeLine.ok) check("Nodes configured", true, nodeLine.detail);
+  else info("Nodes configured", nodeLine.info);
   let needsMigration: string[] = [];
   for (const id of ids) {
     const p = loadProfile(id);

--- a/agent-network/src/doctor-node-count.test.ts
+++ b/agent-network/src/doctor-node-count.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { nodeCountLine } from "./doctor-node-count";
+
+describe("nodeCountLine", () => {
+  test("有节点时是 ok,detail 就是个数", () => {
+    const r = nodeCountLine(3);
+    expect(r.ok).toBe(true);
+    expect((r as { detail: string }).detail).toBe("3 node(s)");
+  });
+
+  test("🔴 0 个节点不算 ok —— 但也不能算 error", () => {
+    // 这条是整个模块的立论:doctor 只有一个数字,分不出「新装」和「配置没了」。
+    const r = nodeCountLine(0);
+    expect(r.ok).toBe(false);
+    const info = (r as { info: string }).info;
+    expect(info).toContain("全新安装");
+    expect(info).toContain("anet node create");
+    expect(info).toContain("配置目录不见了");
+  });
+
+  test("🔴 两种现实都要出现 —— 只说一种就是替用户挑了一个", () => {
+    const info = (nodeCountLine(0) as { info: string }).info;
+    // 只讲「新装正常」会让配置丢失的人以为没事;
+    // 只讲「配置不见了」会吓到刚装好的人。
+    expect(info.includes("全新安装") && info.includes("本来有节点")).toBe(true);
+  });
+
+  test("坏值按 0 处理,不抛", () => {
+    for (const bad of [-1, NaN, Infinity]) {
+      expect(nodeCountLine(bad as number).ok).toBe(false);
+    }
+  });
+});
+
+describe("接线守卫", () => {
+  // 剥注释行再断言 —— 源码里既有那个东西,也有关于它的说明。
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  test("🔴 旧的「0 个就报错」写法不再存在", () => {
+    expect(cli).not.toContain('check("Nodes configured", ids.length > 0');
+  });
+
+  test("而且确实调用了 nodeCountLine —— 「没有旧写法」也可能是整段被删了", () => {
+    expect(cli).toContain("nodeCountLine(ids.length)");
+  });
+});

--- a/agent-network/src/doctor-node-count.ts
+++ b/agent-network/src/doctor-node-count.ts
@@ -1,0 +1,33 @@
+/**
+ * `anet doctor` 原先对「本机配置了几个节点」的判定是:
+ *
+ *   check("Nodes configured", ids.length > 0, `${ids.length} node(s)`);
+ *
+ * 于是 **0 个节点 → ❌**。而一个刚装好、还没建节点的人跑 `anet doctor`,
+ * 看到的是:
+ *
+ *   ❌ Nodes configured — 0 node(s)
+ *   Result: 9 ok, 3 warnings, 2 errors
+ *
+ * 🔴 「还没有节点」是**全新安装的预期状态**,不是故障。把它报成 error,
+ *    等于在新用户的第一次诊断里制造一个假警报 —— 而这条命令存在的意义
+ *    正是告诉他「你这台机器现在好不好」。
+ *
+ * 🔴 但也不能反过来直接判成「一切正常」:同一个 0 对一个**本来有节点**的人
+ *    意味着配置目录不见了。doctor 手上只有一个数字,**分不出这两种现实**。
+ *    所以这里既不报错也不报好 —— 把两种都说出来,让读的人自己对号,
+ *    并给出各自的下一步。
+ */
+
+export type NodeCountLine = { ok: true; detail: string } | { ok: false; info: string };
+
+export function nodeCountLine(count: number): NodeCountLine {
+  const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+  if (n > 0) return { ok: true, detail: `${n} node(s)` };
+  return {
+    ok: false,
+    info:
+      "0 node(s) —— 全新安装时这是正常的,用 `anet node create <name>` 建第一个;" +
+      "如果你本来有节点,那说明它们的配置目录不见了(对一下 `anet node ls`)",
+  };
+}


### PR DESCRIPTION
## 真机对照（在一个没有节点的检出里跑 `anet doctor`）

| | |
|---|---|
| **改前** | `❌ Nodes configured — 0 node(s)`　·　`Result: 9 ok, 3 warnings, **2 errors**` |
| **改后** | `ℹ  Nodes configured: 0 node(s) —— 全新安装时这是正常的,用 anet node create <name> 建第一个;如果你本来有节点,那说明它们的配置目录不见了(对一下 anet node ls)`　·　`Result: 9 ok, 3 warnings, **1 errors**` |

一个刚装好、还没建节点的人跑 `anet doctor`，**第一次诊断就会看到一个 ❌ 和「2 errors」**。而这条命令存在的意义正是告诉他「你这台机器现在好不好」。

## 🔴 但也没有反过来判成 ok

同一个 `0`，对一个**本来有节点**的人意味着配置目录不见了。**doctor 手上只有一个数字，分不出这两种现实** —— 所以既不报错也不报好，把两种都说出来，各给一个下一步。

测试里**钉死了这一条**：

```ts
test("🔴 两种现实都要出现 —— 只说一种就是替用户挑了一个", …)
// 只讲「新装正常」会让配置丢失的人以为没事；
// 只讲「配置不见了」会吓到刚装好的人。
```

## 接线守卫

同时断言两件事：旧写法（`ids.length > 0` 直接进 `check`）不再存在，**且**确实调用了 `nodeCountLine` —— **只查前者的话，整段被删也是绿的**。

**变异见证**：退回旧写法 → `6 pass 0 fail` 变 **`4 pass 2 fail`**；还原 → `6 pass`（`cli.ts` 逐字还原）。

行号 pin 门 `rc=0`、语法 `rc=0`。