### PR TITLE
ci(mutation-pins): 门再认一种变异锚点 —— 内联 Python 的 source.count(target)

### DIFF
--- a/scripts/check-mutation-pins.py
+++ b/scripts/check-mutation-pins.py
@@ -94,6 +94,51 @@ def collect(root: str):
     return out
 
 
+
+# ── 内联 Python 形态的变异锚点（#1689 实测:sed 形态的取集看不见它）─────────────
+# 形如
+#     TARGET='  anet config [path|json]       Show config summary…'
+#     SRC="$ROOT/server/src/auth.ts"
+#     python3 - "$SRC" "$TARGET" "$MUTATED" <<'__MUT__'
+#         if source.count(target) != 1: raise SystemExit("mutation target count changed")
+# 锚点是**字面量**(不是 BRE),所以判据是 `src.count(target) == 1`,与 sed 那一支不同。
+#
+# 🔴 只判静态可解的:单引号字面量、以及 $'…' 的 ANSI-C 形式。
+#    `TARGET="${arr[1]}"`(shell 变量)与 `TARGET="$X/path.yml"`(目标是文件路径,
+#    语义是"在文件里数路径串")**结构上判不了**,计入 skipped 并说明,不静默丢。
+PY_TARGET = re.compile(
+    r"^TARGET=(?P<q>\$?')(?P<lit>(?:[^'\\]|\\.)*)'\s*$", re.M)
+PY_SRC = re.compile(r"^(?:SRC|MUTANT|FILE)=\"\$ROOT/(?P<file>[^\"]+)\"\s*$", re.M)
+PY_ARG = re.compile(r"python3 - \"\$ROOT/(?P<file>[^\"]+)\"")
+
+
+def ansi_c_unescape(s: str) -> str:
+    return s.replace("\\n", "\n").replace("\\t", "\t").replace("\\'", "'").replace("\\\\", "\\")
+
+
+def collect_inline_python(root: str):
+    """(run.sh, 字面量锚点 or None, 目标文件 or None) —— None 表示结构上判不了。"""
+    out = []
+    for base, _dirs, files in os.walk(os.path.join(root, "tests")):
+        if "run.sh" not in files:
+            continue
+        path = os.path.join(base, "run.sh")
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        if "mutation target count changed" not in text:
+            continue
+        m = PY_TARGET.search(text)
+        if not m:
+            out.append((path, None, None))          # 变量/路径形态 ⇒ 判不了
+            continue
+        lit = m.group("lit")
+        if m.group("q").startswith("$"):
+            lit = ansi_c_unescape(lit)
+        sm = PY_SRC.search(text) or PY_ARG.search(text)
+        out.append((path, lit, sm.group("file") if sm else None))
+    return out
+
+
 def main() -> int:
     pins = collect(ROOT)
     checked = skipped = 0
@@ -112,6 +157,25 @@ def main() -> int:
         checked += 1
         if not rx.search(src):
             dead.append((os.path.relpath(sh, ROOT), target, unescape(pat)))
+    # ── 内联 Python 形态（#1689）：锚点是字面量，判据是 count == 1 ──────────────
+    inline = collect_inline_python(ROOT)
+    inline_checked = inline_skipped = 0
+    for sh, lit, rel in inline:
+        if lit is None or rel is None:
+            inline_skipped += 1
+            continue
+        full = os.path.join(ROOT, rel)
+        if not os.path.isfile(full):
+            inline_skipped += 1
+            continue
+        with open(full, encoding="utf-8", errors="replace") as fh:
+            src = fh.read()
+        inline_checked += 1
+        if src.count(lit) != 1:
+            dead.append((os.path.relpath(sh, ROOT), rel,
+                         f"[inline-python] count={src.count(lit)} (要求 1): {lit[:80]}"))
+    print(f"MUTATION-PIN: 内联 Python 变异 {len(inline)} 条，判定 {inline_checked} 条，"
+          f"跳过 {inline_skipped} 条（TARGET 是 shell 变量或指向文件路径，结构上判不了）")
     print(f"MUTATION-PIN: 扫到 {len(pins)} 条 sed 变异，判定 {checked} 条，跳过 {skipped} 条（非字面量或目标不在仓内）")
     if not dead:
         print("MUTATION-PIN: GREEN —— 每条被判定的变异都还能在目标文件里命中。")
@@ -148,6 +212,22 @@ def selftest() -> int:
     ck("取集扫到 ≥10 条 pin", len(collect(ROOT)) >= 10)
     ck("同名多候选判为歧义(不猜)", resolve_target("src/server.ts") is None)
     ck("唯一候选能解析", resolve_target("agent-network/bin/cli.ts") is not None)
