### PR TITLE
test: 一道门 —— tests/*/run.sh 里的 sed 变异必须还能在目标文件里命中

### DIFF
--- a/.github/workflows/mutation-pin-integrity.yml
+++ b/.github/workflows/mutation-pin-integrity.yml
@@ -1,0 +1,29 @@
+# tests/*/run.sh 里的 `sed -i 's/PAT/…/' <file>` —— PAT 必须还能在目标文件里命中。
+#
+# 🔴 **无 paths 过滤，故意的**（同 proc-gone-assertions.yml 的理由）。
+#    这道门要守的是「**任何**改动是否把某条变异守卫钉住的那一行重构掉了」——
+#    而那一行可以在任何源文件里。设了 paths 就会在真正该跑的时候跑不到，
+#    而一道从不被触发的门，在 PR 页面上和没有这道门长得一模一样。
+#
+# 为什么需要它（2026-08-31 真踩）：test649 的 L5 变异钉着
+# `(t.created_at || "?").padEnd(24)`；那一行被重构后 sed 匹配不到，
+# `grep -Fq` 失败、`set -e` 打死脚本 —— 日志上看是「被测行为回归了」，
+# 实际是**那道变异守卫从此什么也测不到**。它当时只有 Docker 套件能发现，
+# 而 Docker 套件不是每个 PR 都跑；这道纯文本检查几秒钟就跑完。
+name: mutation pin integrity
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  mutation-pins:
+    name: mutation pins still apply
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # 判据自检先跑：一道自己都没被证明会红的门，绿了也不能读。
+      - name: selftest (criterion)
+        run: python3 scripts/check-mutation-pins.py --selftest
+      - name: scan repo
+        run: python3 scripts/check-mutation-pins.py

