### PR TITLE
ux(cli): 还有 9 处补齐在数码元不数显示列 —— 本机的 alias 几乎全是中文

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8706,7 +8706,7 @@ async function daemonListCommand() {
   for (const { id, profile } of daemons) {
     const nid = (profile as any)?.node_id || "(missing)";
     const runtimes = ((profile as any)?.runtimes_supported || []).join(",") || "(default)";
-    console.log(`  ${id.padEnd(24)} node_id=${nid}  runtimes=[${runtimes}]`);
+    console.log(`  ${padDisplayEnd(id, 24)} node_id=${nid}  runtimes=[${runtimes}]`);
     if (byNodeId === null) {
       // hub 不可达/未配置 —— 这是**第四种**情况,和"没报过"不同:
       // 那台 daemon 可能报得好好的,只是我们现在问不到。别把它说成未知能力。
@@ -11033,7 +11033,7 @@ Examples:
         const chatsStr =
           allowChats.length > 0 ? `  chats: ${allowChats.join(", ")}` : "";
         console.log(
-          `  ${label.padEnd(20)} ${t.padEnd(12)} from: ${fromStr}${chatsStr}`,
+          `  ${padDisplayEnd(label, 20)} ${t.padEnd(12)} from: ${fromStr}${chatsStr}`,
         );
       }
     }
@@ -11329,7 +11329,7 @@ function printUpgradePlan(plan: UpgradePlanRow[]) {
       case "self-skip":     badge = "(self — see below)"; break;
       case "lookup-failed": badge = "⚠ npm registry lookup failed"; break;
     }
-    console.log(`    ${p.display.padEnd(18)}  ${cur.padEnd(20)}  →  ${tgt.padEnd(20)}  ${badge}`);
+    console.log(`    ${padDisplayEnd(p.display, 18)}  ${cur.padEnd(20)}  →  ${tgt.padEnd(20)}  ${badge}`);
     if (p.note) console.log(`      ${p.note}`);
   }
 }
@@ -12885,7 +12885,7 @@ async function networkCommand() {
         const current = n.network_id === gc.network_id ? " ← current" : "";
         const icon = roleIcon[n.member_role] || " ";
         const role = n.member_role ? ` (${n.member_role})` : "";
-        console.log(`  ${icon} ${n.network_name.padEnd(18)} ${role.padEnd(10)} ${n.network_id.slice(0, 12)}${current}`);
+        console.log(`  ${icon} ${padDisplayEnd(n.network_name, 18)} ${role.padEnd(10)} ${n.network_id.slice(0, 12)}${current}`);
       }
       console.log();
     } catch (e: any) { console.error(friendlyError(e)); }
@@ -13028,7 +13028,7 @@ async function networkCommand() {
       console.log(`\n  Members of ${gc.network_name || netId}:\n`);
       const roleIcon: Record<string, string> = { owner: "⭐", admin: "🔧", member: "👤", viewer: "👁" };
       for (const m of res.members) {
-        console.log(`  ${roleIcon[m.role] || "?"} ${(m.display_name || m.username).padEnd(16)} ${m.role.padEnd(8)} joined ${m.joined_at?.slice(0, 10) || "?"}`);
+        console.log(`  ${roleIcon[m.role] || "?"} ${padDisplayEnd(String(m.display_name || m.username), 16)} ${m.role.padEnd(8)} joined ${m.joined_at?.slice(0, 10) || "?"}`);
       }
       console.log();
     } catch (e: any) { console.error(friendlyError(e)); }
@@ -14150,7 +14150,7 @@ async function runPrReviewOrchestration(input: {
       const t0 = Date.now();
       const reply = await input.invoke(role, alias, reviewerTask);
       const dt = Date.now() - t0;
-      console.log(`        ✓ ${alias.padEnd(28)} ${Math.round(dt / 1000).toString().padStart(3)}s, ${reply.length} 字`);
+      console.log(`        ✓ ${padDisplayEnd(alias, 28)} ${Math.round(dt / 1000).toString().padStart(3)}s, ${reply.length} 字`);
       return { role, alias, text: reply, durationMs: dt };
     });
     const results = await Promise.all(fanouts);
