### PR TITLE
feat(#1645): 上下文压力打在成功路径上 —— 超时不该是第一个信号

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -78,6 +78,7 @@ import {
 import { isTelemetrySchemaRejection, withoutOptionalTelemetry } from "./register-telemetry-fallback";
 import { resolveGrokAcpTimeout } from "./runtime/grok-build-acp/timeout-resolve";
 import { claudeAttemptsDetail, codexTimeoutDetail } from "./runtime/sdk-timeout-detail";
+import { compactionPressure } from "./runtime/compaction-pressure";
 import {
   GROK_COPRESENCE_PROFILE_ENV,
   selectGrokCopresenceCapabilityProfile,
@@ -3056,6 +3057,13 @@ async function processWithCodex(
     const dt = Date.now() - t0;
     const inTokens = outcome.usage?.input_tokens || 0;
     log(`[codex] done | ${dt}ms | in=${inTokens} out=${outcome.usage?.output_tokens || 0} | items=${outcome.itemCount}`);
+    // #1645 —— 上下文压力打在**成功路径**上。实测那次 300s 卡死的真因链里有
+    //   `remote compaction failed last_api_response_total_tokens=195436`,而那是我们
+    //   自己设的 model_auto_compact_token_limit=200000 的 97.7%。也就是说
+    //   「这条线程马上要 compaction」在**上一回合结束时就可知**,而第一个信号
+    //   却是 300 秒后的超时。只在失败时说话的仪表,警告不了任何人。
+    const pressure = compactionPressure(inTokens, CODEX_CONFIG.model_auto_compact_token_limit);
+    if (pressure.text) log(pressure.text);
     if (codexThread?.id) writebackSession(codexThread.id);
     // Auto-compact 由 Codex CLI 原生处理（model_auto_compact_token_limit=200000）
 

--- a/agent-node/src/runtime/compaction-pressure.test.ts
+++ b/agent-node/src/runtime/compaction-pressure.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { COMPACTION_WARN_RATIO, compactionPressure } from "./compaction-pressure";
+
+const LIMIT = 200_000;
+
+describe("compactionPressure (#1645)", () => {
+  test("🔴 实测那次的数:195436/200000 = 98%,必须提醒", () => {
+    const p = compactionPressure(195_436, LIMIT);
+    expect(p.pct).toBe(98);
+    expect(p.warn).toBe(true);
+    expect(p.text).toContain("195436/200000");
+  });
+
+  test("阈值用边界值校准,不用生产值", () => {
+    expect(compactionPressure(LIMIT * COMPACTION_WARN_RATIO, LIMIT).warn).toBe(true);
+    expect(compactionPressure(LIMIT * COMPACTION_WARN_RATIO - 1, LIMIT).warn).toBe(false);
+  });
+
+  test("未越线时 text 为空串 —— 调用方据此不打印", () => {
+    const p = compactionPressure(50_000, LIMIT);
+    expect(p.pct).toBe(25);
+    expect(p.warn).toBe(false);
+    expect(p.text).toBe("");
+  });
+
+  test("🔴 上限拿不到时不算百分比 —— 不要拿猜的分母算出一个像样的数", () => {
+    for (const badLimit of [0, -1, NaN, undefined, null, "200000"]) {
+      const p = compactionPressure(195_436, badLimit as unknown);
+      expect(p.pct).toBe(0);
+      expect(p.warn).toBe(false);
+    }
+  });
+
+  test("token 数是坏值时按 0 处理,不抛", () => {
+    for (const bad of [-5, NaN, Infinity, undefined, "1000"]) {
+      expect(compactionPressure(bad as unknown, LIMIT).warn).toBe(false);
+    }
+  });
+
+  test("🔴 文案不承诺「一定会失败」", () => {
+    const t = compactionPressure(195_436, LIMIT).text;
+    expect(t).toContain("可能");
+    for (const w of ["一定", "必然", "will fail", "肯定"]) expect(t).not.toContain(w);
+  });
+});
+
+describe("接线守卫", () => {
+  // 剥注释行再断言 —— 源码里既有那个东西,也有关于它的说明。
+  const cli = readFileSync(new URL("../cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  test("🔴 打在**成功路径**上 —— 只在失败时说话的仪表警告不了任何人", () => {
+    // 成功路径那一行是 `[codex] done | …`;压力提醒必须紧随其后。
+    const doneAt = cli.indexOf("[codex] done |");
+    const pressureAt = cli.indexOf("compactionPressure(");
+    expect(doneAt).toBeGreaterThan(-1);
+    expect(pressureAt).toBeGreaterThan(doneAt);
+    expect(pressureAt - doneAt).toBeLessThan(400); // 就在它附近,不是文件另一头
+  });
+
+  test("用的是我们自己设的那个上限,不是写死的数字", () => {
+    expect(cli).toContain("CODEX_CONFIG.model_auto_compact_token_limit");
+  });
+});

--- a/agent-node/src/runtime/compaction-pressure.ts
+++ b/agent-node/src/runtime/compaction-pressure.ts
@@ -1,0 +1,59 @@
+/**
+ * #1645 —— 一次 codex turn 卡死 300s 的真因链里有这一段:
+ *
+ *   ERROR codex_core::compact_remote: remote compaction failed
+ *     last_api_response_total_tokens=195436
+ *   ERROR codex_core::session::turn: Failed to run pre-sampling compact
+ *
+ * 而我们**自己**在 CODEX_CONFIG 里设了 `model_auto_compact_token_limit: 200000`。
+ * 195436 是它的 **97.7%** —— 也就是说「这条线程马上要触发 compaction」这件事,
+ * 在**上一回合结束时就已经可知**,而实际的第一个信号是 300 秒之后的超时。
+ *
+ * 🔴 这里**只报压力,不预测失败**。compaction 会不会成功由上游决定,
+ *    我们既不知道也不该猜。报的是一个纯事实:**距离我们自己设的那个上限还有多远**。
+ *
+ * 🔴 而且它必须打在**成功路径**上。一个只在失败时说话的仪表,
+ *    警告不了任何人 —— 等它开口时,那 300 秒已经花掉了。
+ */
+
+export type CompactionPressure = {
+  /** 占已配置上限的百分比,四舍五入到整数 */
+  pct: number;
+  /** 是否已越过提醒阈值 */
+  warn: boolean;
+  /** 越过阈值时的一行说明;未越过时为空串(调用方据此不打印) */
+  text: string;
+};
+
+/**
+ * 阈值取 85%。
+ *
+ * 🔴 这个数是**判断**,不是测量,所以写清它的依据和它不承诺什么:
+ *   - 依据:实测那次失败发生在 97.7%;留出一段余量,让提醒出现在**还能做点什么**
+ *     的时候(换新线程 / 缩小上下文),而不是在悬崖边上。
+ *   - 不承诺:越过 85% **不表示**下一回合一定会失败,更多时候 compaction 会正常完成。
+ *     所以它只是一行日志,**不改变任何行为、不影响任何返回值**。
+ */
+export const COMPACTION_WARN_RATIO = 0.85;
+
+export function compactionPressure(
+  inputTokens: unknown,
+  limit: unknown,
+  warnRatio: number = COMPACTION_WARN_RATIO,
+): CompactionPressure {
+  const t = typeof inputTokens === "number" && Number.isFinite(inputTokens) && inputTokens > 0 ? inputTokens : 0;
+  const l = typeof limit === "number" && Number.isFinite(limit) && limit > 0 ? limit : 0;
+  // 🔴 上限拿不到时返回 pct=0 且不提醒 —— 不要拿一个猜的分母算出一个像样的百分比。
+  if (l === 0) return { pct: 0, warn: false, text: "" };
+  const pct = Math.round((t / l) * 100);
+  const warn = t >= l * warnRatio;
+  if (!warn) return { pct, warn, text: "" };
+  return {
+    pct,
+    warn,
+    text:
+      `[codex] ⚠ 上下文压力 ${t}/${l} tokens (${pct}%) —— 越过 ${Math.round(warnRatio * 100)}% 提醒线。` +
+      `下一回合可能触发 compaction;它**失败**时的表现是整回合卡到超时(见 #1645),` +
+      `而不是一条报错。需要的话现在换条新线程比等超时便宜。`,
+  };
+}


### PR DESCRIPTION
## 那次 300s 卡死，第一个信号来得太晚

真因链里有这一段：

```
ERROR codex_core::compact_remote: remote compaction failed
  last_api_response_total_tokens=195436
ERROR codex_core::session::turn: Failed to run pre-sampling compact
```

而 `model_auto_compact_token_limit: 200000` 是**我们自己**在 `CODEX_CONFIG` 里设的。

**195436 = 它的 97.7%。**

⇒ 「这条线程马上要触发 compaction」在**上一回合结束时就已经可知**，而实际的第一个信号是 **300 秒之后的超时**。

## 🔴 它必须打在成功路径上

> **一个只在失败时说话的仪表警告不了任何人** —— 等它开口时，那 300 秒已经花掉了。

测试**钉死**了这一条：守卫断言 `compactionPressure(` 出现在 `[codex] done |` **之后且相距 < 400 字符**（就在它附近，不是文件另一头）。

## 🔴 只报压力，不预测失败

compaction 会不会成功**由上游决定**，我们既不知道也不该猜。报的是纯事实：**距离我们自己设的那个上限还有多远**。

- 文案用「**可能**」；测试**禁止**出现「一定 / 必然 / 肯定 / will fail」
- 阈值 **85% 是判断不是测量**，所以写清了依据（实测失败在 97.7%，留余量让提醒出现在**还能换线程**的时候）和它**不承诺**什么
- **不改变任何行为、不影响任何返回值** —— 只是一行日志
- 拿不到上限时 `pct=0` 且不提醒：**不要拿一个猜的分母算出一个像样的百分比**

## 变异见证

| 变异 | 结果 |
|---|---|
| 整段删掉 | `8 pass 0 fail` → **`6 pass 2 fail`** |
| 上限改成写死的 `200000`（而非读配置常量） | → **`7 pass 1 fail`** |
| 还原 | `8 pass`（`cli.ts` 逐字还原） |

## typecheck 棘轮：81 = baseline 81，零新增

该门在没装 types 时**fail closed**，报错原文：

> *Failing closed: without types, tsc aborts on TS2688 and reports ~1 error, which would look like a near-perfect result.*

**按它给的命令装了 `typescript` / `@types/node` 再跑的，不是跳过。**（这道门今天抓过我一次真缺陷 —— `let` 声明在 `try` 内而 `catch` 里读不到。）

Refs #1645