### PR TITLE
fix(cli): hub 时间戳显示相对时长并显式标 UTC —— 否则刚心跳的节点看起来像 8 小时前

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -39,6 +39,7 @@ import { classifySessionStatus, summarizeSessions } from "../src/session-status-
 import { formatOfflineAges, parseHubTimestamp, summarizeOfflineAges } from "../src/offline-age";
 import { oneLineCell } from "../src/one-line-cell";
 import { padDisplayEnd } from "../src/display-width";
+import { formatHubTime } from "../src/hub-time-display";
 import { formatCliVersion } from "../src/cli-version-display";
 import { describeCopresenceStartupFailure } from "../src/copresence-startup-diagnosis";
 import { describeCapability, describeFetchFailure, type CapabilityFetchFailure, type DaemonCapabilityRow } from "../src/daemon-capability-display";
@@ -12283,7 +12284,7 @@ function printGoalShow(goal: LocalGoal, displayName: string, path: string) {
   if (goal.parent_task_id) console.log(`  Parent:   ${goal.parent_task_id}`);
   if (goal.report_to) console.log(`  ReportTo: ${goal.report_to}`);
   console.log(`  Created:  ${goal.created_at || "-"}`);
-  console.log(`  Updated:  ${goal.updated_at || "-"}`);
+  console.log(`  Updated:  ${formatHubTime(goal.updated_at)}`);
   console.log(`  File:     ${path}`);
   const log = Array.isArray(goal.progress_log) ? goal.progress_log : [];
   if (log.length === 0) {
@@ -15450,7 +15451,7 @@ async function infoCommand() {
         console.log(`\n  Server Status:`);
         console.log(`    status:   ${session.status}`);
         console.log(`    task:     ${(session.task || "-").slice(0, 60)}`);
-        console.log(`    updated:  ${session.updated_at || "-"}`);
+        console.log(`    updated:  ${formatHubTime(session.updated_at)}`);
       } else {
         console.log(`\n  Server: not registered`);
       }

--- a/agent-network/src/hub-time-display.test.ts
+++ b/agent-network/src/hub-time-display.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { formatAgo, formatHubTime } from "./hub-time-display";
+
+// 实测那一对:名册值 00:20:11 UTC,而 UTC 现在是 00:22:41 —— 2 分钟前。
+const RAW = "2026-08-31 00:20:11";
+const NOW = Date.UTC(2026, 7, 31, 0, 22, 41);
+
+describe("formatHubTime", () => {
+  test("🔴 实测那一对:说的是「分钟前」,不是「8 小时前」", () => {
+    // 这条的立论不是某个具体数字,是**量级** —— 一个刚心跳过的节点不该看起来像 8 小时前。
+    // (150 秒 → `Math.round(2.5)` = 3 分钟。我第一版把断言写成「2 分钟前」,
+    //  是从 shell 的**整除**结果抄的;代码用四舍五入,比截断更诚实。测试抓住了我。)
+    const s = formatHubTime(RAW, NOW);
+    expect(s).toContain("分钟前");
+    expect(s).not.toContain("小时前");
+    expect(s).toContain("UTC");
+    expect(s).toContain(RAW);
+  });
+
+  test("精确值另测,用一个干净的时间对", () => {
+    const base = Date.UTC(2026, 7, 31, 0, 20, 11);
+    expect(formatHubTime(RAW, base + 120_000)).toContain("2 分钟前");
+    expect(formatHubTime(RAW, base + 150_000)).toContain("3 分钟前"); // 2.5 分 → 四舍五入
+  });
+
+  test("🔴 必须显式标 UTC —— 不标就会被当成本地时间读", () => {
+    // 这条是整个模块的立论。去掉 UTC 标记,同一个串在 UTC+8 的用户眼里差 8 小时。
+    expect(formatHubTime(RAW, NOW)).toContain("UTC");
+  });
+
+  test("解不出来就原样回显并说明,不编一个合理的时间", () => {
+    expect(formatHubTime("不是时间", NOW)).toBe("不是时间（无法解析）");
+    expect(formatHubTime("2026-13-45 99:99:99", NOW)).toContain("无法解析");
+  });
+
+  test("空/非字符串给 -", () => {
+    for (const bad of ["", "   ", undefined, null, 42, {}]) expect(formatHubTime(bad as unknown, NOW)).toBe("-");
+  });
+});
+
+describe("formatAgo 的档位（边界值校准，不用生产值）", () => {
+  test.each([
+    [0, "0 秒前"], [59_000, "59 秒前"], [60_000, "1 分钟前"],
+    [59 * 60_000, "59 分钟前"], [60 * 60_000, "1 小时前"],
+    [47 * 3600_000, "47 小时前"], [48 * 3600_000, "2 天前"],
+  ])("%i ms → %s", (ms, want) => expect(formatAgo(ms as number)).toBe(want));
+
+  test("🔴 未来时间如实说「时钟偏差？」,不折成 0 秒前", () => {
+    expect(formatAgo(-5_000)).toContain("时钟偏差");
+    expect(formatAgo(-5 * 60_000)).toContain("时钟偏差");
+  });
+
+  test("坏值不抛", () => {
+    expect(formatAgo(NaN)).toBe("时长未知");
+    expect(formatAgo(Infinity)).toBe("时长未知");
+  });
+});
+
+describe("接线守卫", () => {
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  test("🔴 两处裸打印都换掉了", () => {
+    expect(cli).not.toContain("${session.updated_at || \"-\"}");
+    expect(cli).not.toContain("${goal.updated_at || \"-\"}");
+  });
+
+  test("而且确实调用了 formatHubTime", () => {
+    expect((cli.match(/formatHubTime\(/g) || []).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/agent-network/src/hub-time-display.ts
+++ b/agent-network/src/hub-time-display.ts
@@ -1,0 +1,44 @@
+import { parseHubTimestamp } from "./offline-age";
+
+/**
+ * 把 hub 的 TEXT 时间戳显示给人看。
+ *
+ * 🔴 原先是**原样打印**:
+ *
+ *     updated:  2026-08-31 00:20:11
+ *
+ * 那是 UTC,**没有任何时区标记**。同一时刻本地是 `08:22:41 CST` ——
+ * 于是一个 **2 分钟前**刚心跳过的节点,在 UTC+8 的用户眼里像是 **8 小时前**的。
+ *
+ * 这不是假想:2026-08-31 我自己就这么读错过一次,据此差点报出「舰队心跳陈旧
+ * 8.3 小时」。**CLI 在主动制造这个误读。**
+ *
+ * 所以显示两样东西:
+ *   - **相对时长**(人真正想知道的那个)
+ *   - 绝对值,并**显式标 UTC**(便于和日志、issue 里的时间对齐)
+ */
+export function formatHubTime(raw: unknown, nowMs: number = Date.now()): string {
+  if (typeof raw !== "string" || !raw.trim()) return "-";
+  const ms = parseHubTimestamp(raw);
+  // 🔴 解不出来就**原样回显**,不要编一个看起来合理的时间。
+  //    但要让读的人知道我们没能解析它 —— 否则一个格式变了的字段会静默退化成
+  //    「看起来正常的绝对时间」,而相对时长凭空消失。
+  if (ms === null) return `${raw.trim()}（无法解析）`;
+  return `${raw.trim()} UTC（${formatAgo(nowMs - ms)}）`;
+}
+
+/** 人读的时长。负数(时钟偏差/未来时间)如实说,不折成 0。 */
+export function formatAgo(deltaMs: number): string {
+  if (!Number.isFinite(deltaMs)) return "时长未知";
+  if (deltaMs < 0) {
+    const s = Math.round(-deltaMs / 1000);
+    return s < 90 ? `${s} 秒后（时钟偏差？）` : `${Math.round(s / 60)} 分钟后（时钟偏差？）`;
+  }
+  const s = Math.round(deltaMs / 1000);
+  if (s < 60) return `${s} 秒前`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m} 分钟前`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h} 小时前`;
+  return `${Math.round(h / 24)} 天前`;
+}


### PR DESCRIPTION
## 真跑 `anet info <alias>` 才看见的

| | |
|---|---|
| **改前** | `updated:  2026-08-31 00:23:11` |
| **改后** | `updated:  2026-08-31 00:23:11 UTC（2 分钟前）` |

那是名册里的 UTC 值**原样打印，没有任何时区标记**。同一时刻本地是 `08:25:01 CST` —— 于是一个 **2 分钟前**刚心跳过的节点，在 UTC+8 的用户眼里像是 **8 小时前**的。

## 🔴 这不是假想

**2026-08-31 我自己就这么读错过一次**，据此差点报出「舰队心跳陈旧 8.3 小时」。**CLI 在主动制造这个误读。**

显示两样：**相对时长**（人真正想知道的）+ 绝对值并**显式标 UTC**（便于和日志 / issue 里的时间对齐）。两处：`anet info` 的 `updated:`、`anet goal show` 的 `Updated:`。

## 两条边界

- 🔴 解不出来时**原样回显并注明「无法解析」**，**不编一个看起来合理的时间** —— 否则字段格式一变，就会静默退化成「看起来正常的绝对时间」而相对时长凭空消失
- 未来时间（时钟偏差）**如实说**，不折成「0 秒前」

## 🔴 测试抓到我一次

我把断言写成「2 分钟前」，**是从 shell 的整除结果抄的**；代码用四舍五入（150 秒 → **3 分钟**），比截断更诚实。

改成断言**量级**（含「分钟前」且**不含**「小时前」—— 这才是这条的立论），精确值另用干净的时间对单测。

## 变异见证

回退 2 处里的 1 处 → `16 pass 0 fail` 变 **`14 pass 2 fail`**；还原 → `16 pass`（`cli.ts` 逐字还原）。

行号 pin 由 `--fix` **自动修好**（含 `dashboardReleaseTag`），`rc=0`。