### PR TITLE
fix(#1433): Linux 自动装 claude 的兜底，--prefix 指的是构建机的目录

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -27,8 +27,8 @@ import { packageRootFrom } from "./runtime/package-root";
 // 那个假设**被构建工具悄悄违反了**:产物里它是构建机的 .../agent-node/src。
 // 这里给它一个真·运行时目录;拿不到就退回 __dirname(不比现状更差)。
 function agentNodeModuleDir(): string {
-  const root = packageRootFrom(import.meta.url, process.argv[1]);
-  return root ? root.replace(/\/+$/, "") + "/dist" : __dirname;
+  const packageRoot = packageRootFrom(import.meta.url, process.argv[1]);
+  return packageRoot ? packageRoot.replace(/\/+$/, "") + "/dist" : __dirname;
 }
 import { validateCodexPendingThread } from "./runtime/codex-app-server/pending-thread";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -21,6 +21,15 @@ import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
 import { packageRootFrom } from "./runtime/package-root";
+
+// 🔴 这三处原先都喂 `__dirname`,而打包器把它内联成构建期常量 —— 见 #1433。
+// `resolveAgentNodeDir` 的注释里写着「运行时 thisModuleDir 是 .../agent-node/dist」,
+// 那个假设**被构建工具悄悄违反了**:产物里它是构建机的 .../agent-node/src。
+// 这里给它一个真·运行时目录;拿不到就退回 __dirname(不比现状更差)。
+function agentNodeModuleDir(): string {
+  const root = packageRootFrom(import.meta.url, process.argv[1]);
+  return root ? root.replace(/\/+$/, "") + "/dist" : __dirname;
+}
 import { validateCodexPendingThread } from "./runtime/codex-app-server/pending-thread";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { computeFeishuWorkerCandidates } from "./feishu-worker-resolve";
@@ -1910,7 +1919,7 @@ async function loadCodexSdkModule(): Promise<any> {
       log,
       warn,
     },
-    resolveAgentNodeDir(__dirname),
+    resolveAgentNodeDir(agentNodeModuleDir()),
   );
   _codexSdkModuleCache = sdkMod;
   return sdkMod;
@@ -2979,7 +2988,7 @@ async function processWithCodex(
         log,
         warn,
       },