@@ -14893,7 +14893,7 @@ async function createBatch(opts: BatchOptions): Promise<BatchResult> {
       try {
         await ensureNodeToken(profile, alias);
       } catch (e: any) {
-        console.error(`        ❌ ${alias.padEnd(14)} ntok_ 请求失败: ${e.message}`);
+        console.error(`        ❌ ${padDisplayEnd(alias, 14)} ntok_ 请求失败: ${e.message}`);
         failed.push(alias);
         continue;
       }
@@ -14901,7 +14901,7 @@ async function createBatch(opts: BatchOptions): Promise<BatchResult> {
       created.push(alias);
       if (opts.printSummary !== false) {
         const roleTag = opts.leaderAlias ? ` (${role.padEnd(7)})` : "";
-        console.log(`        ✓ ${alias.padEnd(14)}${roleTag}  ${nodeDir}`);
+        console.log(`        ✓ ${padDisplayEnd(alias, 14)}${roleTag}  ${nodeDir}`);
       }
     }
   } finally {
@@ -15462,7 +15462,7 @@ async function infoCommand() {
       if (tasks.tasks?.length > 0) {
         console.log(`\n  Recent Tasks:`);
         for (const t of tasks.tasks) {
-          console.log(`    ${t.status.padEnd(10)} ${(t.from_name || "?").padEnd(12)} ${oneLineCell(t.content, 40)}`);
+          console.log(`    ${t.status.padEnd(10)} ${padDisplayEnd(String(t.from_name || "?"), 12)} ${oneLineCell(t.content, 40)}`);
         }
       }
     } catch {}

--- a/agent-network/src/pad-display-sweep.test.ts
+++ b/agent-network/src/pad-display-sweep.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { displayWidth, padDisplayEnd } from "./display-width";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1663 把 `anet node ls` 的中文对齐修好了,但 `padEnd`(按码元数)在 cli.ts 里
+// 还留着 10 处接的是**用户数据**:alias / from_name / network_name / display_name /
+// label / p.display / 节点 id —— 本机这些几乎全是中文。
+//
+// 🔴 混合宽度时才现身:三行都叫「通信龙」时两种写法各自都齐,
+// 一旦同一张表里既有 `admin` 又有「通信龙」,padEnd 那版就歪 3 列。
+
+describe("padEnd 与 padDisplayEnd 在混合宽度下的差别", () => {
+  // 都装得下 12 显示列的一组（TM开发机Codex 本身就有 13 列,放它会混进
+  // 「值比列还宽」这另一件事,所以单独一条测）
+  const rows = ["admin", "通信龙", "TMAI"];
+
+  it("🔴 padEnd:同一列的实际显示宽度彼此不同(这就是歪的来源)", () => {
+    const widths = rows.map(r => displayWidth(r.padEnd(12)));
+    expect(new Set(widths).size).toBeGreaterThan(1);
+    expect(widths).toEqual([12, 15, 12]);   // 「通信龙」3 码元补到 12 → 实际占 15 列
+  });
+
+  it("padDisplayEnd:同一列的显示宽度全部相等", () => {
+    const widths = rows.map(r => displayWidth(padDisplayEnd(r, 12)));
+    expect(new Set(widths).size).toBe(1);
+    expect(widths[0]).toBe(12);
+  });
+
+  it("值本身就比列宽时保持原样,不截断 —— 它撑宽那一行,但不丢字", () => {
+    // 第一版我把 TM开发机Codex(13 显示列) 混进「全部相等」那条,红的是**我的期望值**:
+    // padDisplayEnd 补不了负数,它本来就该返回 13。
+    expect(displayWidth("TM开发机Codex")).toBe(13);
+    expect(padDisplayEnd("TM开发机Codex", 12)).toBe("TM开发机Codex");
+  });
+
+  it("纯 ASCII 时两者逐字相同 —— 所以这次替换对英文场景零影响", () => {
+    for (const s of ["admin", "tok_913d", "x", ""]) {
+      expect(padDisplayEnd(s, 12)).toBe(s.padEnd(12));
+    }
+  });
+});
+
+describe("接线:用户数据不再用 padEnd", () => {
+  const cli = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8")
+    .split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+  it("alias / from_name / network_name / display_name 都走 padDisplayEnd", () => {
+    for (const pat of [
+      /\$\{alias\.padEnd\(/,
+      /\(t\.from_name \|\| "\?"\)\.padEnd\(/,
+      /\$\{n\.network_name\.padEnd\(/,
+      /\(m\.display_name \|\| m\.username\)\.padEnd\(/,
+    ]) {
+      expect(pat.test(cli)).toBe(false);
+    }
+  });
+
+  it("正控:padDisplayEnd 确实被用上了(0 处说明我没接)", () => {
+    expect((cli.match(/padDisplayEnd\(/g) || []).length).toBeGreaterThanOrEqual(12);
+  });
+});


### PR DESCRIPTION
`#1663` 修好了 `anet node ls` 的中文对齐，但 `padEnd`（按**码元数**补齐）在 `cli.ts` 里
还留着接**用户数据**的地方。**枚举了全部 36 处 `.padEnd(`**，其中实参是用户数据的 10 处：

```
alias ×3     from_name     network_name     display_name/username
label        p.display     节点 id          (第 10 处 t.name 在 token ls,归 #1673)
```

🔴 **本机的 alias 几乎全是中文** —— `通信龙` / `通信IM牛` / `TM开发机Codex`。

## 混合宽度时才现身

```
padEnd(12)         admin→12   通信龙→15   ← 同一列，实际占的显示列不同
padDisplayEnd(12)  admin→12   通信龙→12
```

三行都叫「通信龙」时两种写法**各自都齐**，所以随手一看是绿的；一旦同一张表里既有
`admin` 又有中文名就歪 3 列。实测 `anet info` 的 Recent Tasks 第三列从 **31 移到 28**。

**纯 ASCII 时两者逐字相同** —— 单独一条测试钉住，所以这次替换对英文场景**零影响**。

## 🔴 我的期望值算错了两次，是测试逮住的

第一版写 `[12, 15, 21]`，真实是 `[12, 15, 15]`；又把 `TM开发机Codex`（**13** 显示列）
混进"全部相等"那条 —— `padDisplayEnd` 补不了负数，它**本来就该返回 13**。

**红的是我的算术，不是代码。** 拆成两条：一条测同宽对齐，一条测"值比列宽时保持原样、不截断"。

## 验收

```
基线                        6 pass 0 fail
变异①退回一处 alias.padEnd  5 pass 1 fail
还原                        6 pass 0 fail
```

`agent-network/src/` 全套 **964 pass 0 fail**；`doc-symbol-pins` `rc=0`。

## 与 #1673 的分工

`token ls` 的 `t.name` 那一处**故意留着** —— 那张表在 `#1673` 里整体重做，
两条 PR 不碰同一行。