### PR TITLE
ci(qa): 失败套件先打失败标记行，再 tail —— 早期失败会被 tail -60 整个截掉

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -687,6 +687,16 @@ jobs:
           set +e
           for f in /tmp/qa-*.log; do
             echo "================ $f ================"
+            # 🔴 先把失败标记行捞出来,再 tail。
+            #    实证(2026-08-31, PR #1680 的 test13-multi-channel):套件自报
+            #    `Results: 17 passed, 1 failed`,而 `tail -60` 那 60 行里
+            #    **一个失败标记都没有** —— 失败发生在前半段,被截掉了。
+            #    于是日志读起来像「全部通过却 rc=1」,排查要翻三层还拿不到名字。
+            #    标记取 `❌|FAIL`:test13 用 `fail(){ echo "  ❌ $1"; }`,
+            #    test225 用 `FAIL: ...` —— 两种写法都覆盖(读源码校准过,不是猜的)。
+            echo "---- failure markers ----"
+            grep -nE '❌|FAIL' "$f" | head -20
+            echo "---- tail -60 ----"
             tail -60 "$f"
           done
 


### PR DESCRIPTION
## 今天的实证

PR #1680 的 `L0 + L1` 红在 `✗ L1 test13-multi-channel`。翻它的 dump:

    ================ /tmp/qa-l1-test13-multi-channel-run.log ================
    …
    8. Verify /api/messages communication history
      ✅ /api/messages has full records
    9. Verify /api/task_events status changes
      ✅ /api/task_events has state changes
    =========================================
      Results: 17 passed, 1 failed
    =========================================

**60 行里一个失败标记都没有**,而套件自己数出 `1 failed` ——
因为 `tail -60` 把前半段(失败发生的地方)整个截掉了。
读起来像「全部通过却 rc=1」,排查要翻三层(`✗` 摘要 → `rc=1` → 后段完整 dump)
**最后仍然拿不到那条失败的名字**。

🔴 而且被截断的 dump 和完整的 dump **长得一样** —— 唯一的线索是那段的第一行
是横幅的中间(`║ Security:`,顶边框没了)。不看这一点,就会把「tail 截掉了」
读成「测试没打印失败」,然后去给测试加打印(而它本来就打了)。

## 改动

失败标记行先捞出来,再 tail:

    echo "---- failure markers ----"
    grep -nE '❌|FAIL' "$f" | head -20
    echo "---- tail -60 ----"
    tail -60 "$f"

`head -20` 封顶,不会把日志撑大。`set +e` 本来就有,grep 无命中返回 1 不影响后续。

## 判据是读源码校准的,不是猜的

    tests/test13-multi-channel/run.sh:13    fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
    test225 (本次另一个失败套件)              FAIL: first stale-lock reclaimer failed

⇒ `❌|FAIL` 两种写法都覆盖。

## 两向见证

造一份「失败在第 2 行 + 之后 100 行全绿」的夹具(正是 test13 的形状):

    旧写法 tail -60          → ❌ 命中 **0**
    新写法 grep + tail       → `2:  ❌ agent-b did not receive broadcast`(带行号)

## 门

action-pins / agent-node-typecheck-ratchet / l1-paths-sync / no-memory-slugs /
qa-paths-symmetry / home-path-baseline 均 rc=0;YAML 解析通过(验的是**改过的**文件)。