--- a/scripts/check-mutation-pins.py
+++ b/scripts/check-mutation-pins.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""tests/*/run.sh 里的 `sed -i 's/PAT/…/' <file>` —— PAT 必须仍能在目标文件里命中。
+
+为什么需要这道门(2026-08-31 真实翻车):
+  test649 的 L5 变异钉着 `(t.created_at || "?").padEnd(24)`。有人(我)把那一行重构成
+  `padDisplayEnd(String(t.created_at || "?"), tW.created)` —— sed 匹配不到,
+  紧跟的 `grep -Fq` 失败,`set -e` 打死脚本。日志的表现是「被测行为回归了」,
+  实际是**那道变异守卫从此什么也测不到**。
+
+  🔴 它是靠 Docker 套件才暴露的,而 Docker 套件不是每个 PR 都跑。纯文本检查在 PR 期
+  就能拦住,几乎不花时间。
+
+判据(刻意保守):只判「PAT 在目标文件里出现」。不判替换后语义对不对 —— 那要跑套件。
+   解析不了的 sed 形式**跳过并计数**:一个只说「0 处失效」却不说「跳过了 N 条」的门,
+   分母是它自己算出来的,永远自洽。
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# `sed -i 's/PAT/REPL/' path` / `sed -i.bak ...`;只收单引号且目标是仓内文件的形式。
+SED = re.compile(r"sed -i(?:\.bak)? +'s/(?P<pat>(?:[^/\\]|\\.)*)/(?P<repl>(?:[^/\\]|\\.)*)/[a-z]*' +(?P<file>[A-Za-z0-9_./-]+)")
+
+
+def unescape(pattern: str) -> str:
+    """把 sed 的反斜杠转义还原成字面文本(\\. → . / \\[ → [ …)。"""
+    return re.sub(r"\\(.)", r"\1", pattern)
+
+
+# sed 用的是 **BRE**:只有 . * [ ] ^ $ 和 \( \) \{ \} 是元字符;
+# ? + | ( ) { } 在 BRE 里都是**字面量**。把 BRE 直译成 Python 正则,
+# 这样含 . 或 ? 的普通代码文本也能判,而不是一律跳过。
+def bre_to_regex(pattern: str):
+    out = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "\\" and i + 1 < len(pattern):
+            nxt = pattern[i + 1]
+            if nxt in "(){}":          # \( \) \{ \} = BRE 的分组/重复
+                out.append(nxt if nxt in "{}" else nxt)
+            else:
+                out.append(re.escape(nxt))
+            i += 2
+            continue
+        if c == "^":
+            # BRE: ^ 只在**模式开头**是锚点,别处是字面量
+            out.append("^" if i == 0 else re.escape("^"))
+        elif c == "$":
+            # BRE: $ 只在**模式末尾**是锚点,别处是字面量(模板串 ${x} 全靠这条)
+            out.append("$" if i == len(pattern) - 1 else re.escape("$"))
+        elif c in ".*[]":
+            out.append(c)              # BRE 元字符,原样传给 Python
+        else:
+            out.append(re.escape(c))   # 其余一律当字面量(含 ? + | ( ) { })
+        i += 1
+    try:
+        return re.compile("".join(out))
+    except re.error:
+        return None
+
+
+# 套件在容器里跑,sed 的目标常是 /workspace/… 或 /mutation/… 这类容器内绝对路径,
+# 也有相对某个包根的写法。**只试确定的几个前缀,试不出就跳过并计数 —— 不猜。**
+def resolve_target(target: str):
+    cands = [target]
+    for prefix in ("/workspace/", "/mutation/"):
+        if target.startswith(prefix):
+            cands.append(target[len(prefix):])
+    rel = cands[-1]
+    tries = [os.path.join(ROOT, c) for c in cands]
+    tries += [os.path.join(ROOT, pkg, rel) for pkg in ("agent-node", "agent-network", "server")]
+    found = []
+    for t in tries:
+        if os.path.isfile(t) and t not in found:
+            found.append(t)
+    # 🔴 多个同名候选(agent-network/src/server.ts 与 server/src/server.ts 都存在)时
+    # **不猜**:取第一个会挑错文件,把活着的 pin 报成死的。判为歧义,跳过并计数。
+    return found[0] if len(found) == 1 else None
+
+
+def collect(root: str):
+    out = []
+    for base, _dirs, files in os.walk(os.path.join(root, "tests")):
+        for name in files:
+            if name != "run.sh":
+                continue
+            path = os.path.join(base, name)
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+            for m in SED.finditer(text):
+                out.append((path, m.group("pat"), m.group("file")))
+    return out
+
+
+def main() -> int:
+    pins = collect(ROOT)
+    checked = skipped = 0
+    dead = []
+    for sh, pat, target in pins:
+        rx = bre_to_regex(pat)
+        if rx is None:
+            skipped += 1
+            continue
+        full = resolve_target(target)
+        if full is None:
+            skipped += 1
+            continue
+        with open(full, encoding="utf-8", errors="replace") as fh:
+            src = fh.read()
+        checked += 1
+        if not rx.search(src):
+            dead.append((os.path.relpath(sh, ROOT), target, unescape(pat)))
+    print(f"MUTATION-PIN: 扫到 {len(pins)} 条 sed 变异，判定 {checked} 条，跳过 {skipped} 条（非字面量或目标不在仓内）")
+    if not dead:
+        print("MUTATION-PIN: GREEN —— 每条被判定的变异都还能在目标文件里命中。")
+        return 0
+    print(f"MUTATION-PIN: RED —— {len(dead)} 条打不进去了：")
+    for sh, target, pat in dead:
+        print(f"  🔴 {sh}")
+        print(f"     目标 {target} 里找不到：{pat[:100]}")
+    print()
+    print("FIX: 被钉的那一行被重构了 ⇒ 那道变异守卫已经变成 NOOP。")
+    print("     把 sed 重新指向新的源码文本，**保持语义不变**；不要放宽它后面的断言。")
+    return 1
+
+
+def selftest() -> int:
+    ok = fail = 0
+
+    def ck(name, cond):
+        nonlocal ok, fail
+        print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+        ok, fail = (ok + 1, fail) if cond else (ok, fail + 1)
+
+    ck("反转义 \\. → .", unescape(r"a\.b") == "a.b")
+    ck("反转义 \\[ → [", unescape(r"args\[1\]") == "args[1]")
+    ck("BRE: ? 是字面量,能命中带 ? 的代码", bool(bre_to_regex(r"a?.b").search("a?xb")))
+    ck("BRE: \\. 只匹配真的点", bre_to_regex(r"a\.b").search("axb") is None)
+    ck("BRE: . 是元字符", bool(bre_to_regex("a.b").search("axb")))
+    ck("BRE: 转义过的 [ 当字面量", bool(bre_to_regex(r"args\[1\]").search("args[1]")))
+    ck("正控:一个不存在的串判不中", bre_to_regex("zzz_not_here").search("hello") is None)
+    ck("BRE: 句中的 $ 是字面量(模板串)", bool(bre_to_regex("a${x}b").search("a${x}b")))
+    ck("BRE: 末尾的 $ 仍是锚点", bre_to_regex("ab$").search("abc") is None)
+    ck("BRE: 开头的 ^ 仍是锚点", bre_to_regex("^ab").search("xab") is None)
+    # 取集:仓里确实有一批 pin —— 分母为 0 会让主判据空过
+    ck("取集扫到 ≥10 条 pin", len(collect(ROOT)) >= 10)
+    ck("同名多候选判为歧义(不猜)", resolve_target("src/server.ts") is None)
+    ck("唯一候选能解析", resolve_target("agent-network/bin/cli.ts") is not None)
+    print(f"selftest: {ok} ok / {fail} fail")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(selftest() if "--selftest" in sys.argv else main())


### PR DESCRIPTION
## 为什么（今天真踩的）

`test649` 的 L5 变异钉着**源码字面量** `(t.created_at || "?").padEnd(24)`。
我在另一条 PR 里把那行重构成 `padDisplayEnd(String(t.created_at || "?"), tW.created)` ——
sed 匹配不到，紧跟的 `grep -Fq` 失败，`set -e` 打死脚本。

🔴 **日志上看是"被测行为回归了"；实际是那道变异守卫从此什么也测不到。**

而它是靠 Docker 套件才暴露的 —— Docker 套件不是每个 PR 都跑。
纯文本检查在 PR 期就能拦住，几乎不花时间。

## 判据

把 sed 的 **BRE** 直译成正则，再去目标文件里搜。全仓 **90 条，判定 87，跳过 3**（明说）。

## 🔴 判据本身错过三次，每次都先验证再改

| # | 我写错了什么 | 后果 | 修法 |
|---|---|---|---|
| 1 | 用"是不是纯字面量"当门槛，把 `?` 当元字符 | 覆盖只有 **29/90** | BRE 里 `? + \| ( ) { }` 都是字面量 → 改成 BRE→正则，**88/90** |
| 2 | `$` 原样透传成正则锚点 | 报出 **7 条失效**，其中 **6 条假阳**（模式含 `${…}` 模板串） | BRE 里 `$` **只有在末尾**才是锚点，`^` 只在开头 |
| 3 | 目标写 `src/server.ts`，而两个包下都有同名文件，取第一个 | 剩的 1 条也是假阳 —— **挑错了文件** | **多候选 = 歧义，跳过并计数，不猜** |

⇒ 最终 main 上 `GREEN`，`--selftest` **13/13**。

**三次都是我的判据在制造发现，不是仓里有问题。** 每一条都验证过才改。

## 见证它真的会红

把今天那条真实破坏重现一次（改掉 `test649` 钉住的那一行）：

```
变异 → MUTATION-PIN: RED —— 1 条打不进去了: tests/test649-token-cli/run.sh
还原 → MUTATION-PIN: GREEN
```

## 输出里一定带「跳过 N 条」

**一个只说"0 处失效"却不说跳过多少的门，分母是它自己算出来的，永远自洽。**

## 边界

- 只判「模式还能不能命中」，**不判替换后的语义对不对** —— 那要真跑套件；
- 只收单引号的 `sed -i 's/…/…/'` 形式；别的写法计入"跳过"。