### PR TITLE
fix(hub): external-schedule-edits 的四个时间列按 UTC 解析，垃圾串不再打 500 (#1650)

### DIFF
--- a/server/src/external-schedule-edits-timestamps.test.ts
+++ b/server/src/external-schedule-edits-timestamps.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { parseHubTimestamp } from "./hub-timestamp";
+
+// #1650 —— external-schedule-edits 的 publicEdit() 原先对四个时间列直接
+// `new Date(row.x).toISOString()`。这些列是 SQLite `datetime('now')` 家族:
+// **UTC 但不带时区标记**,而 JS 对「有时间、无偏移」的串按**本机时区**解析,
+// 且不报错 ⇒ 发给 API 消费方的是一个错的时刻。
+
+function hubIso(raw: unknown): string | null {
+  const ms = parseHubTimestamp(raw);
+  return ms === null ? null : new Date(ms).toISOString();
+}
+
+describe("#1650 hub 时间戳按 UTC 解析", () => {
+  it("🔴 无时区标记的串按 UTC 解析,不按本机时区", () => {
+    expect(hubIso("2026-08-30 21:04:11")).toBe("2026-08-30T21:04:11.000Z");
+  });
+
+  it("🔴 反向见证:旧写法在非 UTC 机器上会给出不同的结果", () => {
+    const old = new Date("2026-08-30 21:04:11").toISOString();
+    const now = hubIso("2026-08-30 21:04:11")!;
+    // 只有当本机恰好是 UTC 时两者才相同;此处断言的是「新写法等于 UTC 语义」,
+    // 而 old 的值取决于运行机器 —— 所以只在两者不同时才有对比意义。
+    const offsetMin = new Date("2026-08-30T21:04:11Z").getTimezoneOffset();
+    if (offsetMin !== 0) expect(old).not.toBe(now);
+    expect(now).toBe("2026-08-30T21:04:11.000Z");
+  });
+
+  it("带 Z 的串保持原意", () => {
+    expect(hubIso("2026-08-30T21:04:11Z")).toBe("2026-08-30T21:04:11.000Z");
+  });
+
+  it("🔴 垃圾串返回 null,而不是抛 RangeError(旧写法会把接口打成 500)", () => {
+    expect(hubIso("not-a-date")).toBeNull();
+    expect(hubIso(null)).toBeNull();
+    expect(hubIso(undefined)).toBeNull();
+    expect(() => new Date("not-a-date").toISOString()).toThrow();
+  });
+});
+
+// 🔴 上面四条测的是 helper 的语义。真正要钉住的是**那个文件用了它**——
+//    否则 helper 再对,publicEdit 里改回 `new Date(row.x)` 也照样全绿。
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("#1650 publicEdit 必须走 hubIso,不能有裸 new Date(row.*)", () => {
+  const SRC = readFileSync(join(import.meta.dir, "external-schedule-edits.ts"), "utf-8");
+  const CODE = SRC.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+  it("🔴 源码里不再有裸 new Date(row.…)", () => {
+    expect(/new Date\(row\./.test(CODE)).toBe(false);
+  });
+
+  it("四个时间列都走 hubIso", () => {
+    for (const f of ["expires_at", "created_at", "delivered_at", "acked_at"]) {
+      expect(CODE).toContain(`${f}: hubIso(row.${f})`);
+    }
+  });
+
+  it("hubIso 复用 parseHubTimestamp,没有第二套判据", () => {
+    expect(CODE).toContain('from "./hub-timestamp"');
+    expect(CODE).toContain("parseHubTimestamp(raw)");
+  });
+});

--- a/server/src/external-schedule-edits.ts
+++ b/server/src/external-schedule-edits.ts
@@ -2,6 +2,7 @@ import { db } from "./db.js";
 import { getUserNetworkRole } from "./auth.js";
 import { pushEvent } from "./push.js";
 import { parseExternalSchedulePatch, type ExternalSchedulePatch } from "./shared/external-schedule-contract.js";
+import { parseHubTimestamp } from "./hub-timestamp";
 
 type Auth = {
   userId: string;
@@ -109,6 +110,18 @@ function reportedSchedule(node: NodeRow, scheduleId: string): Record<string, unk
   }
 }
 
+// 🔴 #1650 —— 这些列是 SQLite `datetime('now')` 家族:**UTC 但不带时区标记**。
+//   `new Date("2026-08-30 21:04:11")` 会按**本机时区**解析(ES 规范:带时间且无偏移
+//   的形式视为本地时间),而且不报错 —— 于是发给 API 消费方的是一个错的时刻,
+//   误差就是这台机器的 offset。
+//   另外原写法在字段是垃圾串时 `new Date(x).toISOString()` 会**抛 RangeError**,
+//   足以把这个接口打成 500;`parseHubTimestamp` 解析失败返回 null,这里也返回 null。
+//   复用 server.ts:1010 已在用的那个 helper,不自造第二套判据。
+function hubIso(raw: unknown): string | null {
+  const ms = parseHubTimestamp(raw);
+  return ms === null ? null : new Date(ms).toISOString();
+}
+
 function publicEdit(row: EditRow): Record<string, unknown> {
   let patch: ExternalSchedulePatch = {};
   try { patch = JSON.parse(row.patch_json); } catch {}
@@ -119,10 +132,10 @@ function publicEdit(row: EditRow): Record<string, unknown> {
     base_revision: row.base_revision,
     patch,
     status: row.status,
-    expires_at: new Date(row.expires_at).toISOString(),
-    created_at: new Date(row.created_at).toISOString(),
-    delivered_at: row.delivered_at ? new Date(row.delivered_at).toISOString() : null,
-    acked_at: row.acked_at ? new Date(row.acked_at).toISOString() : null,
+    expires_at: hubIso(row.expires_at),
+    created_at: hubIso(row.created_at),
+    delivered_at: hubIso(row.delivered_at),
+    acked_at: hubIso(row.acked_at),
     result_revision: row.result_revision,
     error_code: row.error_code,
   };


### PR DESCRIPTION
## 是四处，不是两处

#1650 点名 `expires_at` / `created_at` 两行。打开 `publicEdit()` 一看,
同一个函数里 `delivered_at` / `acked_at` **一模一样**:

    expires_at:   new Date(row.expires_at).toISOString(),
    created_at:   new Date(row.created_at).toISOString(),
    delivered_at: row.delivered_at ? new Date(row.delivered_at).toISOString() : null,
    acked_at:     row.acked_at ? new Date(row.acked_at).toISOString() : null,

只修被点名的那两处,就是「只查被问的那一个」。四处一起改。

## 缺陷 ①：时刻是错的，而且不报错

这些列是 SQLite `datetime('now')` 家族 —— **UTC，但不带任何时区标记**
(实际取到的形如 `2026-08-30 21:04:11`)。

ES 规范:带时间、无偏移的形式**视为本地时间**。所以 `new Date(...)` 会按
**本机时区**解析,误差就是这台机器的 offset,而且**不抛不警告**。
`publicEdit()` 的产物是发给 API 消费方的,于是对方收到一个错的时刻。

## 缺陷 ②：垃圾串会把接口打成 500

`new Date("not-a-date").toISOString()` **抛 RangeError**。原写法没有任何防护。

## 修法：复用仓里已有的 helper，不自造第二套判据

`server/src/hub-timestamp.ts` 的 `parseHubTimestamp()` 就是干这个的
(无时区标记时补 `Z` 再 `Date.parse`,失败返回 `null`),
`server/src/server.ts:1010` 已经在用它修同一个 #1650 的另一处。

    function hubIso(raw: unknown): string | null {
      const ms = parseHubTimestamp(raw);
      return ms === null ? null : new Date(ms).toISOString();
    }

解析失败返回 `null` —— 与 server.ts 那处的既定选择一致。
`delivered_at` / `acked_at` 本来就可能是 `null`,形状不变;
`expires_at` / `created_at` 从「错的字符串或抛异常」变成「对的字符串或 null」。

## 测试写了两层，因为第一层不够

    前 4 条  hubIso 的语义:无时区串按 UTC / 带 Z 保持原意 /
             垃圾串返回 null 而非抛(并显式断言旧写法确实会抛)
    🔴 后 3 条  **那个文件真的用了它**:源码里不再有裸 `new Date(row.`、
             四个列都写成 `hubIso(row.x)`、且 import 的是同一个 parseHubTimestamp

没有后 3 条的话,**helper 再对,把调用点改回 `new Date(row.x)` 也照样全绿** ——
那种测试观察不到这个缺陷。

## 两向见证

把四处之一改回裸 `new Date`:

    控制生效断言 grep -c 'hubIso(row.expires_at)' = 0
    变异后  5 pass / 2 fail
    还原后  7 pass / 0 fail

## 门

doc-symbol-pins / mutation-pins / home-path-baseline /
test-file-coverage / test-suite-registration 均 rc=0。