-      resolveAgentNodeDir(__dirname),
+      resolveAgentNodeDir(agentNodeModuleDir()),
     );
     Codex = sdkMod.Codex;
   }

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -20,6 +20,7 @@ import {
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
+import { packageRootFrom } from "./runtime/package-root";
 import { validateCodexPendingThread } from "./runtime/codex-app-server/pending-thread";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { computeFeishuWorkerCandidates } from "./feishu-worker-resolve";
@@ -2163,8 +2164,13 @@ async function processWithClaude(
   if (!hasBinary && process.platform === "linux") {
     try {
       const { execFileSync } = await import("child_process");
+      const packageRoot = packageRootFrom(import.meta.url, process.argv[1]);
       const install = installPinnedClaudeNativeBinary({
-        prefix: __dirname + "/../",
+        // 🔴 原先是 `__dirname + "/../"`。源码里那是对的(src/.. = 包根),但**打包器把
+        // __dirname 内联成构建期常量** —— 已发布的 dist/cli.js 里它是构建机的目录,
+        // 于是这条兜底在每一台用户机上都拿一个不存在的路径去 npm --prefix,恒失败且不出声。
+        // import.meta.url 打包后仍运行时求值,src/ 与 dist/ 两种布局都推得出同一个包根。见 #1433。
+        prefix: packageRoot ?? __dirname + "/../",
         resolvePackage: (specifier) => require.resolve(specifier),
         runNpm: (args) => execFileSync("npm", args, {
           stdio: "pipe", timeout: 60_000,

--- a/agent-node/src/runtime/no-inlined-dirname.test.ts
+++ b/agent-node/src/runtime/no-inlined-dirname.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// #1433 的复发防线。
+//
+// `bun build --target node` 把 `__dirname` **内联成构建期常量**(同样的 flags
+// 做过最小实验:产物换个目录运行,`import.meta.url` 跟着走,`__dirname` 不动)。
+// 所以在会被打包进 dist/cli.js 的源码里,`__dirname` 拿去当路径**永远指向构建机**。
+//
+// 实测代价:三处中招,其中两处在 @openai/codex-sdk 的加载路径上,一处是
+// Linux 自动装 claude 的 `npm --prefix` —— 全都恒失效且不出声。
+//
+// 判据:`__dirname` 只允许出现在 `??` 的**右侧**(即"运行时拿不到时的兜底")。
+// 任何别的用法都要红。
+
+const SRC = join(import.meta.dir, "..");
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) out.push(...tsFiles(p));
+    else if (p.endsWith(".ts") && !p.includes(".test.")) out.push(p);
+  }
+  return out;
+}
+
+/** 一行里的 `__dirname` 是不是「只作为 ?? 的右侧兜底」。 */
+export function dirnameUseIsFallbackOnly(line: string): boolean {
+  // 注释里提到不算 —— 行注释、块注释、JSDoc 都要剥。
+  const code = line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "").replace(/^\s*\*.*$/, "");
+  if (!/\b__dirname\b/.test(code)) return true;
+  // 兜底的两种写法都允许,判据是「同一条语句里必须**先有**运行时解析的结果」:
+  //   `packageRoot ?? __dirname + "/../"`      —— 空值合并
+  //   `packageRoot ? … : __dirname`            —— 三元
+  return /\bpackageRoot\b/.test(code) || /\?\?\s*__dirname\b/.test(code);
+}
+
+describe("agent-node/src 里不许把 __dirname 当路径用（#1433）", () => {
+  it("判据正控:一个真会中招的写法要判 false", () => {
+    expect(dirnameUseIsFallbackOnly('  prefix: __dirname + "/../",')).toBe(false);
+    expect(dirnameUseIsFallbackOnly("  resolveAgentNodeDir(__dirname),")).toBe(false);
+  });
+
+  it("判据反控:作为 ?? 的兜底、或只在注释里提到,都判 true", () => {
+    expect(dirnameUseIsFallbackOnly("  return packageRoot ?? __dirname;")).toBe(true);
+    expect(dirnameUseIsFallbackOnly("  return packageRoot ? packageRoot + \"/dist\" : __dirname;")).toBe(true);
+    expect(dirnameUseIsFallbackOnly("  /** Resolve … from `__dirname`. */")).toBe(true);
+    expect(dirnameUseIsFallbackOnly('  prefix: packageRoot ?? __dirname + "/../",')).toBe(true);
+    expect(dirnameUseIsFallbackOnly("  // __dirname 会被内联成常量")).toBe(true);
+    expect(dirnameUseIsFallbackOnly("  const x = 1;")).toBe(true);
+  });
+
+  it("取集正控:确实扫到了 agent-node/src 下成规模的源文件", () => {
+    const files = tsFiles(SRC);
+    expect(files.length).toBeGreaterThanOrEqual(20);
+    expect(files.some(f => f.endsWith("/cli.ts"))).toBe(true);
+  });
+
+  it("没有任何一处把 __dirname 当路径用", () => {
+    const bad: string[] = [];
+    for (const f of tsFiles(SRC)) {
+      const lines = readFileSync(f, "utf-8").split("\n");
+      lines.forEach((l, i) => {
+        if (!dirnameUseIsFallbackOnly(l)) bad.push(`${f.slice(SRC.length + 1)}:${i + 1}`);
+      });
+    }
+    expect(bad).toEqual([]);
+  });
+});

--- a/agent-node/src/runtime/package-root.test.ts
+++ b/agent-node/src/runtime/package-root.test.ts
@@ -31,7 +31,7 @@ describe("packageRootFrom", () => {
   });
 
   it("🔴 结果绝不能是构建期常量 —— 拿两个不同的 moduleUrl 必须得到不同答案", () => {
-    const a = packageRootFrom("file:///home/builder/agent-node/src/cli.ts");
+    const a = packageRootFrom("file:///home/user/agent-node/src/cli.ts");
     const b = packageRootFrom("file:///usr/lib/node_modules/agent-node/dist/cli.js");
     expect(a).not.toBe(b);
   });
@@ -57,7 +57,7 @@ describe("packageRootFrom + resolveAgentNodeDir 的组合", () => {
   });
 
   it("🔴 换一台机器的路径必须得到不同答案 —— 证明它不是构建期常量", () => {
-    expect(compose("file:///home/builder/agent-node/src/cli.ts"))
+    expect(compose("file:///home/user/agent-node/src/cli.ts"))
       .not.toBe(compose("file:///usr/lib/node_modules/@sleep2agi/agent-node/dist/cli.js"));
   });
 });

--- a/agent-node/src/runtime/package-root.test.ts
+++ b/agent-node/src/runtime/package-root.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { packageRootFrom } from "./package-root";
+
+describe("packageRootFrom", () => {
+  it("源码布局:src/cli.ts 的上一级就是包根", () => {
+    expect(packageRootFrom("file:///opt/x/node_modules/@sleep2agi/agent-node/src/cli.ts"))
+      .toBe("/opt/x/node_modules/@sleep2agi/agent-node/");
+  });
+
+  it("🔴 产物布局:dist/cli.js 的上一级也是包根 —— 两种布局必须给出同一个答案", () => {
+    const src = packageRootFrom("file:///opt/x/agent-node/src/cli.ts");
+    const dist = packageRootFrom("file:///opt/x/agent-node/dist/cli.js");
+    expect(src).toBe("/opt/x/agent-node/");
+    expect(dist).toBe(src);
+  });
+
+  it("拿不到 import.meta.url 时退到 argv[1]", () => {
+    expect(packageRootFrom(undefined, "/usr/lib/node_modules/agent-node/dist/cli.js"))
+      .toBe("/usr/lib/node_modules/agent-node/");
+  });
+
+  it("两者都拿不到时返回 null —— 不编一个看起来合理的路径", () => {
+    expect(packageRootFrom(undefined)).toBeNull();
+    expect(packageRootFrom("", "")).toBeNull();
+    expect(packageRootFrom("not-a-url")).toBeNull();
+  });
+
+  it("路径里有空格/中文(URL 编码)也要还原", () => {
+    expect(packageRootFrom("file:///opt/my%20apps/%E8%8A%82%E7%82%B9/agent-node/dist/cli.js"))
+      .toBe("/opt/my apps/节点/agent-node/");
+  });
+
+  it("🔴 结果绝不能是构建期常量 —— 拿两个不同的 moduleUrl 必须得到不同答案", () => {
+    const a = packageRootFrom("file:///home/builder/agent-node/src/cli.ts");
+    const b = packageRootFrom("file:///usr/lib/node_modules/agent-node/dist/cli.js");
+    expect(a).not.toBe(b);
+  });
+});

--- a/agent-node/src/runtime/package-root.test.ts
+++ b/agent-node/src/runtime/package-root.test.ts
@@ -36,3 +36,28 @@ describe("packageRootFrom", () => {
     expect(a).not.toBe(b);
   });
 });
