### PR TITLE
fix(daemon): anet_bin_source 的报错点名它真读的文件，并给出免 root 的那条路 (#1635)

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -234,12 +234,12 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
         //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
         //   可能解析到另一个（或找不到）二进制。
         //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
-        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null Or keep the pin in a file you own (no /etc, no sudo): ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\" (put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart)",
     );
   }
   if (!pin) {
     throw unsafePathHelp("anet_bin_source",
-      `no ANET_BIN_ABS resolved from ${trustRoot}; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1`,
+      `no ANET_BIN_ABS resolved from ${confPath}; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1`,
       platform === "win32"
         ? `New-Item -ItemType Directory -Force -Path "${win32.dirname(trustRoot)}" | Out-Null; "ANET_BIN_ABS=<absolute path to anet.cjs>" | Set-Content -Path "${trustRoot}" -Encoding ascii`
         // 🔴 这条命令在 2026-08-30 之前**两处都坏**，而它是 anet_bin_source 唯一给出的修法：
@@ -253,7 +253,7 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
         //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
         //   可能解析到另一个（或找不到）二进制。
         //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
-        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null (needs root). No-root alternative to try first: only `anet daemon init|start|up` auto-declares the pin, so a daemon started via `anet node start` / pm2 / systemd never receives it — restart it with `anet daemon start <name>`.",
+        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null (needs root). No-root alternative to try first: only `anet daemon init|start|up` auto-declares the pin, so a daemon started via `anet node start` / pm2 / systemd never receives it — restart it with `anet daemon start <name>`. Or keep the pin in a file you own (no /etc, no sudo): ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\" (put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart)",
     );
   }
   // ① absolute — cross-platform. Was `startsWith("/")` which returned

--- a/agent-node/src/runtime/daemon-bin-error-help.test.ts
+++ b/agent-node/src/runtime/daemon-bin-error-help.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { loadAndVerifyAnetBin } from "./create-node-daemon";
+
+// #1635 —— `anet_bin_source` 的报错原先只给出**需要 root** 的那条修法,
+// 而 `ANET_DAEMON_PATH_CONF` 这条免 root、活得过重启的路一直在代码里
+// (`confPath = env.ANET_DAEMON_PATH_CONF || trustRoot`),却从没出现在任何
+// 面向用户的文案里。
+//
+// 🔴 第二条是跑出来才看见的,issue 里没有:读的是 `confPath`,报的却是
+// `trustRoot` —— 用户一旦设了这个变量,报错会把他指向一个**从没被读过**的文件。
+
+function messageFor(env: Record<string, string>): string {
+  try {
+    loadAndVerifyAnetBin(env as any, "linux");
+  } catch (e: any) {
+    return String(e?.message || e);
+  }
+  throw new Error("期待抛出 anet_bin_unsafe_path,但它没抛");
+}
+
+describe("#1635 anet_bin_source 的报错", () => {
+  it("点名的是它真读的那个文件,不是默认值", () => {
+    const msg = messageFor({ ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
+    expect(msg).toContain("/nonexistent-xyz-1635");
+    // 🔴 反向见证:修之前这里是默认值。没有这一条,把 confPath 写回 trustRoot 也照样绿。
+    expect(msg).not.toContain("resolved from /etc/anet-daemon/path.conf");
+  });
+
+  it("给出免 root 的那条路", () => {
+    const msg = messageFor({ ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
+    expect(msg).toContain("ANET_DAEMON_PATH_CONF");
+    expect(msg).toContain("no /etc, no sudo");
+  });
+
+  it("🔴 消息里那条 shell 必须真能跑 —— 验的是消息本身,不是源码里的字符串", () => {
+    const msg = messageFor({ ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
+    const m = /no sudo\): ([\s\S]*?) \(put ANET_DAEMON_PATH_CONF/.exec(msg);
+    expect(m).not.toBeNull();
+    const cmd = m![1];
+    expect(cmd.length).toBeGreaterThan(80);
+    // bash -n:只查语法,不执行
+    expect(() => execFileSync("bash", ["-n", "-c", cmd], { stdio: "pipe" })).not.toThrow();
+  });
+
+  it("另一条 reason(设了 ANET_BIN_ABS 但没开 ALLOW_ENV_BIN)也给同一条免 root 路", () => {
+    const msg = messageFor({ ANET_BIN_ABS: "/tmp/whatever", ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
+    expect(msg).toContain("no /etc, no sudo");
+  });
+});


### PR DESCRIPTION
两个缺陷,第二个是**跑出来才看见的**,#1635 正文里没有。

## ① 报错点的文件不是它真读的那个

    const confPath = env.ANET_DAEMON_PATH_CONF || trustRoot;
    pin = readPathConf(confPath);                            // 读 confPath
    throw ... `no ANET_BIN_ABS resolved from ${trustRoot}`   // 报 trustRoot ← 默认值

实测:传 `ANET_DAEMON_PATH_CONF=/nonexistent-xyz`,报错说
`from /etc/anet-daemon/path.conf`。**用户一旦用了这个变量,报错会把他指向一个
从没被读过的文件。** 改用 `confPath`。

## ② 只给了要 root 的修法

`ANET_DAEMON_PATH_CONF` 这条免 root、活得过重启的路一直在代码里,却从没出现在
任何面向用户的文案里(#1635)。两处 `anet_bin_source`(reason 不同:一处是设了
`ANET_BIN_ABS` 但没开 `ALLOW_ENV_BIN`,一处是什么都没配)现在都给出:

    Or keep the pin in a file you own (no /etc, no sudo): ANET_BIN_REAL="$(node -e …)" \
      && mkdir -p "$HOME/.anet" && printf 'ANET_BIN_ABS=%s\n' "$ANET_BIN_REAL" > "$HOME/.anet/path.conf" \
      && export ANET_DAEMON_PATH_CONF="$HOME/.anet/path.conf"
      (put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart)

措辞避开 "no root",因为消息里**已经有**一句 `No-root alternative to try first`
(讲的是 `anet daemon start` 自动声明 pin,另一个机制) —— 两个「免 root」并排会
读成重复。这一点也是跑出来才看见的。

## 验证

- 🔴 `bash -n` 验的是**从真实报错消息里抠出来的那 262 字节**,不是源码里的字符串。
  这个文件自己记着一次翻车:上一版给的修法语法就不成立,用户粘贴只看到 syntax error
  ——「验源码里的字符串」当时正好会放过它。
- 新增 `daemon-bin-error-help.test.ts` 4 项,含一条反向见证
  (`not.toContain("resolved from /etc/anet-daemon/path.conf")`) —— 没有它,
  把 confPath 写回 trustRoot 也照样绿。
- **两向见证**:
  变异① confPath→trustRoot ⇒ 1 fail;变异② 拿掉免 root 那句 ⇒ 3 fail;还原 ⇒ 4 pass。
- 仓内门 5 道全绿:doc-symbol-pins / mutation-pins / home-path-baseline /
  test-file-coverage / test-suite-registration(跑之前先 `git add`,否则新文件对
  `git ls-files` 型的门隐身)。

消息前缀 `anet_bin_unsafe_path:` 未改动(全仓 10 个文件依赖它,含 6 条 toThrow)。