### PR TITLE
fix(cli): anet status 里关于 blocked 的说明改成有代码为证的那个机制 (#1548 #1606)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -12079,8 +12079,9 @@ async function statusCommand() {
     // 🔴 #1548 —— 分类逻辑抽到 ../src/session-status-class.ts 并加了测试。
     //    原先这里把 `blocked` / `error` 折进 `working`,于是运维看到「N working」
     //    时,其中可能有几个是**卡住**或**出错**的。而 #1548 已经证明 `blocked`
-    //    是一个**没有出口**的状态(只有 report_completion 能把它拉回 idle),
-    //    所以一个 agent 可以永远停在那里而被报成「在干活」。
+    //    是一个**长期为真**的状态,所以一个 agent 可以永远停在那里而被报成「在干活」。
+    //    (它并非「没有出口」—— server 的 report_status upsert 里 `status = ?10` 是无条件
+    //     覆盖。真正的机制见下面 Needs attention 那一段的注释与 #1606。)
     const classifyStatus = (s: any) => classifySessionStatus(s?.status);
     // 🔴 #1625 —— **不再用 `statusRes.summary`**。`/api/status` 总是返回一个
     //    summary,于是原先的 `statusRes.summary || …` 让本地分类器从不执行,
@@ -12121,12 +12122,20 @@ async function statusCommand() {
       // 🔴 状态是**自报**的:它只在 agent 显式上报时才变。一个 `blocked` 可能是
       //    3 秒前报的,也可能是三周前报的 —— 这里不假装知道哪一种。
       // 🔴 不要写「not progressing」:#1548 的实测证据正好相反 —— 一个 blocked 节点
-      //    22 秒答完了一条任务。blocked 说的是「没有出口」(只有 report_completion
-      //    会把它清回 idle),不是「它停了」。这两句话对用户的含义完全不同。
-      console.log("    (🔴 blocked ≠ 停了 —— 实测 blocked 节点仍能秒回任务;它只是没有出口:");
-      console.log("     只有 report_completion 会把 status 清回 idle。状态由 agent 自报,");
-      console.log("     不含活性成分,名册里也没有「何时变成 blocked」这个字段 —— updated_at");
-      console.log("     被心跳一直刷,不是它。要确认它还在不在,发一条任务试试。)");
+      //    22 秒答完了一条任务。
+      // 🔴 也不要声称「只有那个终态回调能清」——旧注释里的那句是错的:
+      //    server/src/tools.ts 的 report_status upsert 里 `status = ?10` 是**无条件覆盖**
+      //    (同句其余二十来个字段全是 COALESCE),所以 report_status(status="idle") 就能清。
+      //    grok 共存节点出不来的真正原因在 agent-node 侧:
+      //      runtime/grok-copresence/liveness.ts
+      //        if (!liveness.usable && (requested === "idle" || requested === "working")) return "blocked";
+      //    agent-node 每 3 分钟上报的 idle 在发出前被改写成 blocked —— 见 #1606。
+      console.log("    (🔴 blocked ≠ 停了 —— 实测 blocked 节点仍能秒回任务。状态由 agent 自报,");
+      console.log("     不含活性成分;名册里也没有「何时变成 blocked」这个字段 —— updated_at");
+      console.log("     被心跳一直刷,不是它。要确认它还在不在,发一条任务试试。");
+      console.log("     🔴 grok 共存节点还有一种可能:blocked 表示的是「共存运行时不可用」,");
+      console.log("     而不是「这个 agent 卡住了」—— agent-node 每 3 分钟上报的 idle 会在");
+      console.log("     liveness 判不可用时被改写成 blocked。见 #1606。)");
       console.log();
     }
 

--- a/agent-network/src/blocked-note-accuracy.test.ts
+++ b/agent-network/src/blocked-note-accuracy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `anet status` 的 Needs attention 一节里，关于 blocked 的说明原本写着
+// 「只有 report_completion 会把 status 清回 idle」。**那句是错的**：
+//
+//   server/src/tools.ts 的 report_status upsert 里
+//     status = ?10                       ← 无条件覆盖（同句其余二十来个字段全是 COALESCE）
+//
+// 所以 report_status(status="idle") 就能清。真正让 grok 共存节点出不来的是
+//   agent-node/src/runtime/grok-copresence/liveness.ts
+//     if (!liveness.usable && (requested === "idle" || requested === "working")) return "blocked";
+// —— agent-node 每 3 分钟上报的 idle 在发出前被改写成 blocked（#1606）。
+//
+// 🔴 这条测试只钉「不要再断言那个错的机制」和「要提到共存这种可能」，
+//    **不钉任何建议动作** —— 在 #1606 定案前，任何「调 X 就能清」都会误导。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+
+describe("anet status 对 blocked 的说明", () => {
+  it("🔴 不再声称只有 report_completion 能清", () => {
+    expect(CLI).not.toContain("report_completion");
+  });
+
+  it("说明 grok 共存节点的 blocked 可能是「共存运行时不可用」", () => {
+    expect(CLI).toContain("共存运行时不可用");
+    expect(CLI).toContain("#1606");
+  });
+
+  it("保留两条经得起复核的事实", () => {
+    expect(CLI).toContain("blocked ≠ 停了");      // 实测：blocked 节点仍能秒回任务
+    expect(CLI).toContain("发一条任务试试");        // 唯一安全的验活方式
+  });
+});


### PR DESCRIPTION
## 原文错在哪

`anet status` 的 Needs attention 一节以及它上下两处注释都写着:

    blocked 是一个**没有出口**的状态(只有 report_completion 能把它拉回 idle)

**那句是错的。** `server/src/tools.ts` 里 `report_status` 的 upsert:

    ON CONFLICT(resume_id) DO UPDATE SET
      alias  = COALESCE(?2, sessions.alias),   -- 其余二十来个字段全是 COALESCE
      status = ?10,                            -- 🔴 唯独这个无条件覆盖

⇒ `report_status(status="idle")` 就能清。**出口是有的。**

grok 共存节点出不来的真正机制在 agent-node 侧:

    agent-node/src/cli.ts:6620      setInterval(() => reportStatus("idle"), 3*60*1000)
    agent-node/src/cli.ts:1487      status: resolveReportedStatus(status)     ← 不是原值
    runtime/grok-copresence/liveness.ts:121
      if (!liveness.usable && (requested === "idle" || requested === "working")) return "blocked";

⇒ **每 3 分钟上报的 `idle` 在发出前被改写成 `blocked`。** 不是「没有出口」,
是「有一条周期性写回的路径」。这两句话导出的修法**相反**:
前者会去给 hub 加外部清除接口,而那个接口下一个 3 分钟就会被写回。见 #1606。

## 改了三处，不是一处

    用户看的输出        删掉那句错的;加一条:grok 共存节点的 blocked 还可能表示
                       「共存运行时不可用」,而不是「这个 agent 卡住了」
    cli.ts 上方注释      「没有出口」→「长期为真」,并注明 `status = ?10` 是无条件覆盖
    cli.ts 下方注释      换上有代码为证的机制(liveness.ts 那三行 + 每 3 分钟改写)

🔴 只改用户那份是不够的:**下一个来改这段代码的人读到的是注释。**
我第一版只改了输出,是自己写的断言(对整个源文件断言,而不是只对 console.log 那几行)
把另外两处揪出来的。

## 明确不做的事

**没有加任何新的「建议动作」。** 在 #1606 定案前,任何「调 X 就能清」都会误导:
在 liveness 判不可用时,谁调都会被写回。

## 验证

- 构建产物里那三句真实文案各 1 次(`blocked ≠ 停了` / `共存运行时不可用` / `发一条任务试试`),
  `report_completion` **0 次** —— 验的是 bundle,不是源码里的字符串。
- 新增 `agent-network/src/blocked-note-accuracy.test.ts` 3 项。
- 两向见证:把那句错的机制写回注释 ⇒ `2 pass / 1 fail`;还原 ⇒ `3 pass / 0 fail`;
  控制生效断言 `grep -c report_completion` = 1(变异时) / 0(还原后)。
- 门:doc-symbol-pins / mutation-pins / home-path-baseline 均 rc=0。