### PR TITLE
docs(troubleshooting): 新增「anet doctor 的输出怎么读」（中英）

### DIFF
--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -275,6 +275,9 @@ When the layer-by-layer pass above does not settle it, each of these targets one
   goes unanswered, answer "can it still do work" first. Includes a table ordered by how much each
   signal is worth (`status = idle` covers four different realities; only "it answered you" is hard
   evidence).
+- [**Reading `anet doctor` output**](/en/troubleshooting/reading-anet-doctor) — what the four
+  prefixes mean, why the version lines report instead of judging, and which questions it
+  **cannot** answer.
 - [Connectivity: channels and MCP](/en/troubleshooting/connectivity-channels-mcp)
 - [CLI login on a remote node](/en/troubleshooting/remote-node-cli-login)
 - [Case: Feishu silently denies](/en/troubleshooting/case-feishu-silent-deny)

--- a/docs-site/docs/en/troubleshooting/reading-anet-doctor.md
+++ b/docs-site/docs/en/troubleshooting/reading-anet-doctor.md
@@ -1,0 +1,102 @@
+# Reading `anet doctor` output
+
+`anet doctor` is the first command for "is this machine OK right now". It looks only at
+**this machine and the Hub it points at** — it never probes whether any node is alive.
+For that, see [Is this node still alive](/en/troubleshooting/is-this-node-alive).
+
+A real run (from a configured machine):
+
+```
+anet doctor — System Diagnostic
+
+  ✅ Global config (~/.anet/config.json) (http://127.0.0.1:9200)
+  ✅ Auth token configured
+  ⚠  Package file modes: umask is 0002, so npm extracts packages group-writable …
+  ✅ CommHub reachable (http://127.0.0.1:9200 v0.9.0-preview.38; this machine's anet hub start pins 0.9.0-preview.44)
+  ℹ  API version: v3
+  ℹ  Sessions: 271 registered
+  ℹ  SSE connections: 127 active
+  ✅ No plain-secret config (all env values are either non-secret or envRef objects)
+  ✅ Claude Code CLI (2.1.251 (Claude Code))
+  ✅ Codex CLI (codex-cli 0.149.1)
+  ✅ Bun runtime (1.4.0)
+  ✅ SkillHub catalog (7 skill(s) available …)
+
+  Result: 9 ok, 3 warnings, 1 errors
+```
+
+## What the four prefixes mean
+
+| Prefix | Meaning | Counted in the result line? |
+| --- | --- | --- |
+| ✅ | Judged, and it is good | counted in `ok` |
+| ⚠ | Judged, not bad but worth knowing (e.g. a umask that makes npm extract packages group-writable) | counted in `warnings` |
+| ❌ | Judged, and it is bad | counted in `errors` |
+| ℹ | **A fact, stated without judgement** | **counted in none of them** |
+
+🔴 **`ℹ` does not mean "fine" — it means this command is not judging that cell for you.**
+For example `Sessions: 271 registered` says the roster holds 271 session rows. It does **not**
+mean 271 nodes are alive; the roster carries a large number of offline rows at all times.
+
+## The version lines report, they do not judge
+
+```
+✅ Claude Code CLI (2.1.251 (Claude Code))
+✅ Codex CLI (codex-cli 0.149.1)
+✅ Bun runtime (1.4.0)
+```
+
+🔴 **The parentheses hold the version actually installed. These lines make no
+"new enough?" judgement.**
+
+The reason is a measured one: `codex-cli 0.149.1` was **installed**, but could not decode a
+reasoning-effort value it did not know in the upstream models response; the rmcp worker died
+fatally and the user saw a 300s timeout — while doctor, which only checked *presence*, showed
+a ✅.
+
+So why not add a minimum-version check? Because "how new is new enough" is decided by what
+upstream returns, not by a constant we can pin. A guessed floor turns into a false alarm the
+next time someone upgrades the CLI or upstream shifts again — and a check that cries wolf gets
+switched off in its first week. **Printing the actual version and letting the reader match it
+up is all this cell can honestly do.**
+
+⇒ When chasing an unexplained timeout, read these version numbers first, then decide whether
+to upgrade.
+
+## The Hub line: two version numbers side by side
+
+```
+✅ CommHub reachable (… v0.9.0-preview.38; this machine's anet hub start pins 0.9.0-preview.44)
+```
+
+The first is the **version the Hub reports**; the second is the version **this CLI's
+`anet hub start` pins**. 🔴 **The second half is hidden when they match** — it only appears when
+there is a gap.
+
+Here too, no judgement is made about which is right: a Hub older or newer than the pin can both
+be perfectly reasonable (you are connected to a Hub someone else operates, the local Hub has not
+been restarted, or the pin is deliberately old). It states both numbers and leaves the decision
+to you.
+
+⇒ When chasing "this feature behaves wrong against this Hub", read how far apart these two are first.
+
+## What it **cannot** answer
+
+This section matters more than the ones above — the most dangerous way to use a diagnostic is
+to ask it something it never judged.
+
+- **Not "is my node alive".** doctor sends no probe to any node. `Sessions: N registered` is a
+  roster count with no liveness in it.
+  → [Is this node still alive](/en/troubleshooting/is-this-node-alive)
+- **Not "is the Hub's data correct".** It only called `/health`.
+- **Not "can my runtime actually run".** The version lines only prove the binary exists and can
+  report a version.
+- **`0 node(s)` is not a fault.** A fresh install has no nodes yet; but if you did have some,
+  their config directory is gone. doctor cannot tell these apart, so it states both and does not
+  pick one for you.
+
+## `--fix` changes things
+
+`anet doctor --fix` runs compatibility migrations and re-issues node tokens the Hub rejected.
+**It modifies configuration** — it is not read-only. Run it without `--fix` first and read the
+output before deciding.

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -274,6 +274,8 @@ docker compose logs --tail=200 <service>
 - [**这个节点还活着吗**](/troubleshooting/is-this-node-alive) —— 派出去的任务没有回音时，
   先回答「它还能不能干活」。附一张按可信度排序的判据表（`status = idle` 覆盖四种现实，
   只有「它自己回一句话」算硬证据）。