+    # ── #1689：内联 Python 形态的解析自检 ──────────────────────────────
+    # 判据(能不能从 run.sh 里解出锚点)与取集(哪些文件算数)是两层,分开测。
+    for label, sh_text, want in [
+        ("单引号字面量", "mutation target count changed\nTARGET='abc def'\nSRC=\"$ROOT/x/y.ts\"\n", ("abc def", "x/y.ts")),
+        ("ANSI-C 多行",  "mutation target count changed\nTARGET=$'a\\nb'\nSRC=\"$ROOT/p/q.ts\"\n", ("a\nb", "p/q.ts")),
+        ("shell 变量",   "mutation target count changed\nTARGET=\"${arr[1]}\"\n", (None, None)),
+    ]:
+        import tempfile, os as _os
+        d = tempfile.mkdtemp(); _os.makedirs(_os.path.join(d, "tests", "t"), exist_ok=True)
+        with open(_os.path.join(d, "tests", "t", "run.sh"), "w", encoding="utf-8") as fh:
+            fh.write(sh_text)
+        rows = collect_inline_python(d)
+        got = (rows[0][1], rows[0][2]) if rows else (None, None)
+        ck(f"inline: {label} (期望 {want!r} 实得 {got!r})", got == want)
+    # 取集自检:真实仓里必须抓到 >=3 条(否则下面的判定恒真)
+    ck("inline: 真实仓里抓到 >=3 条(否则 collector 空转)", len(collect_inline_python(ROOT)) >= 3)
     print(f"selftest: {ok} ok / {fail} fail")
     return 0 if fail == 0 else 1
 


### PR DESCRIPTION
## 为什么

`#1689` 里我把 `anet` 帮助文本按段重排,CI 红在

    [L1] witnessed-red: top-level config help must match the implemented parser
    mutation target count changed

而**本地跑这道门是 rc=0**。原因:它只认 `tests/*/run.sh` 里
`sed -i 's/PAT/…/' <file>` 形态的 pin,而那条锚点是**内联 Python**:

    TARGET='  anet config [path|json]       Show config summary, path, or raw JSON'
    SRC="$ROOT/agent-network/bin/cli.ts"
    python3 - "$SRC" "$TARGET" "$MUTATED" <<'__MUT__'
        if source.count(target) != 1:
            raise SystemExit("mutation target count changed")

**同一个概念、两种写法,门只认一种。** 它此前报的「90 条全绿」
应读作「**它认识的那 90 条**全绿」。

## 覆盖面(先看全集再定判据)

全仓 5 个 run.sh 用这种写法,形态**并不统一**:

| 文件 | TARGET 形态 | 判 |
|---|---|---|
| test745 | `'…'` 单引号字面量 | ✅ 目标 agent-network/bin/cli.ts |
| test798 | `'…'` 单引号字面量 | ✅ 目标 server/src/auth.ts |
| test725 | `$'…\n…'` ANSI-C 多行 | ✅ 目标 agent-node/src/cli.ts |
| test1183 | `"${network_versions[1]}"` shell 变量 | ❌ 静态解不出 |
| test746 | `"$MUTANT_ROOT/workflows/release.yml"` 文件路径 | ❌ 语义不同 |

⇒ **3 判 2 跳**。跳过的**计数并说明理由**,不静默丢 ——
否则分母又会从「我打算判的」算出来。

🔴 只照 test745 一个样本写规则会漏掉 test725 的 `$'…'` 多行形态,
并在 test1183 上误报。**这是看全 5 个之后量出来的,不是预感。**

## 实现

只加一个 `collect_inline_python()`,`main()` 的判定循环**一行未改** ——
不会把已有的 87 条判坏。判据与 sed 那支不同:锚点是**字面量**,
所以是 `src.count(target) == 1` 而不是正则 search。

新输出多一行:

    MUTATION-PIN: 内联 Python 变异 5 条，判定 3 条，跳过 2 条（TARGET 是 shell 变量或指向文件路径，结构上判不了）

## 验证:判据 / 取集 / 门本身,三层各自见证

**判据 + 取集**(selftest 13 → 17):

    ok  inline: 单引号字面量        期望 ('abc def','x/y.ts')
    ok  inline: ANSI-C 多行         期望 ('a\nb','p/q.ts')
    ok  inline: shell 变量          期望 (None, None) ← 该判不了就得判不了
    ok  inline: 真实仓里抓到 >=3 条  ← 取集自检,防 collector 空转导致判定恒真

**门本身**(两向见证):把 test745 的锚点多加一个空格 —— **这正是 #1689 里真实发生的事**:

    控制生效断言 count = 0
    MUTATION-PIN: RED —— 1 条打不进去了
      🔴 tests/test745-agent-network-unit-ci/run.sh
         [inline-python] count=0 (要求 1): '  anet config [path|json]        Show…'
    rc=1 → 还原 rc=0

**selftest 自己也能红**:关掉 ANSI-C 解转义那一支(`if …startswith("$")` → `if False:`,
带控制生效断言)⇒ `16 ok / 1 fail`;还原 ⇒ `17 ok / 0 fail`。

## 门

doc-symbol-pins / mutation-pins / home-path-baseline 均 rc=0;
`.github/workflows/mutation-pin-integrity.yml` 已同时跑 `--selftest` 与本体,无需改 workflow。