### PR TITLE
fix(demo): anet demo 的清单在每台机器上都印着乱码颜色码

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -13263,18 +13263,18 @@ function demoListCommand() {
   console.log(`
   Available demos:
 
-  [32m●[0m debate          辩论赛 — 6 agent (主持人 / 正反 4 辩 / 评委), ~10 min
+  ● debate          辩论赛 — 6 agent (主持人 / 正反 4 辩 / 评委), ~10 min
                   anet demo debate --topic "AI 创造的岗位是否比消灭的多"
 
-  [32m●[0m socialmedia     社交媒体内容工厂 — 4 agent (选题/文案/配图/审核), ~3 min
+  ● socialmedia     社交媒体内容工厂 — 4 agent (选题/文案/配图/审核), ~3 min
                   anet demo socialmedia --topic "..." --platform xiaohongshu
 
-  [32m●[0m pr-review       代码 PR 审查室 — 4 agent (安全/性能/风格 3 reviewer 并行 + judge), ~2 min
+  ● pr-review       代码 PR 审查室 — 4 agent (安全/性能/风格 3 reviewer 并行 + judge), ~2 min
                   anet demo pr-review --diff path/to/change.diff
                   anet demo pr-review --pr https://github.com/owner/repo/pull/N
                   anet demo pr-review --ref origin/main
 
-  [32m●[0m sci-team    科研军团 — 1 leader + N-1 worker (默认 10, 5-50 可调) 跑书生模型, Phase 1 scaffold
+  ● sci-team        科研军团 — 1 leader + N-1 worker (默认 10, 5-50 可调) 跑书生模型, Phase 1 scaffold
                   anet demo sci-team
                   anet demo sci-team --count 20 --dir ~/intern-s --intern-api $KEY
                   anet demo sci-team --stop / --restart / --cleanup

--- a/agent-network/src/demo-list-alignment.test.ts
+++ b/agent-network/src/demo-list-alignment.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { displayWidth } from "./display-width";
+
+// `anet demo` 的清单是**手敲在模板字符串里的空格**。sci-team 是后加的,
+// 补齐写成了 4 个空格而其余三项是 8/5/7(名字+空格 = 16),于是它的说明列
+// 比别人靠左 4 列。
+//
+// 判据不看空格数,看**每一行的名字段占多少显示列** —— 那才是用户看到的东西。
+// 下一个人加 demo 时补错了空格,这条会红。
+//
+// 🔴 顺带钉住另一件同处发现的事:这一块原先带着 8 处**缺了 ESC 前缀**的颜色码
+// (`[32m` / `[0m` 的纯文本),用户跑 `anet demo` 看到的是字面量乱码而不是绿点。
+// 本文件其余地方 0 处真 ANSI 上色 —— 状态一律用 ✅/🔴/● 这类字符,所以修法是**删掉**,
+// 不是补 ESC。下面单独一条守着它不再回来。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+
+/** 从 demoListCommand 的模板里取出每一行的「名字 + 其后的空格」宽度。 */
+export function demoNameFieldWidths(src: string): { name: string; width: number }[] {
+  const start = src.indexOf("Available demos:");
+  if (start < 0) throw new Error("找不到 `Available demos:` —— demo 清单被改写了");
+  const end = src.indexOf("See 'anet demo", start);
+  if (end < 0) throw new Error("找不到清单结尾的 See 'anet demo …'");
+  const block = src.slice(start, end);
+  const out: { name: string; width: number }[] = [];
+  for (const line of block.split("\n")) {
+    const m = /●\s+([a-z][a-z-]*)( +)/.exec(line);
+    if (!m) continue;
+    out.push({ name: m[1]!, width: displayWidth(m[1]!) + m[2]!.length });
+  }
+  return out;
+}
+
+describe("anet demo 清单的名字列", () => {
+  const rows = demoNameFieldWidths(CLI);
+
+  it("取集正控:确实解析出了多行(0 行会让下面那条空过)", () => {
+    expect(rows.length).toBeGreaterThanOrEqual(4);
+    expect(rows.map(r => r.name)).toContain("debate");
+    expect(rows.map(r => r.name)).toContain("sci-team");
+  });
+
+  it("🔴 每一行的名字列占同样多的显示列 —— 否则说明文字会错位", () => {
+    const widths = [...new Set(rows.map(r => r.width))];
+    expect(widths).toHaveLength(1);
+  });
+
+  it("🔴 清单里不留缺了 ESC 前缀的颜色码 —— 那是用户眼里的乱码", () => {
+    const start = CLI.indexOf("Available demos:");
+    const end = CLI.indexOf("See 'anet demo", start);
+    const block = CLI.slice(start, end);
+    expect(block.match(/\[[0-9;]{1,4}m/g) ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
fix(demo): anet demo 的清单在每台机器上都印着乱码颜色码

## 用户实际看到的（已发布 latest 与 preview 逐字相同）

    [32m●[0m debate          辩论赛 — 6 agent ...
    [32m●[0m socialmedia     社交媒体内容工厂 ...

`[32m` 出现 **4 次**。原因:那 8 处颜色码**没有 ESC 前缀** —— 源码里就是纯文本
`[32m` / `[0m`（od -c 确认过,没有那个不可见字节）。

## 为什么修法是「删掉」而不是「补 ESC」

`agent-network/bin/cli.ts` 里**带 ESC 的真 ANSI 上色共 0 处** —— 全文件的状态
一律用 OK/RED/● 这类字符表达。补 ESC 等于往这个文件里新引入一套它本来没有的约定;
删掉才是回到既有立场。

## 顺带修另一处:sci-team 那行的补齐少了 4 列

    debate       6 + 10 = 16
    socialmedia 11 +  5 = 16
    pr-review    9 +  7 = 16
    sci-team     8 +  4 = 12   <- 后加的,说明文字整体左移 4 列

改后四行的说明列都起于第 27 显示列（实跑量的）。

## 两向变异见证

    基线                          3 pass 0 fail
    变异1 sci-team 补齐改回 4 空格 2 pass 1 fail
    变异2 把缺 ESC 的颜色码放回来  1 pass 2 fail
    还原                          3 pass 0 fail   cli.ts 逐字还原 OK

🔴 写这条测试时我先猜了两次正则（先以为源码里是转义字面量、又以为是真 ESC 字节）,
两次都解析出 0 行 —— **取集正控当场报红**。第三次直接 od -c 看字节才定案:
两个猜测都不对,那里根本没有 ESC。

doc-symbol-pins / mutation-pins rc=0;agent-network 单测 977 个 0 fail。
