### PR TITLE
ux(doctor): 同一个节点 doctor 说 stopped、node ls 说 idle —— 两个词都没说自己量的是什么

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -47,6 +47,7 @@ import { formatHubVersionDetail } from "../src/hub-version-skew";
 import { nodeCountLine } from "../src/doctor-node-count";
 import { nodeNotFoundMessage } from "../src/node-not-found";
 import { lsHeaderRow, lsSeparatorRow, runtimeColumnWidth } from "../src/ls-columns";
+import { describeLocalProcess, LOCAL_VS_HUB_NOTE, type LocalProcessState } from "../src/local-process-state";
 import { daemonSubcommandRedirect, nodeSubcommandRedirect, projectSubcommandRedirect } from "../src/subcommand-redirect";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
 import { isSameIncarnation, processVanished, resolveOwnedRoots, type OwnedRootCandidate } from "../src/owned-roots";
@@ -15837,8 +15838,16 @@ async function doctorCommand() {
     const name = nodeDisplayName(id, p);
     const runtime = normalizeRuntime(p || undefined);
     const pid = join(nodesDir(), id, ".pid");
-    const alive = existsSync(pid) ? (() => { try { process.kill(parseInt(readFileSync(pid, "utf-8")), 0); return true; } catch { return false; } })() : false;
-    info(`  ${name}`, `${runtime} ${alive ? "● running" : "○ stopped"} node_id=${p?.node_id || "-"}`);
+    // 🔴 这一列量的是**本机进程**,不是 hub 的看法。原先印无限定的 running/stopped,
+    // 和 `anet node ls` 的 STATUS(来自 CommHub)会给出相反答案而无从分辨。
+    const localState: LocalProcessState = (() => {
+      if (!existsSync(pid)) return { kind: "none" };
+      const raw = parseInt(readFileSync(pid, "utf-8").trim(), 10);
+      if (!Number.isFinite(raw)) return { kind: "none" };
+      try { process.kill(raw, 0); return { kind: "alive", pid: raw }; } catch { return { kind: "stale", pid: raw }; }
+    })();
+    const alive = localState.kind === "alive";
+    info(`  ${name}`, `${runtime} ${describeLocalProcess(localState)} node_id=${p?.node_id || "-"}`);
     if (p && runtime === "codex-app-server") {
       const audit = codexTopologyAudit(p as any, join(nodesDir(), id), process.cwd());
       const verified = audit.lastRecoveryVerification as any;
@@ -15866,6 +15875,9 @@ async function doctorCommand() {
       }
     }
   }
