### PR TITLE
ux(cli): anet status / anet tasks 的表里有三个不同的列位 —— 表头 13、普通行 11、delivered 行 12

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -46,7 +46,7 @@ import { daemonPathWarnings } from "../src/daemon-runtime-path-preflight";
 import { formatHubVersionDetail } from "../src/hub-version-skew";
 import { nodeCountLine } from "../src/doctor-node-count";
 import { nodeNotFoundMessage } from "../src/node-not-found";
-import { lsHeaderRow, lsSeparatorRow, runtimeColumnWidth } from "../src/ls-columns";
+import { columnWidth, lsHeaderRow, lsSeparatorRow, runtimeColumnWidth } from "../src/ls-columns";
 import { describeLocalProcess, LOCAL_VS_HUB_NOTE, type LocalProcessState } from "../src/local-process-state";
 import { daemonSubcommandRedirect, nodeSubcommandRedirect, projectSubcommandRedirect } from "../src/subcommand-redirect";
 import { resolveRuntimeForResume } from "../src/resume-runtime-infer";
@@ -12121,10 +12121,16 @@ async function statusCommand() {
 
     if (tasks.length > 0) {
       console.log("  Recent Tasks:");
-      console.log("  STATUS     FROM            TO              CONTENT");
-      console.log("  ──────── ─────────────── ─────────────── ────────────────────────");
+      // 🔴 STATUS 列原先写死 8,而 "delivered"/"cancelled"/"completed" 都是 9 —— 
+      // 那些行会把 FROM 往右顶 1 列。而表头和分隔线是两个各写各的字面量,
+      // 实测同一张表出现三个列位:表头 13 / 普通行 11 / delivered 行 12。
+      // 宽度从**要打印的这批行**算(状态值域在另一个包里,CLI import 不到),
+      // 表头/分隔线/数据行共用它。
+      const stW = columnWidth(tasks.map((t: any) => String(t.status || "?")), "STATUS");
+      console.log(`  ${"STATUS".padEnd(stW)} ${"FROM".padEnd(15)} ${"TO".padEnd(15)} CONTENT`);
+      console.log(`  ${"─".repeat(stW)} ${"─".repeat(15)} ${"─".repeat(15)} ${"─".repeat(8)}`);
       for (const t of tasks.slice(0, 10)) {
-        const st = (t.status || "?").padEnd(8);
+        const st = (t.status || "?").padEnd(stW);
         const from = padDisplayEnd(t.from_name || "?", 15);
         const to = padDisplayEnd(t.to_name || "?", 15);
         const content = oneLineCell(t.content, 40);
@@ -12159,10 +12165,16 @@ async function tasksCommand() {
     }
 
     console.log(`\n  Tasks (${tasks.length}):\n`);
-    console.log("  STATUS     FROM            TO              AGE      CONTENT");
-    console.log("  ──────── ─────────────── ─────────────── ──────── ────────────────────────");
+    // 🔴 STATUS 列原先写死 8,而 "delivered"/"cancelled"/"completed" 都是 9 —— 
+    // 那些行会把 FROM 往右顶 1 列。而表头和分隔线是两个各写各的字面量,
+    // 实测同一张表出现三个列位:表头 13 / 普通行 11 / delivered 行 12。
+    // 宽度从**要打印的这批行**算(状态值域在另一个包里,CLI import 不到),
+    // 表头/分隔线/数据行共用它。
+    const stW = columnWidth(tasks.map((t: any) => String(t.status || "?")), "STATUS");
+    console.log(`  ${"STATUS".padEnd(stW)} ${"FROM".padEnd(15)} ${"TO".padEnd(15)} ${"AGE".padEnd(8)} CONTENT`);
+    console.log(`  ${"─".repeat(stW)} ${"─".repeat(15)} ${"─".repeat(15)} ${"─".repeat(8)} ${"─".repeat(8)}`);
     for (const t of tasks) {
-      const st = (t.status || "?").padEnd(8);
+      const st = (t.status || "?").padEnd(stW);
       const from = padDisplayEnd((t.from_name || "?").slice(0, 15), 15);
       const to = padDisplayEnd((t.to_name || "?").slice(0, 15), 15);
       const age = t.created_at ? timeAgo(t.created_at) : "?";

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8868,12 +8868,16 @@ function sessionCommand() {
     if (sessions.length === 0) { console.log(`No sessions for ${cwd}`); return; }
 
     console.log(`\nSessions in ${cwd} (${sessions.length} total):\n`);
-    console.log("  SESSION ID                             SIZE      MODIFIED");
-    console.log("  ──────────────────────────────────────  ────────  ────────────────");
+    // 🔴 表头和分隔线原是两个写死的字面量,和数据行对不上:数据行右边缘 38/48/60,
+    // 分隔线 40/50/68,表头的 SIZE 落在 45。数据行彼此是一致的 —— 歪的是这两行。
+    // id 列宽从**本次要打印的会话**算;SIZE 保持右对齐(padStart)因为它是数字。
+    const idW = columnWidth(sessions.map((x) => x.id), "SESSION ID");
+    console.log(`  ${"SESSION ID".padEnd(idW)}  ${"SIZE".padStart(8)}  MODIFIED`);
+    console.log(`  ${"─".repeat(idW)}  ${"─".repeat(8)}  ${"─".repeat(16)}`);
 
     for (const s of sessions) {
       const mtime = new Date(s.mtimeMs).toISOString().replace("T", " ").slice(0, 16);
-      console.log(`  ${s.id}  ${formatSize(s.sizeBytes).padStart(8)}  ${mtime}`);
+      console.log(`  ${s.id.padEnd(idW)}  ${formatSize(s.sizeBytes).padStart(8)}  ${mtime}`);
     }
     console.log();
   } else {
@@ -13190,10 +13194,19 @@ anet token <command>
     if (!res.ok) { console.error(res.error); return; }
     if (!res.tokens?.length) { console.log("\n  No tokens. Create one: anet token create <name>\n"); return; }
     console.log("\n  API Tokens:\n");
-    console.log("  ID                   NAME           CREATED                  LAST USED");
-    console.log("  ──────────────────── ────────────── ──────────────────────── ────────────────────────");
+    // 🔴 表头里 ID 留 20 列,数据行却是 padEnd(22) —— 整张表从第二列起就错开 2。
+    // 三处宽度改为同一组常量。
+    // 🔴 而 name 是用户起的、没有上限:写死 14 时一个长名字就把 CREATED 顶偏(本机实测有一个)。
+    // 三列宽度全部从**本次要打印的这批 token** 算,表头/分隔线/数据行共用同一组。
+    const tW = {
+      id: columnWidth(res.tokens.map((t: any) => String(t.token_id || "?")), "ID"),
+      name: columnWidth(res.tokens.map((t: any) => String(t.name || "?")), "NAME"),
+      created: columnWidth(res.tokens.map((t: any) => String(t.created_at || "?")), "CREATED"),
+    };
+    console.log(`  ${padDisplayEnd("ID", tW.id)} ${padDisplayEnd("NAME", tW.name)} ${padDisplayEnd("CREATED", tW.created)} LAST USED`);
+    console.log(`  ${"─".repeat(tW.id)} ${"─".repeat(tW.name)} ${"─".repeat(tW.created)} ${"─".repeat(9)}`);
     for (const t of res.tokens) {
-      console.log(`  ${(t.token_id || "?").padEnd(22)} ${(t.name || "?").padEnd(14)} ${(t.created_at || "?").padEnd(24)} ${t.last_used_at || "never"}`);
+      console.log(`  ${padDisplayEnd(String(t.token_id || "?"), tW.id)} ${padDisplayEnd(String(t.name || "?"), tW.name)} ${padDisplayEnd(String(t.created_at || "?"), tW.created)} ${t.last_used_at || "never"}`);
     }
     console.log();
   } catch (e: any) { console.error(friendlyError(e)); }

--- a/agent-network/src/ls-columns.test.ts
+++ b/agent-network/src/ls-columns.test.ts
@@ -43,3 +43,50 @@ describe("anet node ls 的 RUNTIME 列宽", () => {
     expect(runtimeColumnWidth(["codex-sdk", null as any, undefined as any])).toBe(9);
   });
 });
+
+// ── anet status / anet tasks 的 STATUS 列 ──
+// 这一列的值域在 server/ 里(另一个包),CLI import 不到,所以宽度从**要打印的那批行**算。
+import { columnWidth } from "./ls-columns";
+import { readFileSync as readCli } from "node:fs";
+import { join as joinCli } from "node:path";
+
+describe("STATUS 列宽", () => {
+  it("🔴 'delivered' 是 9 —— 写死的 8 装不下它,这正是表歪掉的原因", () => {
+    expect(columnWidth(["delivered"], "STATUS")).toBe(9);
+    expect(columnWidth(["running", "replied"], "STATUS")).toBe(7);  // 都比表头短 → 取表头
+  });
+
+  it("值域将来变长也跟得上(不是又写死一个 9)", () => {
+    expect(columnWidth(["in_progress"], "STATUS")).toBe(11);
+  });
+
+  it("空行集时至少留得下表头", () => {
+    expect(columnWidth([], "STATUS")).toBe(6);
+  });
+
+  it("非字符串项跳过,不把列撑坏", () => {
+    expect(columnWidth([null, undefined, 42, "delivered"] as any, "STATUS")).toBe(9);
+  });
+});
+
+describe("接线:两张表不再各写各的表头字面量", () => {
+  const cli = readCli(joinCli(import.meta.dir, "..", "bin", "cli.ts"), "utf-8")
+    .split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+  it("写死的 STATUS 表头字面量一个都不剩", () => {
+    const literals = [...cli.matchAll(/console\.log\("  STATUS {2,}FROM[^"]*"\)/g)];
+    expect(literals.map(m => m[0])).toEqual([]);
+  });
+
+  it("正控:确实接上了 —— 两张表各自算 stW", () => {
+    expect((cli.match(/const stW = columnWidth\(/g) || []).length).toBe(2);
+  });
+
+  it("🔴 每一处 status 数据行都用 stW —— 不能有任何一处还写死宽度", () => {
+    // 第一版这里写的是 `.padEnd(stW) 至少 2 次`,而它实际有 4 次(2 表头 + 2 数据行),
+    // 退回一处还剩 3 仍然过 —— 判据太松,朝「没问题」错。改成直接盯 status 那个表达式。
+    const statusPads = [...cli.matchAll(/\(t\.status \|\| "\?"\)\.padEnd\((\w+)\)/g)].map(m => m[1]);
+    expect(statusPads.length).toBe(2);
+    expect(statusPads).toEqual(["stW", "stW"]);
+  });
+});

--- a/agent-network/src/ls-columns.ts
+++ b/agent-network/src/ls-columns.ts
@@ -11,14 +11,29 @@ import { displayWidth } from "./display-width";
 // 表头和分隔线也从同一个宽度生成 —— 原先它们是两个各自写死的字符串字面量,
 // 三处宽度靠人对齐,任何一处改了另外两处不会跟。
 
-export function runtimeColumnWidth(names: readonly string[], header = "RUNTIME"): number {
+/**
+ * 一列该多宽:装得下表头,也装得下这一列里最长的那个值。
+ *
+ * 🔴 两处用它的地方来源不同,但问题一样:
+ *  - `anet node ls` 的 RUNTIME 列:值域来自 `SUPPORTED_RUNTIME_NAMES`(唯一真源);
+ *  - `anet status` / `anet tasks` 的 STATUS 列:值域散在 server/ 里(另一个包),
+ *    CLI 没法 import —— 但**要打印的那些行就在手上**,直接从数据算。
+ *
+ * 两种情况都不该写死一个数:写死的那个,下一次加 runtime / 加状态时就漂了。
+ */
+export function columnWidth(values: readonly unknown[], header: string): number {
   let w = displayWidth(header);
-  for (const n of names) {
-    if (typeof n !== "string") continue;
-    const d = displayWidth(n);
+  for (const v of values) {
+    if (typeof v !== "string") continue;
+    const d = displayWidth(v);
     if (d > w) w = d;
   }
   return w;
+}
+
+/** RUNTIME 列的专用入口 —— 保留原名,调用点不用改。 */
+export function runtimeColumnWidth(names: readonly string[], header = "RUNTIME"): number {
+  return columnWidth(names, header);
 }
 
 const NAME_W = 20;

--- a/tests/test649-token-cli/run.sh
+++ b/tests/test649-token-cli/run.sh
@@ -127,8 +127,12 @@ echo "MUTATION_RED: parsed-name-bypassed rc=$name_rc"
 cp /tmp/test649-cli.ts agent-network/bin/cli.ts
 
 echo "L5 witnessed-red: omit created_at from rendered list"
-sed -i 's/(t.created_at || "?")\.padEnd(24)/"".padEnd(24)/' agent-network/bin/cli.ts
-grep -Fq '"".padEnd(24)' agent-network/bin/cli.ts
+# 🔴 这条变异钉的是**源码字面量**。列宽改成从数据算之后(见 anet status/tasks/session/token
+# 四张表统一列宽那条 PR),原来的 `(t.created_at || "?").padEnd(24)` 不存在了 ——
+# sed 匹配不到 ⇒ 下一行 grep 失败 ⇒ set -e 打死脚本,**看起来像被测行为回归了,其实是变异打不进去**。
+# 重新指向新文本,语义一字不变:把 created_at 换成空串,日期必须从输出里消失。
+sed -i 's/padDisplayEnd(String(t.created_at || "?"), tW.created)/padDisplayEnd("", tW.created)/' agent-network/bin/cli.ts
+grep -Fq 'padDisplayEnd("", tW.created)' agent-network/bin/cli.ts
 build_cli
 run_cli token ls >/tmp/test649-created-mutation.out
 set +e


### PR DESCRIPTION
真跑 main 构建，量每一行**第二列的显示起始列**：

```
改前   表头                 FROM 起于 13
       分隔线                        11
       running / replied 行          11
       delivered 行                  12   ← "delivered" 是 9，而列宽写死 8

改后   全部 [2, 12, 28, 44]（anet tasks 多一列 AGE：53）
```

🔴 **表头连自己的分隔线都对不上** —— 它们是两个各写各的字符串字面量，
数据行是第三处独立的 `padEnd(8)`。**三处宽度靠人对齐。**

## 状态值域在另一个包里，所以从数据算

`delivered` / `cancelled` / `completed` 都是 **9**。这些值散在 `server/` 里
（`scheduled-tasks.ts` / `db.ts` / `task-diagnostic.ts`），**CLI import 不到**，没有唯一枚举可反推。

但这张表**手上就有要打印的那批行** —— 宽度从数据算，对将来任何新状态都成立，
而不是再写死一个 9（那是下次加状态时再漂一遍）。

复用 `#1671` 抽出的 `ls-columns`：把 `runtimeColumnWidth` 泛化成 `columnWidth`，
`runtimeColumnWidth` 改为调用它，**不留两份同义实现**。

## 🔴 我的接线守卫第一版是松的，变异当场逮住

第一版写 `.padEnd(stW)` **至少 2 次**。而它实际有 **4 次**（2 表头 + 2 数据行），
退回一处还剩 3，**仍然过** —— 判据朝"没问题"错。

改成直接盯 `(t.status || "?").padEnd(?)` 的**实参**，断言恰好 2 处且都是 `stW`：

```
收紧前  变异①退回一处数据行   11 pass 0 fail   ← 没红
收紧后  基线                  12 pass 0 fail
        变异①退回一处数据行   11 pass 1 fail   ← 红了
        变异②判据只看表头      6 pass 5 fail
        还原                  12 pass 0 fail   逐字还原 ✓
```

## 验收

列位是**真跑 build 出来的 CLI 量的**，不是设想。
`agent-network/src/` 全套 **970 pass 0 fail**；`doc-symbol-pins` `rc=0`。

## 依赖

基于 `#1671` 的分支（共用 `ls-columns`）。`#1671` 合入后本条即可跟进。