### PR TITLE
fix(cli): #1545 surface daemon create capability in doctor

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8721,24 +8721,12 @@ async function daemonListCommand() {
   // 🔴 hub 不可达时**不让整条命令失败**:本地清单本来就不需要网络,
   //    而"看不到能力"和"没有 daemon"是两件完全不同的事,必须分别说清。
   const fetched = await fetchDaemonCapabilities();
-  const byNodeId = fetched.ok ? fetched.rows : null;
 
   for (const { id, profile } of daemons) {
     const nid = (profile as any)?.node_id || "(missing)";
     const runtimes = ((profile as any)?.runtimes_supported || []).join(",") || "(default)";
     console.log(`  ${padDisplayEnd(id, 24)} node_id=${nid}  runtimes=[${runtimes}]`);
-    if (byNodeId === null) {
-      // hub 不可达/未配置 —— 这是**第四种**情况,和"没报过"不同:
-      // 那台 daemon 可能报得好好的,只是我们现在问不到。别把它说成未知能力。
-      console.log(`    ${describeFetchFailure((fetched as any).failure)}`);
-      continue;
-    }
-    const row = byNodeId.get(nid);
-    if (!row) {
-      console.log(`    创建能力:查不到 —— hub 上没有这个 node_id(还没注册过,或注册到了别的网络)`);
-      continue;
-    }
-    console.log(`    ${describeCapability(row, Date.now()).line}`);
+    console.log(`    ${daemonCreateCapabilityLine(nid, fetched, Date.now())}`);
   }
 }
 
