### PR TITLE
fix(cli): anet 帮助文本按段对齐描述列，并加一条防漂的测试

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3793,46 +3793,46 @@ function printHelp() {
 anet — AI Agent Network CLI (V2)
 
 Quick start:
-  anet hub start                  Start local hub
-  anet login                      Log in to the hub
-  anet node create my-agent       Create a node
-  anet node start my-agent        Start the node
-  anet demo                       List demos
+  anet hub start             Start local hub
+  anet login                 Log in to the hub
+  anet node create my-agent  Create a node
+  anet node start my-agent   Start the node
+  anet demo                  List demos
   (连别人已有的 hub: anet init --hub <url>)
 
 Node Management:
-  anet node create <name>        Create a new agent node
-  anet node start <name>         Start a node
-  anet node start --all          Start every node in cwd (= anet project up)
-  anet node stop <name>          Stop a running node
-  anet node resume <name>        Resume interrupted session
-  anet node delete <name>        Delete node and config
-  anet node rename <ref> <new>   Rename a node
-  anet node ls                   List all nodes
-  anet attach <name>             Attach the node's exact tmux TUI session
+  anet node create <name>       Create a new agent node
+  anet node start <name>        Start a node
+  anet node start --all         Start every node in cwd (= anet project up)
+  anet node stop <name>         Stop a running node
+  anet node resume <name>       Resume interrupted session
+  anet node delete <name>       Delete node and config
+  anet node rename <ref> <new>  Rename a node
+  anet node ls                  List all nodes
+  anet attach <name>            Attach the node's exact tmux TUI session
   anet info <name>              Detailed node info + server status
   anet status                   Network overview (agents + tasks)
   anet tasks [status]           Query tasks (replied/failed/delivered)
-  anet goal list [node]          List local scheduled goals
-  anet goal show <node> <id>     Show one goal in detail (progress log)
+  anet goal list [node]         List local scheduled goals
+  anet goal show <node> <id>    Show one goal in detail (progress log)
   anet goal edit <node> <id> ... Edit a goal's interval / text / status
-  anet goal cancel <node> <id>   Mark a scheduled goal cancelled
+  anet goal cancel <node> <id>  Mark a scheduled goal cancelled
 
 Project (cwd-wide):
-  anet project up                Start every node in cwd (skip already-running)
-  anet project restart           Kill existing tmux + start fresh (every node)
-  anet project down              Stop every node + notify hub offline
+  anet project up               Start every node in cwd (skip already-running)
+  anet project restart          Kill existing tmux + start fresh (every node)
+  anet project down             Stop every node + notify hub offline
   --stagger <s>                  Delay between nodes (default: 3, 0 disables)
   --only a,b / --exclude x,y     Filter by alias or node id
 
 Session:
-  anet node create <name> --resume <id>  Bind an existing Claude session
+  anet node create <name> --resume <id>    Bind an existing Claude session
   anet node create <name> --resume-latest  Bind the latest Claude session
-  anet node start <name>                 Start in this terminal (foreground, default)
-  anet node start <name> --tmux          Start in a tmux session (attach with a terminal; detached when headless)
-  anet node start <name> --new-session   Start with fresh Claude session
+  anet node start <name>                   Start in this terminal (foreground, default)
+  anet node start <name> --tmux            Start in a tmux session (attach with a terminal; detached when headless)
+  anet node start <name> --new-session     Start with fresh Claude session
   anet node resume <name> --session <id> Resume specific session
-  anet session ls               List Claude Code sessions
+  anet session ls                          List Claude Code sessions
 
 Co-presence (human TUI + network agent share one thread):
   anet node start <name> --copresence
@@ -3854,38 +3854,38 @@ Grok co-presence (preview only):
                                 Create an experimental shared Grok TUI node
   anet node create <name> --runtime grok-build-cli --tools WebSearch
                                 Opt into general web search (supports basic X URL search)
-  anet grok attach <name>       Attach this terminal (Ctrl-] detaches)
-  anet grok model <name> <id>   Switch the model; works while attached
+  anet grok attach <name>                  Attach this terminal (Ctrl-] detaches)
+  anet grok model <name> <id>              Switch the model; works while attached
   --grok-headless               Use legacy per-turn grok-build-cli instead
   --owner-schedule-control      Opt this node into owner-gated managed-cron edits
   WARNING: network tasks drive the same TUI; use trusted tasks/networks only
 
 Channel:
   anet channel add telegram <name> --bot-token <tok> --allow <uid>
-  anet channel ls [name]        List channels
+  anet channel ls [name]  List channels
 
 Setup:
-  anet init [--hub <url>]       Configure hub URL (global; no token prompt)
+  anet init [--hub <url>]                                 Configure hub URL (global; no token prompt)
   anet init --hub <url> --token <tok>
                                 Legacy master-token compatibility path
