### PR TITLE
fix(cli): anet goal/token/batch/opencode --help 打的是 126 行全局帮助 —— 它们各自写的 help 一次没跑过

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -16059,6 +16059,22 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
     case "grok":
       console.log("Usage: anet grok attach <node>");
       break;
+      // #1668 — 同一个 bug 的第三次:opencode / goal / token / batch **各自都在
+      // 自己的命令里写了 `sub === "--help"` 分支**,而这个拦截器先命中 default,
+      // 于是那四段 help 一次都没被执行过 —— 被写了四遍的死代码。
+      //
+      // 🔴 这里**不剥 --help**(和下面 daemon 那支不同):`tokenCommand` 的守卫只认
+      // `sub === "--help"`,不认 `!sub` —— 剥掉之后它反而不打帮助了。四个的守卫都
+      // 直接认这个 flag,原样传进去即可。
+      //
+      // 🔴 只收这四个是有判据的,不是挑的:它们的 --help 分支是 console.log 之后
+      // 直接返回。而 network 一进来就 loadGlobal() 读 hub/token、channel 一进来
+      // parseOpts()、session 的 !sub 直接跑 ls —— 那三个没有前置 help 守卫,
+      // 路由过去会有副作用,正是 #215 那条 default 要防的东西,留着不动。
+    case "opencode": await opencodeCommand(); process.exit(0);
+    case "goal":     await goalCommand();     process.exit(0);
+    case "token":    await tokenCommand();    process.exit(0);
+    case "batch":    await batchCommand();    process.exit(0);
     case "daemon":
       // #717 — daemonCommand() already prints its own subcommand help for
       // bare `anet daemon`, but this intercept ran first and bounced to the