@@ -8753,6 +8741,19 @@ async function daemonListCommand() {
 type CapabilityFetchResult =
   | { ok: true; rows: Map<string, DaemonCapabilityRow> }
   | { ok: false; failure: CapabilityFetchFailure };
+
+function daemonCreateCapabilityLine(nid: string, fetched: CapabilityFetchResult, nowMs: number): string {
+  if (!fetched.ok) {
+    // hub 不可达/未配置 —— 这是**第四种**情况,和"没报过"不同:
+    // 那台 daemon 可能报得好好的,只是我们现在问不到。别把它说成未知能力。
+    return describeFetchFailure(fetched.failure);
+  }
+  const row = fetched.rows.get(nid);
+  if (!row) {
+    return "创建能力:查不到 —— hub 上没有这个 node_id(还没注册过,或注册到了别的网络)";
+  }
+  return describeCapability(row, nowMs).line;
+}
 
 async function fetchDaemonCapabilities(): Promise<CapabilityFetchResult> {
   const gc = loadGlobal();
@@ -15944,6 +15945,20 @@ async function doctorCommand() {
   // 说清上面那一列量的是什么 —— 否则它和 anet node ls 的 STATUS 是两个
   // 同样权威、可以互相矛盾的答案。
   if (ids.length) info("  这一列的含义", LOCAL_VS_HUB_NOTE);
+
+  const localDaemons = ids
+    .map(id => ({ id, profile: loadProfile(id) }))
+    .filter(({ profile }) => profile?.role === "host_supervisor");
+  if (localDaemons.length) {
+    const fetched = await fetchDaemonCapabilities();
+    const nowMs = Date.now();
+    for (const { id, profile } of localDaemons) {
+      const name = nodeDisplayName(id, profile);
+      const nid = profile?.node_id || "(missing)";
+      info(`    ↳ ${name} create-node`, daemonCreateCapabilityLine(nid, fetched, nowMs));
+    }
+  }
+
   if (needsMigration.length) {
     if (fix) {
       console.log(`\n  ⚙  Auto-fixing ${needsMigration.length} node(s)...`);

--- a/agent-network/src/doctor-daemon-capability-wiring.test.ts
+++ b/agent-network/src/doctor-daemon-capability-wiring.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+describe("#1545 doctor daemon create-node capability wiring", () => {
+  const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8")
+    .split("\n")
+    .filter(l => { const c = l.trim(); return !c.startsWith("//") && !c.startsWith("*") && !c.startsWith("/*"); })
+    .join("\n");
+
+  const doctor = cli.slice(cli.indexOf("async function doctorCommand()"));
+
+  test("doctor prints each local host_supervisor through the shared capability renderer", () => {
+    expect(doctor).toContain('profile?.role === "host_supervisor"');
+    expect(doctor).toContain("await fetchDaemonCapabilities()");
+    expect(doctor).toContain("daemonCreateCapabilityLine(nid, fetched, nowMs)");
+  });
+
+  test("daemon list and doctor share the same describeCapability call path", () => {
+    expect(cli.match(/describeCapability\(/g)?.length).toBe(1);
+    expect(cli).toContain("return describeCapability(row, nowMs).line;");
+  });
+});

--- a/docs/tests/report-test1545-doctor-daemon-capability.txt
+++ b/docs/tests/report-test1545-doctor-daemon-capability.txt
@@ -1,0 +1,43 @@
+Issue: #1545 doctor daemon create-node capability
+Date: 2026-08-31
+
+Worktree:
+  <repo>/.worktrees/issue-1545-doctor-capability
+
+Change:
+  anet doctor now prints each local host_supervisor daemon's create-node
+  capability through the same renderer used by anet daemon list.
+
+Build:
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun run build
+  Result: pass
+
+Rendered CLI evidence from built dist/bin/anet.cjs with a temporary project and
+local fake hub returning three daemon capability rows:
+
+  blocked:
+    ℹ      ↳ daemon-blocked create-node: 创建能力:**不可用**(anet_bin_source,1ms 前测)
+      修法(可整行粘贴):sudo install -d -m 755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\n' "$(command -v anet)" | sudo tee /etc/anet-daemon/path.conf
+
+  ready:
+    ℹ      ↳ daemon-ready create-node: 创建能力:可用(1ms 前测)
+
+  unknown:
+    ℹ      ↳ daemon-unknown create-node: 创建能力:未知 —— 这台 daemon 没报过这一格。
+
+Tests:
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/doctor-daemon-capability-wiring.test.ts ./agent-network/src/daemon-capability-display.test.ts
+  Result: pass
+  Summary: 55 pass, 0 fail, 161 expect() calls.
+
+  PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/
+  Result: pass
+  Summary: 971 pass, 3 skip, 0 fail, 2773 expect() calls, 974 tests across 105 files.
+
+Checks:
+  python3 scripts/check-doc-symbol-pins.py --fix
+  python3 scripts/check-doc-symbol-pins.py
+  Result: pass, SYMBOL-PIN OK, 0 drift.
+
+  python3 .github/scripts/check-home-path-baseline.py
+  Result: pass, no file is above its baseline.


### PR DESCRIPTION
## Summary

- `anet doctor` now prints each local `host_supervisor` daemon's create-node capability.
- `anet daemon list` and `anet doctor` share the same `daemonCreateCapabilityLine(...)` path, which reuses `describeCapability(...)`.
- Adds a wiring test and records the verification report in `docs/tests/report-test1545-doctor-daemon-capability.txt`.

## Evidence Boundary

代码接上了，也测到 doctor 输出渲染；但证据来自 fake hub，不是手上真实 daemon。

I did not start a real daemon to manufacture that evidence. The fake hub coverage proves the three rendered rows are wired through the CLI output path; real-daemon evidence remains a separate line if needed.

## Verification

- `PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun test ./agent-network/src/doctor-daemon-capability-wiring.test.ts ./agent-network/src/daemon-capability-display.test.ts`
  - Result: pass, 55 pass / 0 fail / 161 expect() calls
- `(cd agent-network && PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH" bun run build)`
  - Result: pass

## Notes

Before pushing, I fast-forwarded the worktree to the latest `origin/main`; `git rev-list --count HEAD..origin/main` and `git rev-list --count origin/main..HEAD` were both 0 before commit.