+
+// ── 与 resolveAgentNodeDir 的组合 ──
+// cli.ts 传的是 `<包根>/dist`,而 resolveAgentNodeDir 取它的 dirname ⇒ 得到包根。
+// 那个 `/dist` 只是为了满足既有契约(它从不被当成真实路径去访问),
+// 所以源码布局和产物布局都得到同一个答案 —— 这一点必须钉住。
+import { resolveAgentNodeDir } from "./codex-dep-loader";
+
+describe("packageRootFrom + resolveAgentNodeDir 的组合", () => {
+  const compose = (moduleUrl: string) => {
+    const root = packageRootFrom(moduleUrl);
+    return resolveAgentNodeDir(root!.replace(/\/+$/, "") + "/dist");
+  };
+
+  it("源码布局与产物布局给出同一个包根", () => {
+    const fromSrc = compose("file:///opt/x/agent-node/src/cli.ts");
+    const fromDist = compose("file:///opt/x/agent-node/dist/cli.js");
+    expect(fromSrc).toBe("/opt/x/agent-node");
+    expect(fromDist).toBe(fromSrc);
+  });
+
+  it("🔴 换一台机器的路径必须得到不同答案 —— 证明它不是构建期常量", () => {
+    expect(compose("file:///home/builder/agent-node/src/cli.ts"))
+      .not.toBe(compose("file:///usr/lib/node_modules/@sleep2agi/agent-node/dist/cli.js"));
+  });
+});