+  // 说清上面那一列量的是什么 —— 否则它和 anet node ls 的 STATUS 是两个
+  // 同样权威、可以互相矛盾的答案。
+  if (ids.length) info("  这一列的含义", LOCAL_VS_HUB_NOTE);
   if (needsMigration.length) {
     if (fix) {
       console.log(`\n  ⚙  Auto-fixing ${needsMigration.length} node(s)...`);

--- a/agent-network/src/local-process-state.test.ts
+++ b/agent-network/src/local-process-state.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { describeLocalProcess, LOCAL_VS_HUB_NOTE } from "./local-process-state";
+
+describe("doctor 的本机进程一列", () => {
+  it("活着时把 pid 一起说出来 —— 好让人能自己去核", () => {
+    expect(describeLocalProcess({ kind: "alive", pid: 892216 })).toContain("892216");
+    expect(describeLocalProcess({ kind: "alive", pid: 892216 })).toContain("●");
+  });
+
+  it("🔴 有 .pid 但进程已死,要说清是**哪个 pid 不在了**,不能只说 stopped", () => {
+    const m = describeLocalProcess({ kind: "stale", pid: 308103 });
+    expect(m).toContain("308103");
+    expect(m).toContain("已不在");
+  });
+
+  it("从来没有 .pid,和「有但死了」必须是两句不同的话", () => {
+    const none = describeLocalProcess({ kind: "none" });
+    const stale = describeLocalProcess({ kind: "stale", pid: 1 });
+    expect(none).not.toBe(stale);
+    expect(none).not.toContain("已不在");
+  });
+
+  it("三种情况都不说无限定的 running/stopped —— 那正是和 node ls 打架的措辞", () => {
+    for (const s of [
+      { kind: "alive", pid: 1 } as const,
+      { kind: "stale", pid: 1 } as const,
+      { kind: "none" } as const,
+    ]) {
+      const m = describeLocalProcess(s);
+      expect(m).not.toContain("running");
+      expect(m).not.toContain("stopped");
+      expect(m).toContain("本机");   // 每一句都点名量的是本机
+    }
+  });
+
+  it("那句说明必须同时点名两边和各自的去处", () => {
+    expect(LOCAL_VS_HUB_NOTE).toContain("本机进程");
+    expect(LOCAL_VS_HUB_NOTE).toContain("anet node ls");
+    expect(LOCAL_VS_HUB_NOTE).toContain("不一致");
+  });
+});

--- a/agent-network/src/local-process-state.ts
+++ b/agent-network/src/local-process-state.ts
@@ -1,0 +1,32 @@
+// `anet doctor` 每个节点后面印 `● running` / `○ stopped`,而它量的其实只是
+// **本机 `.anet/nodes/<id>/.pid` 里的那个进程还在不在**。`anet node ls` 的
+// STATUS 列量的是**另一件事** —— CommHub 说这个 alias 是什么状态。
+//
+// 🔴 实测两者会给出相反的答案:2026-08-31 本机 `通信牛` 的 `.pid` 记着 308103,
+// 那个进程**已经死了**(doctor 说 stopped),而 hub 仍然报它 idle(node ls 说 idle)。
+// 两句话都是真的,只是说的不是同一件事 —— 而两边都写成了无限定的 running/stopped,
+// 用户拿到两个同样权威的相反答案,无从判断信哪个。
+//
+// 所以这里不改判据(它量得没错),改的是**它说自己量了什么**。
+// 同族:doctor 的 0 节点那一格(#1660)也是"同一个数字对应两种现实,就把两种都说出来"。
+
+export type LocalProcessState =
+  | { kind: "alive"; pid: number }
+  | { kind: "stale"; pid: number }   // 有 .pid,但那个进程已经不在了
+  | { kind: "none" };                // 压根没有 .pid 记录
+
+export function describeLocalProcess(state: LocalProcessState): string {
+  switch (state.kind) {
+    case "alive":
+      return `● 本机进程存活 (pid ${state.pid})`;
+    case "stale":
+      return `○ 本机无存活进程 (.pid 记的 ${state.pid} 已不在)`;
+    case "none":
+      return `○ 本机没有 .pid 记录`;
+  }
+}
+
+/** doctor 印完节点清单后的那一句:说清这一列量的是本机,不是 hub。 */
+export const LOCAL_VS_HUB_NOTE =
+  "上面这一列量的是本机进程;hub 那边怎么看要用 anet node ls 的 STATUS 列 —— " +
+  "两者可以不一致(共存节点、hub 会话尚未过期、进程在别的机器上,都会造成这种情况)。";


### PR DESCRIPTION
真跑本机，两条命令给出**相反**的答案：

```console
$ anet node ls  → 通信牛  codex-app-server  idle
$ anet doctor   → 通信牛: codex-app-server ○ stopped
```

🔴 **不是谁算错了，是两个都是真的**：

| 命令 | 它量的是 |
|---|---|
| `anet doctor` | **本机** `.anet/nodes/<id>/.pid` 里那个进程还在不在 |
| `anet node ls` 的 STATUS | **CommHub** 说这个 alias 是什么状态 |

坐实的机制：`通信牛` 的 `.pid` 记着 **308103，而那个进程已经死了**；hub 那边的会话还没过期，
所以仍报 `idle`。**用户拿到两个同样权威的相反答案，无从判断信哪个。**

## 所以改的不是判据（它量得没错），是「它说自己量了什么」

```
改前   通信牛: codex-app-server ○ stopped
改后   通信牛: codex-app-server ○ 本机无存活进程 (.pid 记的 308103 已不在)
```

三种现实分开说 —— 它们的下一步不同：

```
● 本机进程存活 (pid 892216)
○ 本机无存活进程 (.pid 记的 308103 已不在)     ← 有记录但进程没了
○ 本机没有 .pid 记录                            ← 从没在本机起过
```

清单末尾补一行：这一列量的是本机，hub 那边看 `anet node ls` 的 STATUS，
**并明说两者可以不一致**（共存节点 / hub 会话未过期 / 进程在别的机器上）。

同族：`#1660` 让 doctor 的 0 节点不再报 error，也是"同一个观察对应两种现实，就把两种都说出来"。

## 三向变异见证

```
基线                                    5 pass 0 fail
变异①stale 退回无限定的 stopped（判据层） 3 pass 2 fail
变异②把「没有记录」和「记录已死」合并    4 pass 1 fail
变异③说明行不再点名去哪看（可操作性）    4 pass 1 fail
还原                                    5 pass 0 fail
```

三条测的不是同一件事：①问「措辞退回去红不红」，②问「两种现实合并红不红」，③问「说明行还指不指得出去处」。

## 两处只有真跑才看得到的措辞问题

`info()` 会给标签补冒号，`info("  ↳", …)` 印出来是 `↳:` 读着别扭；
`**本机进程**` 的星号在终端**不渲染**。都改掉了。

## 验收

上面的改前/改后是**两个真实构建各跑一次**量出来的，不是设想。
`agent-network/src/` 单测 **949 个 0 fail**；`doc-symbol-pins` `rc=0`。