### PR TITLE
ux(cli): anet goal list 为空时也给下一步 —— 同一个 CLI 里另外三处都给了

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -12456,7 +12456,15 @@ async function goalCommand() {
         console.log(`  ${short} ${status} ${every} ${due} ${text}`);
       }
     }
-    if (total === 0) console.log("\nNo goals found.\n");
+    if (total === 0) {
+      // 空清单也要给下一步 —— 同一个 CLI 里 `anet node ls`(Get started: anet init)
+      // 和 `anet project up`(Create some with: anet node create <name>) 都这么做,
+      // 只有这里是光秃秃一句。正确写法就在隔壁。
+      // 🔴 `anet goal` **没有创建子命令**(只有 list/show/wake-log/edit/cancel),
+      // 所以这里不能写 `anet goal add` —— 创建路径是 `anet node loop`,已实跑确认。
+      console.log("\nNo goals found.");
+      console.log('Schedule one: anet node loop <node> "<task>" --every 5m\n');
+    }
     else console.log();
     return;
   }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8809,7 +8809,15 @@ async function importCommand() {
     ? claudeSessions.filter((s: any) => s.alias === targetAlias)
     : claudeSessions;
 
-  if (toImport.length === 0) { console.log(`No session found for "${targetAlias}".`); return; }
+  if (toImport.length === 0) {
+    // 🔴 可导入的会话就在手边(claudeSessions),只说「没找到」等于把用户手上的
+    // 信息藏起来 —— 同 #1667 的 `Node "x" not found`。把真名给他。
+    const names = claudeSessions.map((s: any) => String(s.alias || "")).filter(Boolean);
+    const shown = names.slice(0, 5).join(", ");
+    const more = names.length > 5 ? `, … (${names.length} total)` : "";
+    console.log(`No session found for "${targetAlias}". ${names.length} importable: ${shown}${more}`);
+    return;
+  }
 
   let created = 0;
   for (const s of toImport) {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -12188,7 +12188,14 @@ async function tasksCommand() {
     const tasks = res.tasks || [];
 
     if (tasks.length === 0) {
-      console.log("\n  No tasks found.\n");
+      // 🔴 「0 条」有两解:真的一条都没有 / 只是**这个 status** 没有。
+      // status 就在手边,说出来比让用户自己猜便宜 —— 同族:#1660(0 节点)、#1667(节点名找不到)。
+      if (status) {
+        console.log(`\n  No tasks with status "${status}".`);
+        console.log("  去掉过滤看全部: anet tasks\n");
+      } else {
+        console.log("\n  No tasks found.\n");
+      }
       return;
     }
 

--- a/agent-network/src/empty-state-next-step.test.ts
+++ b/agent-network/src/empty-state-next-step.test.ts
@@ -50,6 +50,14 @@ describe("空状态给下一步", () => {
     expect(/anet skill (install|add|pull)/.test(CODE.slice(idx, idx + 200))).toBe(false);
   });
 
+  it("🔴 anet import 找不到 alias 时把可导入的真名列出来 —— 数据就在手边", () => {
+    const i = CODE.indexOf('No session found for');
+    const near = CODE.slice(Math.max(0, i - 400), i + 200);
+    expect(near).toContain("importable");
+    // 连守卫一起钉:名字必须真的从 claudeSessions 取,而不是写死一句话
+    expect(near).toMatch(/claudeSessions\.map\(/);
+  });
+
   it("正控:另外两处既有的空状态提示还在(它们是这条的样板)", () => {
     expect(CODE).toContain("Get started: anet init");
     expect(CODE).toContain("Create some with: anet node create");

--- a/agent-network/src/empty-state-next-step.test.ts
+++ b/agent-network/src/empty-state-next-step.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// 空状态也要给下一步。同一个 CLI 里已经有三处这么做:
+//   anet node ls    → "Get started: anet init"
+//   anet project up → "Create some with: anet node create <name>"
+//   anet doctor     → 0 个节点那一格(#1660)同时说出两种现实
+// 只有 `anet goal list` 是光秃秃的 "No goals found."。**正确写法就在隔壁。**
+//
+// 🔴 而"下一步"里写的命令必须**真的存在**:`anet goal` 只有
+// list/show/wake-log/edit/cancel,**没有创建子命令** —— 所以这里不能写
+// `anet goal add`。创建路径是 `anet node loop <alias> "<task>" --every <interval>`,
+// 已跑 `anet node loop --help` 确认("Schedule a recurring task on a running node")。
+// 今天已经因为「文档教了一个装到的版本里没有的命令」踩过一次(#1666)。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+const CODE = CLI.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+describe("空状态给下一步", () => {
+  it("goal list 为空时给出创建路径", () => {
+    expect(CODE).toContain("No goals found.");
+    expect(CODE).toContain("Schedule one: anet node loop");
+  });
+
+  it("🔴 那条建议里的命令必须真的存在 —— anet goal 没有创建子命令", () => {
+    // goal 的 usage 里不能出现 add/create 这类子命令(否则说明我建议错了目标)
+    const usage = CODE.slice(CODE.indexOf("anet goal <command>"), CODE.indexOf("Data: .anet/nodes/<node>/goals.json"));
+    expect(/^\s{2}(add|create)\b/m.test(usage)).toBe(false);
+    // 而 node 的分发里必须有 loop 这一支
+    expect(CODE).toContain('case "loop"');
+  });
+
+  it("正控:另外两处既有的空状态提示还在(它们是这条的样板)", () => {
+    expect(CODE).toContain("Get started: anet init");
+    expect(CODE).toContain("Create some with: anet node create");
+  });
+});

--- a/agent-network/src/empty-state-next-step.test.ts
+++ b/agent-network/src/empty-state-next-step.test.ts
@@ -31,6 +31,25 @@ describe("空状态给下一步", () => {
     expect(CODE).toContain('case "loop"');
   });
 
+  it("🔴 tasks 的 0 条要分清「一条都没有」和「这个 status 没有」", () => {
+    // 🔴 只断言"字符串在源码里"是观察不到这个缺陷的:把 `if (status)` 改成 `if (false)`
+    // 之后那两句仍然原样躺在死分支里,断言照样过。所以要连**守卫条件**一起钉。
+    const branch = CODE.slice(CODE.indexOf("if (tasks.length === 0) {"));
+    expect(branch.slice(0, 400)).toMatch(/if \(status\) \{/);
+    expect(branch.slice(0, 400)).toContain('No tasks with status');
+    expect(branch.slice(0, 400)).toContain("去掉过滤看全部: anet tasks");
+    // 不带过滤时仍是原来那句 —— 两支都要在
+    expect(branch.slice(0, 400)).toContain("No tasks found.");
+  });
+
+  it("🔴 没有真实下一步的地方**不编一个** —— anet skill 只有 list/ls/show", () => {
+    const skillFn = CODE.slice(CODE.indexOf("async function skillCommand()"), CODE.indexOf("async function skillCommand()") + 4000);
+    expect(/sub === "(install|add|pull)"/.test(skillFn)).toBe(false);
+    // 所以 "No skills found." 后面**不该**出现一条 anet skill 的安装建议
+    const idx = CODE.indexOf('"No skills found."');
+    expect(/anet skill (install|add|pull)/.test(CODE.slice(idx, idx + 200))).toBe(false);
+  });
+
   it("正控:另外两处既有的空状态提示还在(它们是这条的样板)", () => {
     expect(CODE).toContain("Get started: anet init");
     expect(CODE).toContain("Create some with: anet node create");


### PR DESCRIPTION
ux(cli): anet goal list 为空时也给下一步 —— 同一个 CLI 里另外三处都给了

全新安装那条路上，四条常用命令的空状态：

    anet node ls     No sessions or nodes in this directory.
                     Get started: anet init                        <- 给了
    anet project up  [anet] No nodes match.
                     Create some with: anet node create <name>     <- 给了
    anet doctor      0 个节点同时说出两种现实（#1660）              <- 给了
    anet goal list   No goals found.                               <- 只有这一句

**正确写法就在隔壁。** 改成：

    No goals found.
    Schedule one: anet node loop <node> "<task>" --every 5m

## 🔴 写这句之前先验了它建议的命令真的存在

`anet goal` 的子命令只有 **list / show / wake-log / edit / cancel —— 没有创建**。
所以这里**不能**写 `anet goal add`。创建路径是 `anet node loop`，我跑了
`anet node loop --help` 确认（原文：Schedule a recurring task on a running node）。

今天已经因为这一类踩过一次：文档教用户敲一个他装到的版本里没有的命令（#1666）。

## 两向变异见证

    基线                                    3 pass 0 fail
    变异1 拿掉那句下一步                     2 pass 1 fail
    变异2 往 goal usage 里塞一个假的 add      2 pass 1 fail
    还原                                    3 pass 0 fail   cli.ts 逐字还原

变异 2 测的是**判据能不能发现「我建议错了目标」**——如果哪天 goal 真的加了创建子命令，
这条会红，提醒人回来改这句提示。

🔴 变异 2 第一次是**空操作**：我的替换目标 `  loop <alias>` 在 goal 的 usage 里根本不存在
（那是 node 的 usage）。一个打不进去的变异和一个「守卫没逮住」长得一模一样 —— 重做后才红。

## 一处我没查清的

跑全套时有一次是 `1002 pass 1 fail`，随后连跑三次都是 `1003 pass 0 fail`。
总数相同 ⇒ 恰好一条从 fail 翻成 pass。**我没能定位是哪一条**（当时输出没抓到文件名，
之后复现不出）。如实写在这里，不说成"没事"——CI 会再跑一遍。

doc-symbol-pins / mutation-pins rc=0。
