### PR TITLE
docs(daemon): restart 那条给出版本下限 —— 「去跑一下看看」不如直接给数

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -265,7 +265,11 @@ anet daemon restart <name>
 ```
 
 ::: tip 你的版本有没有这条？
-跑一下 `anet daemon`（不带子命令）看列表里有没有 `restart`。**没有的话用两步** ——
+`restart` 从 **2.3.0-preview.73**（#1601）起才有。🔴 **`npm i -g` 装到的 `latest` 目前是
+2.3.0-preview.47 —— 还没有这条**，所以默认安装的用户现在走的就是下面这两步。
+（两个端点都实跑过：`.47` 报 `Unknown daemon subcommand "restart"`，`.75` 正常。）
+
+拿不准就跑 `anet daemon`（不带子命令）看列表里有没有 `restart`。**没有就用两步** ——
 因为 `daemon start` 委托给 `node start`，所以停也走 `node`：
 
 ```bash

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -287,9 +287,14 @@ anet daemon restart <name>
 ```
 
 ::: tip Does your version have it?
-Run `anet daemon` with no subcommand and check the list for `restart`. **If it is absent,
-use the two-step form** — `daemon start` delegates to `node start`, so stopping goes
-through `node` too:
+`restart` landed in **2.3.0-preview.73** (#1601). 🔴 **The `latest` tag that `npm i -g`
+installs is currently 2.3.0-preview.47 — it does not have it yet**, so a default install
+takes the two-step form below. (Both endpoints were actually run: `.47` prints
+`Unknown daemon subcommand "restart"`, `.75` works.)
+
+If unsure, run `anet daemon` with no subcommand and check the list for `restart`.
+**If it is absent, use the two-step form** — `daemon start` delegates to `node start`,
+so stopping goes through `node` too:
 
 ```bash
 anet node stop <name>


### PR DESCRIPTION
## 先说清楚这不是 bug 修复

原文**已经**处理了「你的版本可能没有 `restart`」——`restart` 代码块往下第 3 行就是
`::: tip 你的版本有没有这条？` 加两步回退。**我一开始读了版本戳（第 19 行）和
`restart`（第 264 行）就下了「文档自相矛盾」的结论，没往下读三行。**

这条只是把 **procedure 换成 fact**。

## 换成什么

| | |
|---|---|
| `restart` 从哪个版本起有 | **2.3.0-preview.73**（#1601，2026-08-30） |
| 🔴 `npm i -g` 装到的 `latest` | **2.3.0-preview.47** —— **还没有这条** |

⇒ **默认安装的用户现在 100% 走两步那条路**，而原文让他们自己跑 `anet daemon` 才知道。
一个数比一次探测省事。

## 两个端点都实跑过，不是从代码推的

```console
$ node dist/bin/cli.js daemon restart        # 2.3.0-preview.47 (latest)
Unknown daemon subcommand "restart". Did you mean: anet daemon start?
rc=1

$ node dist/bin/cli.js daemon restart        # 2.3.0-preview.75 (preview)
Usage: anet daemon restart <name>
```

版本下限来自引入提交 `3371eabc`（#1601）当时的 `package.json`：`2.3.0-preview.73`。

## 顺带：我量过一道门，然后决定**不建**它

本来想做「文档里出现的 `anet <cmd>` 必须在 `cli.ts` 里真实存在」的门。先量了噪声：

- 全文匹配 → **36 条**，绝大多数是英文散文（`anet is` / `anet can` / `anet runs`）
- 收窄到只认代码围栏与行内代码 → **5 条**，逐条看完 **0 条真缺陷**：
  `anet v` 是版本串 `v2.3.0…`／`anet im` 文档明写「未实现，RFC-020 排队中」／
  `anet creat` 是 changelog 在引用 CLI 自己的报错／`anet self` 是散文／`anet is` 在 shell 注释里

要压到 0 噪声还得再加 4 条排除规则，**而每条排除都是真缺陷可以藏身的地方**；
今天的产出又是 0。**一道全是误报的门第一周就会被关掉**，所以没建。

而且它本来也拦不住今天这件事：`restart` 在 main 上是**存在**的，
出问题的是**已发布制品落后**——那是 CI 结构上看不见的东西。

## 门

`docs-integrity`（含 `--selftest`）/ `release-channel-assertions` / `doc-version-claims` /
`doc-claims` / `doc-symbol-pins` / `docs-site-orphans` 七道全部 `rc=0`。中英同步。