--- a/agent-network/src/help-intercept-coverage.test.ts
+++ b/agent-network/src/help-intercept-coverage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `anet <group> --help` 先被顶层的 universal 拦截器接住(#215)。拦截器里有一张
+// **手写的 case 名单**;没在名单上的一律落 `default: printHelp()`,打出 126 行全局帮助。
+//
+// 🔴 后果不是"少了点提示",是**别人写的 help 一次都跑不到**:实测 opencode /
+// goal / token / batch 四个命令**各自都在自己的函数里写了 `sub === "--help"` 分支**,
+// 四段代码全是死的。#240 已经为 hub 修过一次同样的事,#717 为 daemon 修过第二次。
+//
+// 所以这道门的判据不是"名单里有没有 X",而是**从源码反推**:
+// 凡是自己写了 `sub === "--help"` 守卫的命令,都必须在拦截器名单里 ——
+// 否则那段守卫永远执行不到。这样将来第五个人写 help 时,漏了会红。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+const CODE = CLI.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+/** 自己处理了 `sub === "--help"` 的命令函数 → 命令名。 */
+function commandsWithOwnHelp(src: string): string[] {
+  const out = new Set<string>();
+  let fn: string | null = null;
+  for (const line of src.split("\n")) {
+    const m = /^(?:async\s+)?function (\w+)\(/.exec(line);
+    if (m) fn = m[1]!;
+    if (fn && /sub === "--help"/.test(line)) {
+      const cmd = fn.replace(/Command$/, "");
+      if (cmd !== fn) out.add(cmd.toLowerCase());
+    }
+  }
+  return [...out].sort();
+}
+
+/** 拦截器 `if (args.slice(1).some(... "--help" ...))` 块里的 case 标签。 */
+function interceptCases(src: string): string[] {
+  const start = src.indexOf('if (args.slice(1).some((a) => a === "--help"');
+  if (start < 0) throw new Error("找不到 universal --help 拦截器 —— 它被改写了");
+  const end = src.indexOf("default:", start);
+  if (end < 0) throw new Error("拦截器里找不到 default 分支");
+  return [...src.slice(start, end).matchAll(/case "([^"]+)":/g)].map(m => m[1]!).sort();
+}
+
+describe("--help 拦截器的覆盖", () => {
+  const own = commandsWithOwnHelp(CODE);
+  const cases = interceptCases(CODE);
+
+  it("取集正控：两侧都真的解析出了东西（空集会让下面那条空过）", () => {
+    expect(own.length).toBeGreaterThanOrEqual(4);
+    expect(cases.length).toBeGreaterThanOrEqual(6);
+    expect(cases).toContain("daemon");   // #717 修过的那个,不该消失
+    expect(cases).toContain("hub");      // #240 修过的那个
+  });
+
+  it("凡是自己写了 --help 守卫的命令,都在拦截器名单里 —— 否则那段守卫是死代码", () => {
+    const dead = own.filter(c => !cases.includes(c));
+    expect(dead).toEqual([]);
+  });
+
+  it("这四个是漏过的,单独钉住", () => {
+    for (const c of ["opencode", "goal", "token", "batch"]) expect(cases).toContain(c);
+  });
+});


### PR DESCRIPTION
`anet <group> --help` 先被顶层的 universal 拦截器（`#215`）接住，而那是一张**手写的 case 名单**；
不在名单上的一律落 `default: printHelp()`。

🔴 **后果不是"少了点提示"，是别人写的 help 一次都执行不到：**

| 命令 | `--help` 实际打出 | 而它自己写了 |
|---|---|---|
| `anet goal --help` | 126 行全局帮助 | `goalCommand` L12327 `sub === "--help"` |
| `anet token --help` | 126 行全局帮助 | `tokenCommand` L13069 |
| `anet batch --help` | 126 行全局帮助 | `batchCommand` L15296 |
| `anet opencode --help` | 126 行全局帮助 | `opencodeCommand` L11317 |

**四个作者各写了一段 help，四段都是死代码。**

这是同一个 bug 的**第三次**。`#240` 已经为 `hub` 修过（注释原话：*"hid stop/status entirely —
looked like a regression even though the routes were still wired"*），`#717` 为 `daemon` 修过第二次。

## 只收这四个，是有判据的，不是挑的

它们的 `--help` 分支是 `console.log` 之后**直接返回**。而：

- `networkCommand` 一进来就 `loadGlobal()` 读 hub/token
- `channelCommand` 一进来就 `parseOpts()`
- `sessionCommand` 的 `!sub` **直接跑 ls**

这三个**没有前置 help 守卫**，路由过去会有副作用 —— 正是 `#215` 那条 `default` 要防的东西，
留着不动。（它们的 `--help` 仍然不对，但修法是先给它们加前置守卫，不在本 PR 范围。）

## 🔴 第一版我写错了，是"跑一遍"抓住的，不是 build

先把四个 `case` 贯穿到 `daemon` 那段体上。**build 绿**，而实跑：

```console
$ anet goal  --help → Usage: anet daemon <subcommand> [name] [options]
$ anet token --help → Usage: anet daemon <subcommand> [name] [options]
```

**四个命令全去打 daemon 的帮助了 —— 比原来更糟。** 改成各调各的函数。

另外**不剥 `--help`**（和 `daemon` 那支不同）：`tokenCommand` 的守卫只认
`sub === "--help"`、不认 `!sub`，剥掉之后它反而不打帮助。

## 门的判据是反推的，不是又一张手写名单

`help-intercept-coverage.test.ts`：**凡是自己写了 `sub === "--help"` 守卫的命令，
必须在拦截器名单里** —— 否则那段守卫是死代码。第五个人漏了会红。

```
基线                          3 pass 0 fail
变异①去掉 goal 那一支（名单层）1 pass 2 fail
变异②反推器恒返空（取集层）    2 pass 1 fail   ← 正控逮住
还原                          3 pass 0 fail   cli.ts 逐字还原 ✓
```

## 验收

八个组**实跑逐一确认**：`goal` / `token` / `batch` / `opencode` 新修好，
`daemon` / `hub` / `node` / `project` 未受影响。
`doc-symbol-pins` `rc=0`；`agent-network/src/` 单测 **933 个 0 fail**。