### PR TITLE
fix(cli): route network/channel/session help before side effects

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8817,9 +8817,22 @@ async function importCommand() {
 
 // ── session ──
 
+function printSessionUsage() {
+  console.log(`
+anet session <command>
+
+  ls    List Claude Code sessions in current project
+`);
+}
+
 function sessionCommand() {
   const sub = args[1];
-  if (sub === "ls" || sub === "list" || !sub) {
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    printSessionUsage();
+    return;
+  }
+
+  if (sub === "ls" || sub === "list") {
     // Scan ~/.claude/projects/{project-key}/ for .jsonl files (#115: shared
     // helper with the `anet node create` resume picker).
     const cwd = process.cwd();
@@ -8837,11 +8850,7 @@ function sessionCommand() {
     }
     console.log();
   } else {
-    console.log(`
-anet session <command>
-
-  ls    List Claude Code sessions in current project
-`);
+    printSessionUsage();
   }
 }
 
@@ -10837,10 +10846,28 @@ Delete a node and its config. Use --force to skip confirmation.
 
 // ── channel ──
 
+function printChannelUsage() {
+  console.log(`
+anet channel <command>
+
+  add <type> <node-id>          Add channel to a node
+  allow feishu <node-id>        Manage feishu allowFrom / allowChats (--add-from/--add-chat/--rm-from/--rm-chat; repeatable)
+  ls [node-id]                  List channels (shows allowFrom + allowChats for feishu)
+  status [node-id]              Show resolved access.json path + allowlist + pending pairings
+
+Data: .anet/nodes/<node-id>/channels/<type>/
+`);
+}
+
 async function channelCommand() {
   // anet channel add telegram <node-id> --bot-token xxx --allow xxx
   // anet channel ls [node-id]
   const sub = args[1];
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    printChannelUsage();
+    return;
+  }
+
   const opts = parseOpts();
 
   if (sub === "add") {
@@ -11180,16 +11207,7 @@ Note: changes take effect on next \`anet node start\` (no hot-reload yet).
     }
 
   } else {
-    console.log(`
-anet channel <command>
-
-  add <type> <node-id>          Add channel to a node
-  allow feishu <node-id>        Manage feishu allowFrom / allowChats (--add-from/--add-chat/--rm-from/--rm-chat; repeatable)
-  ls [node-id]                  List channels (shows allowFrom + allowChats for feishu)
-  status [node-id]              Show resolved access.json path + allowlist + pending pairings
-
-Data: .anet/nodes/<node-id>/channels/<type>/
-`);
+    printChannelUsage();
   }
 }
 
@@ -12824,8 +12842,29 @@ async function whoamiCommand() {
 
 // ── network ──
 
+function printNetworkUsage() {
+  console.log(`
+anet network <command>
+
+  ls                    List my networks
+  create <name>         Create a new network
+  use <name>            Switch to a network
+  info                  Current network details + stats
+  rename <old> <new>    Rename a network
+  delete <name> --force Delete a network
+  invite                Generate invite code for current network
+  join <code>           Join a network by invite code
+  members               List members of current network
+`);
+}
+
 async function networkCommand() {
   const sub = args[1];
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    printNetworkUsage();
+    return;
+  }
+
   const gc = loadGlobal();
   const hub = gc.hub;
   const token = gc.token;
@@ -13014,19 +13053,7 @@ async function networkCommand() {
     return;
   }
 
-  console.log(`
-anet network <command>
-
-  ls                    List my networks
-  create <name>         Create a new network
-  use <name>            Switch to a network
-  info                  Current network details + stats
-  rename <old> <new>    Rename a network
-  delete <name> --force Delete a network
-  invite                Generate invite code for current network
-  join <code>           Join a network by invite code
-  members               List members of current network
-`);
+  printNetworkUsage();
 }
 
 // ── logs ──
@@ -16073,10 +16100,19 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
       // 直接返回。而 network 一进来就 loadGlobal() 读 hub/token、channel 一进来
       // parseOpts()、session 的 !sub 直接跑 ls —— 那三个没有前置 help 守卫,
       // 路由过去会有副作用,正是 #215 那条 default 要防的东西,留着不动。
-    case "opencode": await opencodeCommand(); process.exit(0);
-    case "goal":     await goalCommand();     process.exit(0);
-    case "token":    await tokenCommand();    process.exit(0);
-    case "batch":    await batchCommand();    process.exit(0);
+    case "opencode": await opencodeCommand(); break;
+    case "goal":     await goalCommand();     break;
+    case "token":    await tokenCommand();    break;
+    case "batch":    await batchCommand();    break;
+    case "network":
+      await networkCommand();
+      break;
+    case "channel":
+      await channelCommand();
+      break;
+    case "session":
+      sessionCommand();
+      break;
     case "daemon":
       // #717 — daemonCommand() already prints its own subcommand help for
       // bare `anet daemon`, but this intercept ran first and bounced to the

--- a/docs/tests/report-test1669-help-routing.txt
+++ b/docs/tests/report-test1669-help-routing.txt
@@ -1,0 +1,32 @@
+Issue: #1669 anet network/channel/session --help routing
+Date: 2026-08-31
+
+Worktree:
+  /home/vansin/agent-orchestra/.worktrees/issue-1669-help-guards
+
+Before change (origin/main 89837513, built dist/bin/anet.cjs):
+  anet network --help  first non-empty line: anet — AI Agent Network CLI (V2)
+  anet channel --help  first non-empty line: anet — AI Agent Network CLI (V2)
+  anet session --help  first non-empty line: anet — AI Agent Network CLI (V2)
+
+After change (built dist/bin/anet.cjs):
+  anet network --help  first non-empty line: anet network <command>
+  anet channel --help  first non-empty line: anet channel <command>
+  anet session --help  first non-empty line: anet session <command>
+
+Commands:
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun run build
+  Result: pass
+
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/
+  Result: fail
+  Summary: 943 pass, 3 skip, 1 fail, 2706 expect() calls, 947 tests across 100 files.
+  Failure: agent-network/src/posix-codex-copresence.test.ts expected probePosixOwnedLoopbackConnection(process.pid, server.port) to be true, received false.
+
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/top-level-help-contract.test.ts
+  Result: pass
+  Summary: 2 pass, 0 fail, 9 expect() calls.
+
+  python3 scripts/check-doc-symbol-pins.py --fix
+  Result: pass
+  Summary: SYMBOL-PIN OK, 0 drift.

--- a/docs/tests/report-test1669-help-routing.txt
+++ b/docs/tests/report-test1669-help-routing.txt
@@ -2,7 +2,7 @@ Issue: #1669 anet network/channel/session --help routing
 Date: 2026-08-31
 
 Worktree:
-  /home/vansin/agent-orchestra/.worktrees/issue-1669-help-guards
+  <repo>/.worktrees/issue-1669-help-guards   # 公开仓不写本机绝对路径（check-home-path-baseline）
 
 Before change (origin/main 89837513, built dist/bin/anet.cjs):
   anet network --help  first non-empty line: anet — AI Agent Network CLI (V2)


### PR DESCRIPTION
## Summary

Fixes #1669.

- add early, pre-I/O help guards for `networkCommand`, `channelCommand`, and `sessionCommand`
- route `anet network/channel/session --help` through the per-command handlers in the global help interceptor
- keep `session ls/list` as the explicit session scan path while bare `anet session` now prints usage
- record verification in `docs/tests/report-test1669-help-routing.txt`

## Verification

Built CLI before change from `origin/main` (`89837513`) and checked first non-empty line:

```text
anet network --help  -> anet — AI Agent Network CLI (V2)
anet channel --help  -> anet — AI Agent Network CLI (V2)
anet session --help  -> anet — AI Agent Network CLI (V2)
```

Built CLI after change and checked first non-empty line:

```text
anet network --help  -> anet network <command>
anet channel --help  -> anet channel <command>
anet session --help  -> anet session <command>
```

Commands run:

```text
PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun run build
# pass

PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/
# 943 pass, 3 skip, 1 fail, 2706 expect() calls, 947 tests across 100 files
# fail: agent-network/src/posix-codex-copresence.test.ts expected
# probePosixOwnedLoopbackConnection(process.pid, server.port) to be true, received false

PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/top-level-help-contract.test.ts
# 2 pass, 0 fail, 9 expect() calls

python3 scripts/check-doc-symbol-pins.py --fix
# SYMBOL-PIN OK, 0 drift
```