+- [**`anet doctor` 的输出怎么读**](/troubleshooting/reading-anet-doctor) —— 四种前缀分别代表什么、
+  为什么版本那几行只报不判、以及它**回答不了**哪些问题。
 - [连通性：Channel 与 MCP](/troubleshooting/connectivity-channels-mcp)
 - [远端节点的 CLI 登录](/troubleshooting/remote-node-cli-login)
 - [案例：飞书静默拒绝](/troubleshooting/case-feishu-silent-deny)

--- a/docs-site/docs/troubleshooting/reading-anet-doctor.md
+++ b/docs-site/docs/troubleshooting/reading-anet-doctor.md
@@ -1,0 +1,90 @@
+# `anet doctor` 的输出怎么读
+
+`anet doctor` 是「我这台机器现在好不好」的第一道命令。它**只看本机 + 它连的那个 Hub**，
+不去探任何节点是不是活的 —— 那一格见[这个节点还活着吗](/troubleshooting/is-this-node-alive)。
+
+一次真实输出（截自一台已配置好的机器）：
+
+```
+anet doctor — System Diagnostic
+
+  ✅ Global config (~/.anet/config.json) (http://127.0.0.1:9200)
+  ✅ Auth token configured
+  ⚠  Package file modes: umask is 0002, so npm extracts packages group-writable …
+  ✅ CommHub reachable (http://127.0.0.1:9200 v0.9.0-preview.38；本机 anet hub start 钉 0.9.0-preview.44)
+  ℹ  API version: v3
+  ℹ  Sessions: 271 registered
+  ℹ  SSE connections: 127 active
+  ✅ No plain-secret config (all env values are either non-secret or envRef objects)
+  ✅ Claude Code CLI (2.1.251 (Claude Code))
+  ✅ Codex CLI (codex-cli 0.149.1)
+  ✅ Bun runtime (1.4.0)
+  ✅ SkillHub catalog (7 skill(s) available …)
+
+  Result: 9 ok, 3 warnings, 1 errors
+```
+
+## 四种前缀各是什么意思
+
+| 前缀 | 含义 | 计入结果行吗 |
+| --- | --- | --- |
+| ✅ | 这一格判过了，并且是好的 | 计入 `ok` |
+| ⚠ | 判过了，不算坏但值得知道（例如 umask 会让 npm 解出组可写的包） | 计入 `warnings` |
+| ❌ | 判过了，是坏的 | 计入 `errors` |
+| ℹ | **只是把一个事实摆出来，不做判断** | **不计入任何一项** |
+
+🔴 **`ℹ` 不是「没问题」，是「这道命令不替你判断这一格」。** 例如
+`Sessions: 271 registered` 说的是名册里有 271 条会话记录 —— 它**不**表示
+271 个节点都活着（名册里长期有大量 offline 行）。
+
+## 版本那几行：只报，不判
+
+```
+✅ Claude Code CLI (2.1.251 (Claude Code))
+✅ Codex CLI (codex-cli 0.149.1)
+✅ Bun runtime (1.4.0)
+```
+
+🔴 **括号里是实际装着的版本，这几行不做「够不够新」的判断。**
+
+原因是实测过一次：`codex-cli 0.149.1` **装着**，但解不动上游 models 响应里一个
+它不认识的推理档位，rmcp worker 因此致命退出，用户看到的是 300s 超时 ——
+而当时 doctor 只检查了「在不在」，给的是一个 ✅。
+
+那么为什么不干脆加一个最低版本判据？因为「多少版本才够」**由上游返回什么决定**，
+不是我们能钉死的常量；猜一个下限，会在别人升级 CLI、上游又改动之后变成误报，
+而一个会误报的检查第一周就会被关掉。**把实际版本摆出来、让读的人自己对上号，
+是这一格能诚实做到的全部。**
+
+⇒ 排查一条「莫名其妙的超时」时，先看这几行的版本号，再决定要不要升级。
+
+## Hub 那一行:两个版本号并排
+
+```
+✅ CommHub reachable (… v0.9.0-preview.38；本机 anet hub start 钉 0.9.0-preview.44)
+```
+
+前一个是 **Hub 自报的版本**,后一个是**这台 CLI 里 `anet hub start` 钉死的版本**。
+🔴 **两者一致时后半句不显示** —— 只在不一致时才提醒你有个差。
+
+同样地,这里**不判断谁对**:hub 比 pin 老或新都可能完全合理(你连的是别人运维的
+hub、本机 hub 还没重启、或者故意钉在旧版)。摆出两个数,让读的人自己决定要不要动它。
+
+⇒ 排查「某个功能在这台 hub 上行为不对」时,先看这两个数差多少。
+
+## 它**回答不了**什么
+
+这一节比上面几节都重要 —— 一条诊断命令最危险的用法是拿它回答它没在判的问题。
+
+- **不回答「我的节点还活着吗」。** doctor 不给任何节点发探针。
+  `Sessions: N registered` 是名册计数，不含活性成分。
+  → [这个节点还活着吗](/troubleshooting/is-this-node-alive)
+- **不回答「Hub 上的数据对不对」。** 它只打了 `/health`。
+- **不回答「我的 runtime 能不能真的跑起来」。** 版本那几行只证明二进制在、能报版本。
+- **`0 node(s)` 不是故障。** 全新安装本来就没有节点；但如果你本来有，
+  那说明配置目录不见了 —— 这两种 doctor 分不出来，所以它两种都说，不替你挑一种。
+
+## `--fix` 会改东西
+
+`anet doctor --fix` 会执行兼容迁移、并重新签发被 Hub 拒绝的节点 token。
+**它会修改配置**，不是只读。先跑不带 `--fix` 的看清楚再决定。

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -97,6 +97,8 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > | `docs-site/docs/guide/getting-started.md` | 19–20 | latest `2.2.21` 裸崩 / preview `2.3.0-preview.x` 被拦 |
 > | `docs-site/docs/en/guide/getting-started.md` | 19–20 | 同上(英文) |
 > | `docs-site/docs/troubleshooting/is-this-node-alive.md` | 见门输出 | #895 stdout 假报「`2.3.0-preview.40` 起已修」——修复版本钉死在断言里,promote latest 时核对 latest 是否已含 #895 |