-  anet init project             Setup project (channel plugin)
-  anet setup                    Install runtime dependencies
-  anet hub start                 Start CommHub Server + admin bootstrap
-  anet hub dashboard             Start Web Dashboard
-  anet hub config                Show/set server config
-  anet upgrade                  Upgrade all anet packages (channel-aware)
+  anet init project                                       Setup project (channel plugin)
+  anet setup                                              Install runtime dependencies
+  anet hub start                                          Start CommHub Server + admin bootstrap
+  anet hub dashboard                                      Start Web Dashboard
+  anet hub config                                         Show/set server config
+  anet upgrade                                            Upgrade all anet packages (channel-aware)
   anet upgrade --channel preview|latest --dry-run --self  (see flags)
 
 Daemon (host_supervisor — required by the dashboard's node-creation wizard):
-  anet daemon up [name]         Create + start a daemon (one-shot, default: "daemon")
-  anet daemon init <name>       Create a host_supervisor node config
-  anet daemon start <name>      Start an existing daemon
-  anet daemon list              List locally-configured daemons
+  anet daemon up [name]                                   Create + start a daemon (one-shot, default: "daemon")
+  anet daemon init <name>                                 Create a host_supervisor node config
+  anet daemon start <name>                                Start an existing daemon
+  anet daemon list                                        List locally-configured daemons
 
 Config & tokens:
-  anet config [path|json]       Show config summary, path, or raw JSON
-  anet token ls|create|revoke   Manage API tokens
-  anet batch <verb> [prefix]    Manage groups created by create --batch
+  anet config [path|json]      Show config summary, path, or raw JSON
+  anet token ls|create|revoke  Manage API tokens
+  anet batch <verb> [prefix]   Manage groups created by create --batch
 
 OpenCode:
   anet opencode upgrade-pin <v> Verify + pin the exact opencode-ai release
@@ -3893,28 +3893,28 @@ OpenCode:
                                 API-key login for an opencode-cli node
 
 Other:
-  anet import [alias]           Import sessions from CommHub
-  anet register                  Create new account
-  anet login                    Login (username + password)
-  anet login --token <tok>      Login with API token
-  anet logout                   Remove saved token
-  anet passwd                   Change password
-  anet whoami                   Show current user + networks
-  anet network ls               List my networks
-  anet network create <name>    Create a network
-  anet network use <name>       Switch to a network
-  anet skill list               List public SkillHub skills
-  anet skill show <slug>        Print a skill's SKILL.md (sha256 verified)
-  anet license                  Show license status + limits
-  anet activate <key>           Activate license key
-  anet logs <name>              Show recent agent logs
-  anet doctor                   System diagnostic check
-  anet run                      Standalone SSE agent
-  anet -v                       Version + dependency report
+  anet import [alias]         Import sessions from CommHub
+  anet register               Create new account
+  anet login                  Login (username + password)
+  anet login --token <tok>    Login with API token
+  anet logout                 Remove saved token
+  anet passwd                 Change password
+  anet whoami                 Show current user + networks
+  anet network ls             List my networks
+  anet network create <name>  Create a network
+  anet network use <name>     Switch to a network
+  anet skill list             List public SkillHub skills
+  anet skill show <slug>      Print a skill's SKILL.md (sha256 verified)
+  anet license                Show license status + limits
+  anet activate <key>         Activate license key
+  anet logs <name>            Show recent agent logs
+  anet doctor                 System diagnostic check
+  anet run                    Standalone SSE agent
+  anet -v                     Version + dependency report
 
 Legacy aliases:
-  anet create <name>              Alias for anet node create
-  anet start <name>               Alias for anet node start
+  anet create <name>  Alias for anet node create
+  anet start <name>   Alias for anet node start
 `);
 }
 
@@ -8249,11 +8249,11 @@ Options:
   --password <pass>  Bootstrap admin password (default: a random anet-xxxx, printed once)
 
 Example:
-  anet hub start                     # Start server + bootstrap admin account
-  anet hub dashboard                 # Start Dashboard UI
-  anet hub start --host 0.0.0.0      # Allow LAN agents
-  anet hub start --port 8080         # Custom port
-  anet hub config                    # Show config
+  anet hub start                 # Start server + bootstrap admin account
+  anet hub dashboard             # Start Dashboard UI
+  anet hub start --host 0.0.0.0  # Allow LAN agents
+  anet hub start --port 8080     # Custom port
+  anet hub config                # Show config
 `);
 }
 
@@ -8440,9 +8440,9 @@ Options:
 
 Daemon 就是一个 role=host_supervisor 的 agent-node,所以停 / 删 / 看**没有** daemon 版,
 直接用 node 级命令(anet daemon restart 内部调的也正是其中的 stop):