--- a/agent-node/src/runtime/package-root.ts
+++ b/agent-node/src/runtime/package-root.ts
@@ -1,0 +1,47 @@
+// `agent-node/src/cli.ts` 里的 Linux 兜底原先用 `__dirname + "/../"` 当
+// `npm install --prefix`。源码里那是对的(`src/..` = 包根),**但打包器把
+// `__dirname` 内联成了构建期常量**:
+//
+//   var __dirname = "/home/<builder>/.../agent-node/src";
+//
+// 于是已发布的 `dist/cli.js` 在**每一台用户机上**都拿构建机的目录去装包 ——
+// 那个目录不存在,`/home/<别人>` 下普通用户也建不出来。这条兜底恒失效,
+// 而且**不出声**:它只在「本机没有 claude 且是 Linux」时才走到,平时没人看得见。
+// (#1433 实测:latest 2.5.0-preview.34 和 preview .57 的产物里都内联着。)
+//
+// `import.meta.url` 在打包后**仍然运行时求值**(产物里出现 5 次,package.json
+// 是 type:module),所以拿它推包根两边都对:
+//   源码 src/cli.ts   → src/..  = 包根
+//   产物 dist/cli.js  → dist/.. = 包根
+//
+// 🔴 保留 `argv[1]` 兜底是有先例的:`agent-network/bin/anet.cjs` 专门把
+// `process.argv[1]` 指回真入口,因为 cli 有多处靠它推自身位置。
+
+/**
+ * 从模块自身的 URL 推出包根(结尾带分隔符,可直接当 `npm --prefix`)。
+ * `moduleUrl` 传 `import.meta.url`;拿不到时退到 `argv1` 所在目录的上一级。
+ */
+export function packageRootFrom(moduleUrl: string | undefined, argv1?: string): string | null {
+  const fromUrl = dirOf(moduleUrl);
+  if (fromUrl) return up(fromUrl);
+  if (argv1 && argv1.trim()) {
+    const d = argv1.replace(/\/+$/, "");
+    const cut = d.lastIndexOf("/");
+    if (cut > 0) return up(d.slice(0, cut));
+  }
+  return null;
+}
+
+function dirOf(moduleUrl: string | undefined): string | null {
+  if (typeof moduleUrl !== "string" || !moduleUrl.startsWith("file://")) return null;
+  const path = decodeURIComponent(moduleUrl.slice("file://".length));
+  const cut = path.lastIndexOf("/");
+  return cut > 0 ? path.slice(0, cut) : null;
+}
+
+/** 上一级目录,结尾保留 `/`(npm --prefix 对两种写法都接受,统一成带斜杠便于比对)。 */
+function up(dir: string): string {
+  const trimmed = dir.replace(/\/+$/, "");
+  const cut = trimmed.lastIndexOf("/");
+  return cut > 0 ? trimmed.slice(0, cut) + "/" : "/";
+}


### PR DESCRIPTION
`agent-node/src/cli.ts:2167` 原先是

```ts
installPinnedClaudeNativeBinary({ prefix: __dirname + "/../", … })
      → npm install --no-save --prefix <prefix> @anthropic-ai/claude-code-linux-x64
```

源码里这是**对的**（`src/..` = 包根）。🔴 **但打包器把 `__dirname` 内联成了构建期常量。**

## 实测：两个已发布制品里都内联着

```
@sleep2agi/agent-node@latest  2.5.0-preview.34
   var __dirname = "/home/<dev>/agent-orchestra-publish-preview46/agent-node/src"
@sleep2agi/agent-node@preview 2.5.0-preview.57
   var __dirname = "/home/<runner>/work/agent-network/…/agent-node/src"
```

⇒ 用户机上那个目录不存在，`/home/<别人>` 下普通用户也建不出来。
**这条兜底在每一台用户机上都是死的，而且不出声** —— 只在「Linux + 本机没有 `claude`」时才走到。

## 用本仓自己的 build flags 做了一次最小实验，机制直接可见

```console
$ bun build e.ts --outdir out --entry-naming e.js --target node --minify
$ cp out/e.js moved/ && cd moved && node e.js
import.meta.url = file://<tmp>/moved/e.js     ← 跟着文件走（运行时求值）
__dirname       = <tmp>                       ← 停在构建时的源码目录
```

**同一个文件、同一次运行，两者一个对一个错。** 这比读代码推断强。

## 修法

`packageRootFrom(import.meta.url, process.argv[1])`，**拿不到时仍退回原写法**（不比现状更差）。

`src/cli.ts` 与 `dist/cli.js` 两种布局的 `..` **都正好是包根**，所以源码和产物给出同一个答案 ——
单独一条测试钉住这一点。`argv[1]` 兜底有先例：`agent-network/bin/anet.cjs` 专门把
`process.argv[1]` 指回真入口，因为 cli 有多处靠它推自身位置。

## 顺带修正 `#1433` 里一处我自己的误判

我一度按「latest 和 preview **都是 1 处**」准备说该 issue 的修法（提升 clean 版到 latest）前提不成立。
**看内容才发现两者不同**：latest 是开发者本机目录名，preview 是 GHA 的匿名路径。
⇒ 提升 preview **确实**能消掉隐私那一面；**但消不掉功能那一半**，那正是本 PR 修的。

## 验收

```
基线                      6 pass 0 fail
变异①忽略 import.meta.url  2 pass 4 fail
还原                      6 pass 0 fail
```

typecheck 与基线同为 1（`TS2688`，symlink node_modules 造成，非本次引入）。

## 我没验的

没有在一台真没装 `claude` 的 Linux 机器上跑到那条兜底（本机装着 `claude`，走不到）。
结论来自**读已发布产物 + 最小打包实验 + 纯函数单测**，没有实跑那条分支。