+> | `docs-site/docs/troubleshooting/reading-anet-doctor.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/troubleshooting/reading-anet-doctor.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/en/troubleshooting/is-this-node-alive.md` | 见门输出 | 同上(英文) |
 > | `docs-site/docs/troubleshooting/node-stuck-lifecycle.md` | 4–5 | **下界断言**(agent-node ≥ `2.5.0-preview.49` / commhub-server ≥ `0.9.0-preview.40`)——发版**不会**让它变假;要核的是另一件事:**当这两个修复进入 `latest` 时,把页面的指引从「需要 preview」改成「latest 已含」**,否则 latest 用户会以为必须切 preview |
 > | `docs-site/docs/en/troubleshooting/node-stuck-lifecycle.md` | 4–5 | 同上(英文) |

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -204,9 +204,20 @@ broken=$(printf '%s' "$out" | sed -nE 's/^broken_pins=([0-9]+)$/\1/p')
 #   以为哪里多算了(只加了一个 .md),是去读那个常量才对上的。**别按"我加了几个 .md"推。**
 #   `uniq` 仍 9、`occ` 仍 24(新加的 skill 里没有 #L 源码行号 pin)。
 #   catalog.json 由 scripts/build-public-skillhub.mjs 生成,不是手改。
+# 2026-08-31:files 131 → 133。新增「anet doctor 的输出怎么读」(中英各一份):
+#     docs-site/docs/troubleshooting/reading-anet-doctor.md
+#     docs-site/docs/en/troubleshooting/reading-anet-doctor.md
+#   这次是 +2 = 两个 .md,与上一条那个「+2 其实是 1 个 .md + 1 个 .json」不同 ——
+#   上面那条警告仍然成立,只是这次恰好按 .md 数也对。**不要因为这次对了就回去按 .md 推。**
+#   `uniq` 仍 9、`occ` 仍 24:CI 只报了 files 那一条(「预期扫 131 …,实际 133」),
+#   另两条没红 —— 这比我自己去数两页里有没有 #L pin 更可靠。
+#   顺带记一笔:按 `SCANNED_SUFFIXES` 在 docs+docs-site 下自己数是 392 → 394,
+#   与门的 131 → 133 **绝对值不同(门的扫描面更窄),但增量一致都是 +2**。
+#   能确认的是增量,不是绝对值 —— 绝对值以门的输出为准。
+#
 # 🔴 下面三条是 `-eq`(精确相等),**不是下界** —— job 名里的 "floor" 会误导。
 #    新增/删除文档都会让 files 变,必须回来按实际值更新,并写清变的是哪个数、为什么。