-  anet node stop <name>      停一个 daemon
-  anet node delete <name>    删掉它
-  anet node ls               看它在不在跑(daemon list 只列本机配置过的 daemon,不含活性)
+  anet node stop <name>    停一个 daemon
+  anet node delete <name>  删掉它
+  anet node ls             看它在不在跑(daemon list 只列本机配置过的 daemon,不含活性)
 
 A "daemon" is an agent-node with role:host_supervisor — receives create_node
 dispatches from the hub/dashboard and forks child agent-nodes on demand.
@@ -10233,9 +10233,9 @@ Options (shared):
   --exclude x,y         Skip these aliases (or node ids)
 
 Examples:
-  anet project up                       # 起所有，skip 已跑的
-  anet project restart --stagger 1      # 全重启，1s 错峰
-  anet project down --only commhub_1    # 只停一个
+  anet project up                           # 起所有，skip 已跑的
+  anet project restart --stagger 1          # 全重启，1s 错峰
+  anet project down --only commhub_1        # 只停一个
 `);
 }
 
@@ -10704,7 +10704,7 @@ Examples:
   anet node loop my-codex "monitor #271 PR" --every 5m
   anet node loop researcher "scan twitter for grok updates" --every 30m
   anet node loop daily-bot "post the morning summary" --every 2h
-  anet node loop nightly-bot "rotate logs"                  --every 1d
+  anet node loop nightly-bot "rotate logs"  --every 1d
 
 Interval format: 5m / 2h / 1d (m/h/d suffix required, integer ≥ 1).
 Sub-minute intervals (e.g. 30s) are not accepted — the scheduler tick
@@ -10938,8 +10938,8 @@ Options (feishu, RFC-020 #179):
 
 Examples:
   anet channel add telegram 指挥室 --bot-token 123:ABC --allow <your-numeric-uid>
-  anet channel add feishu  指挥室 --app-id cli_xxx --app-secret yyy --allow ou_zzz
-  anet channel add feishu  指挥室                # 交互式
+  anet channel add feishu                   指挥室 --app-id cli_xxx --app-secret yyy --allow ou_zzz
+  anet channel add feishu                   指挥室                # 交互式
 `);
       return;
     }
