### PR TITLE
docs(release): .76 的 release notes 补上 Install + Upgrade 段（预演 gate 3 抓到）

### DIFF
--- a/docs/tests/release-v2.3.0-preview.76.md
+++ b/docs/tests/release-v2.3.0-preview.76.md
@@ -50,6 +50,20 @@
 - **#1636 / #1637 / #1657** Windows 归属探测：整张进程表只枚举一次（实测单次调用占 waited 的 96%），
   且把耗时**打在成功路径上** —— 只在失败时说话的仪表验不了自己促成的修复。
 
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.76
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.76
+# daemon 是长驻进程,换包要重启才生效:
+anet daemon restart <daemon>
+```
+
 ## 边界
 
 - 本条只发 `@sleep2agi/agent-network`。`agent-node`（3 个提交）与 `commhub-server`（2 个提交）


### PR DESCRIPTION
`release-gate (v0)` 的 gate 3 要求 release notes 同时有 `## Install`
(新用户装) 和 `## Upgrade` (老用户升) 两段,且 Install 段里点名被发的那个版本。
`docs/tests/release-v2.3.0-preview.76.md` 三个标题是「为什么发这一版 / 逐条 /
边界」,两段都没有 —— **.76 一按发布就会卡在 gate 3。**

怎么发现的:用 `publish=false` 把发布路径**预演**了一遍(run 33356833173),
gate 3 打出

    ::error::file:docs/tests/release-v2.3.0-preview.76.md missing '## Install' section

也就是说,这个红是**在 owner 按开关之前**拿到的,不是发布当场才炸。

格式照 `.75` 那份(它过了同一道门)的相对位置与写法,没另发明一套。
自检用的是 workflow 里那三条 grep 原文,不是我重写的判据。