-[[ "$files" -eq 131 ]] || fail "预期扫 131 个文档文件(= git ls-files 的结果),实际 $files"
+[[ "$files" -eq 133 ]] || fail "预期扫 133 个文档文件(= git ls-files 的结果),实际 $files"
 [[ "$uniq"  -eq 9  ]] || fail "预期 9 个唯一 pin,实际 $uniq"
 [[ "$occ"   -eq 24 ]] || fail "预期 24 处原始出现,实际 $occ"
 echo "  OK  walk 路径与 git 路径给出同一份清单($files 文件 / $uniq 唯一 pin / $occ 处)"


### PR DESCRIPTION
## 缺口

`anet doctor` 是最「傻瓜」的那条诊断命令，而它在文档里此前只有**两行表格**，没有任何一处讲它报什么、怎么读、以及**它回答不了什么**。

## 新页三节，内容全部取自真实输出（不是照源码推）

**① 四种前缀**：✅/⚠/❌ 各计入结果行的哪一项，而 🔴 **`ℹ` 不计入任何一项** —— 它不是「没问题」，是「这道命令**不替你判断**这一格」。

例：`Sessions: 271 registered` 说的是**名册计数**，**不**表示 271 个节点活着。

**② 版本那几行只报不判**：实测过 `codex-cli 0.149.1` **装着**但解不动上游 models 响应，用户看到 300s 超时**而 doctor 给的是 ✅**。

并写明为什么**不**加最低版本判据：「多少版本才够」由上游返回什么决定，不是能钉死的常量；猜一个下限会在别人升级后变成误报，**而会误报的检查第一周就被关掉**。

**③ 🔴 它回答不了什么** —— 这一节比前两节都重要：

> 一条诊断命令最危险的用法，是拿它回答**它没在判**的问题。

- 不回答「我的节点还活着吗」—— **它不给任何节点发探针**
- 不回答「Hub 上的数据对不对」—— 只打了 `/health`
- 不回答「runtime 能不能真跑起来」—— 版本行只证明二进制在、能报版本
- `0 node(s)` **不是故障** —— 全新安装本来就没有节点

## 形式

中英双份，已挂进两个 `troubleshooting` 索引 —— **那是这些页唯一的入口**（侧边栏只指 `/troubleshooting`，不逐页列）。

四道文档门在 **`git add` 之后**重跑，全 `rc=0` —— 用 `git ls-files` 的门看不见未跟踪的新文件，先 add 再跑。

> ⚠️ 合入后**用户仍看不到** —— anet.sh 的自动部署因 `VERCEL_TOKEN` 未配一直静默跳过（#1619）。