@@ -15400,7 +15400,7 @@ async function batchCommand() {
   const sub = args[1];
   if (!sub || sub === "-h" || sub === "--help" || sub.startsWith("-")) {
     console.log(`
-  anet batch <verb> <prefix>   # batch lifecycle ops (issue #55)
+  anet batch <verb> <prefix>                # batch lifecycle ops (issue #55)
 
   Verbs:
     start <prefix>                        re-launch (Phase 1: hint re-run create)
@@ -16336,10 +16336,10 @@ switch (command) {
     // Removed per issue #45. Print migration help and exit non-zero so users
     // notice the breakage instead of silently failing.
     console.error(`[anet] ⚠ 'anet quickstart' 已删除（per #45）。改用现代命令组合:
-  anet hub start          # 起 CommHub Server
-  anet setup              # 装 runtime deps + 选 runtime (wizard)
-  anet register           # 创建账号
-  anet login              # 登录
+  anet hub start                            # 起 CommHub Server
+  anet setup                                # 装 runtime deps + 选 runtime (wizard)
+  anet register                             # 创建账号
+  anet login                                # 登录
   anet node create <name> # 创建 agent
 
 或一键 demo: cd demos/hello-world && docker compose up`);

--- a/agent-network/src/help-column-alignment.test.ts
+++ b/agent-network/src/help-column-alignment.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `anet` 的帮助文本是手写模板字面量 + 手数空格。实测(2026-08-31)：11 段里 4 段
+// **段内**描述起始列不一致 —— 例如 Session 段主列 41，而 `anet session ls` 在 32，差 9 列。
+//
+// 🔴 这条测试钉的是「**段内**一致」，不是「全局一致」：不同段本来就可以有不同列宽
+//    （段内最长命令不同）。我第一次把所有段混在一起数，得出一个看起来很严重但
+//    没有意义的数字 —— 分组错了，判据再对也没用。
+//
+// 判据对着**源码里的帮助模板**，而不是对着运行输出：这样它在 CI 里不需要起进程。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+
+type Row = { section: string; col: number; cmd: string };
+
+function helpRows(src: string): Row[] {
+  const out: Row[] = [];
+  let section = "";
+  for (const raw of src.split("\n")) {
+    const line = raw.replace(/\s+$/, "");
+    if (/^[A-Z][A-Za-z /&]*:$/.test(line.trim())) { section = line.trim(); continue; }
+    const m = /^(  anet [^\s].*?)(\s{2,})(\S.*)$/.exec(line);
+    if (m && section) out.push({ section, col: m[1].length + m[2].length, cmd: m[1].trim() });
+  }
+  return out;
+}
+
+describe("anet 帮助文本的列对齐", () => {
+  const rows = helpRows(CLI);
+
+  it("🔴 取集自检：确实抓到了帮助行（否则下面的断言恒真）", () => {
+    expect(rows.length).toBeGreaterThan(40);
+    expect(new Set(rows.map(r => r.section)).size).toBeGreaterThan(3);
+  });
+
+  it("🔴 每一段内部，描述的起始列必须一致", () => {
+    const bySection = new Map<string, Row[]>();
+    for (const r of rows) {
+      if (!bySection.has(r.section)) bySection.set(r.section, []);
+      bySection.get(r.section)!.push(r);
+    }
+    const offenders: string[] = [];
+    for (const [section, group] of bySection) {
+      const cols = new Set(group.map(r => r.col));
+      if (cols.size > 1) {
+        const counts = [...cols].map(c => `${c}×${group.filter(r => r.col === c).length}`).join(" ");
+        offenders.push(`${section} → ${counts}（例：${group.find(r => r.col !== group[0].col)?.cmd}）`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("描述与命令之间至少留两个空格", () => {
+    for (const r of rows) expect(r.col).toBeGreaterThan(r.cmd.length + 2);
+  });
+});

--- a/tests/test745-agent-network-unit-ci/run.sh
+++ b/tests/test745-agent-network-unit-ci/run.sh
@@ -104,7 +104,7 @@ AGENT_NETWORK_TESTS_FLOOR=15
 }
 
 echo "[L1] witnessed-red: top-level config help must match the implemented parser"
-TARGET='  anet config [path|json]       Show config summary, path, or raw JSON'
+TARGET='  anet config [path|json]      Show config summary, path, or raw JSON'
 MUTATED='  anet config get|set          Inspect or edit config'
 before=$(sha256sum "$ROOT/agent-network/bin/cli.ts" | cut -d' ' -f1)
 python3 - "$ROOT/agent-network/bin/cli.ts" "$TARGET" "$MUTATED" <<'PY'


### PR DESCRIPTION
## 现象

`anet`（无参数）打出的帮助里，**同一段内部**描述的起始列不一致。
实测 `origin/main`（同一把尺子量）：**8 段里 4 段不齐**。

```
Node Management   主列 33，3 行在 32   ← anet info / status / tasks
Session           主列 41，3 行在 32、1 行在 43   ← anet session ls 差 9 列
Setup             主列 32，3 行在 33、1 行在 58
Other             主列 32，1 行在 33   ← anet register
```

`Session` 那一处眼睛都能看出来。其余几处一行一格，但整段读起来是毛的。

## 改法与代价

帮助文本是**手写模板字面量 + 手数空格**。两条路：

- (a) 手工对齐 —— 小，但以后还会漂；
- (b) 改成数据表 + `padDisplayEnd` —— 自维护，但要重构一大段帮助文本，
  而 `cli.ts` 是本仓最热的文件（doc 行号 pin 今天漂了好几次）。

**取 (a) + 一条钉住「段内一致」的测试**：改动只有空格，且以后漂了会红。

按**段内最长命令 + 2 空格**统一重排，所以改了 81 行而不是只改那 10 行偏离的
—— 代价是 diff 大，收益是段内彻底一致、规则可被测试钉住。

## 验证

```
git diff --stat        1 file changed, 81 insertions(+), 81 deletions(-)
git diff -w --stat     （无输出）← 忽略空白后零改动，一个可见字符都没动
构建产物行数           127 → 127
段内不一致（同一把尺子） 4/8 → 0/8
```

🔴 中途发现前后两次测量用了**不同的段头正则**（11 段 vs 8 段），
那不是单变量对照 —— 已用同一把尺子重量改前那份，上面的 4/8 是可比的数。

## 测试

`agent-network/src/help-column-alignment.test.ts` 三条，判据对着**源码模板**
（CI 里不需要起进程）：

1. 🔴 **取集自检**：确实抓到了 >40 行、>3 段 —— 没有这一条，
   哪天帮助换了格式、正则一行都抓不到时，「段内一致」会以**空集恒真**通过；
2. 段内起始列必须一致（失败时打印是哪一段、各列各几行、举一个例子）；
3. 命令与描述之间至少两个空格。

🔴 它钉的是**段内**一致，不是全局一致 —— 不同段本来就可以有不同列宽。
我第一次把所有段混在一起数，得出一个看起来很严重但没有意义的数字：
**分组错了，判据再对也没用。**

## 两向见证

把 `anet session ls` 的空格改回 3 个 ⇒ `2 pass / 1 fail`；还原 ⇒ `3 pass / 0 fail`。

## 门

doc-symbol-pins / mutation-pins / home-path-baseline /
test-file-coverage / test-suite-registration 均 rc=0。