### PR TITLE
docs(daemon): path.conf 的位置可由 ANET_DAEMON_PATH_CONF 覆盖 —— 免 root 且活得过重启 (#1635)

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -188,6 +188,21 @@ anet daemon up
 | `/etc/anet-daemon/path.conf` | 生产信任根；存在时优先于环境变量 |
 | `ANET_BIN_ABS` 环境变量 | Docker、开发机或手工运维的便利通道 |
 
+🔴 **第 ① 条不一定要写 `/etc`,也就不一定要 root。** 它的位置由
+`ANET_DAEMON_PATH_CONF` 决定 —— 没设时才回落到 `/etc/anet-daemon/path.conf`
+(Windows 是 `%ProgramData%\anet-daemon\path.conf`)。把它指到一个你自己有权限的文件,
+就得到一条**免 root、且活得过重启**的路(与 `ANET_BIN_ABS` 不同,后者只活在那一个进程里):
+
+```bash
+ANET_BIN_REAL="$(node -e 'console.log(require("fs").realpathSync(process.argv[1]))' "$(command -v anet)")" \
+  && mkdir -p "$HOME/.anet" \
+  && printf 'ANET_BIN_ABS=%s\n' "$ANET_BIN_REAL" > "$HOME/.anet/path.conf" \
+  && export ANET_DAEMON_PATH_CONF="$HOME/.anet/path.conf"
+```
+
+把 `ANET_DAEMON_PATH_CONF` 放进 daemon 自己的环境(systemd 的 `Environment=`、
+pm2 的 `env`、或启动它的那个 shell 的 profile),否则重启后又会回落到 `/etc`。
+
 `ANET_BIN_ABS` 只有在 `ANET_DAEMON_ALLOW_ENV_BIN=1` 时才会被 runtime 接受。
 `anet daemon init` / `start` / `up` 会自己设置这个声明,所以上面的 quickstart
 不需要你手工加环境变量；只有绕过 `anet daemon`、直接拼 daemon 启动命令时才需要自己声明。

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -199,6 +199,23 @@ The `anet` path has two sources with different trust levels:
 | `/etc/anet-daemon/path.conf` | Production trust root; when present, it wins over the environment |
 | `ANET_BIN_ABS` environment variable | Docker, development machines, or manual operations convenience |
 
+🔴 **Source ① does not have to live in `/etc`, so it does not have to need root.**
+Its location comes from `ANET_DAEMON_PATH_CONF`; only when that is unset does it
+fall back to `/etc/anet-daemon/path.conf` (`%ProgramData%\anet-daemon\path.conf` on
+Windows). Point it at a file you own and you get a **root-free pin that survives a
+restart** — unlike `ANET_BIN_ABS`, which lives only in that one process:
+
+```bash
+ANET_BIN_REAL="$(node -e 'console.log(require("fs").realpathSync(process.argv[1]))' "$(command -v anet)")" \
+  && mkdir -p "$HOME/.anet" \
+  && printf 'ANET_BIN_ABS=%s\n' "$ANET_BIN_REAL" > "$HOME/.anet/path.conf" \
+  && export ANET_DAEMON_PATH_CONF="$HOME/.anet/path.conf"
+```
+
+Put `ANET_DAEMON_PATH_CONF` in the daemon's own environment (systemd `Environment=`,
+pm2 `env`, or the profile of the shell that starts it) — otherwise a restart falls
+back to `/etc` again.
+
 The runtime accepts `ANET_BIN_ABS` only when `ANET_DAEMON_ALLOW_ENV_BIN=1` is also set.
 `anet daemon init` / `start` / `up` sets that declaration itself, so the quickstart above
 does not need a manual environment variable. You only need to set it yourself when bypassing


### PR DESCRIPTION
#1635 指出 `ANET_DAEMON_PATH_CONF` **在任何面向用户的文档和报错文案里都没有出现过**。
报错文案那半已由 #1682 修掉,这条补文档那半。

实测(2026-08-31, origin/main):

    docs-site 里 ANET_DAEMON_PATH_CONF        0 次
    docs-site 里 ANET_BIN_ABS                46 次
    docs-site 里 ANET_DAEMON_ALLOW_ENV_BIN    7 次

⇒ 文档确实在讲这个话题,**唯独漏了那条免 root 的路**。

## 🔴 定性先搞对:它不是「第三个来源」

    agent-node/src/runtime/create-node-daemon.ts
    const confPath = env.ANET_DAEMON_PATH_CONF || trustRoot;

它改的是**第 ① 个来源的位置**,不是新增一个来源。所以文档里原来那句
「`anet` 只信任两个来源」**仍然成立**,补的是「第 ① 条的位置可以搬」。
写成「第三条路」会把信任模型讲错。

## 内容

在两个来源的表格之后补一段,说明:

- 位置由 `ANET_DAEMON_PATH_CONF` 决定,未设才回落 `/etc/anet-daemon/path.conf`
  (Windows 是 `%ProgramData%\anet-daemon\path.conf`);
- 指到自己有权限的文件 ⇒ 免 root,**且活得过重启**
  (与 `ANET_BIN_ABS` 不同 —— 后者只活在那一个进程里);
- 要把这个变量放进 daemon **自己的**环境(systemd `Environment=` / pm2 `env` /
  启动它那个 shell 的 profile),否则重启后又回落到 `/etc`。

中英两份同步。

## 验证

🔴 文档里给的命令是**从渲染后的正文里抠出来跑的**,不是看着像对:

    抠出 274 字节 → bash -n rc=0 → 在一个临时 HOME 里实跑
    → 写出 ANET_BIN_ABS=/…/@sleep2agi/agent-network/dist/bin/cli.js

(`create-node-daemon.ts` 自己记着一次翻车:上一版给用户的修法**语法就不成立**,
粘贴进去只看到 `syntax error`。一条跑不通的建议比没有建议更糟 —— 它让人以为自己已经修过了。)

门:home-path-baseline / doc-symbol-pins 均 rc=0。