### PR TITLE
ci(published-artifact-drift): paths 补上它自己跑的两个脚本

### DIFF
--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -58,6 +58,12 @@ on:
       - '.github/scripts/check-docs-site-drift.py'
       - 'scripts/verify-published-pins.sh'
       - 'scripts/verify-release-tag.sh'
+      # 🔴 下面两个脚本的**唯一**调用方就是本 workflow，而它们原先不在 paths 里 ——
+      #    改了它们、合进 main，那次 push 不会跑本 workflow，最长空窗到次日 03:17 UTC 的定时跑。
+      #    (另外两个曾被怀疑漏掉的其实有第二入口:check-docs-site-drift.py 已在上面列出;
+      #     check-doc-version-claims.py 由 docs-site-build.yml 在**每个 PR** 上跑。)
+      - '.github/scripts/check-published-build-paths.py'
+      - '.github/scripts/docs-site-drift-notify.sh'
       - '.github/workflows/published-artifact-drift.yml'
 
 jobs:


### PR DESCRIPTION
## 起因

`#1690` 改的是 `scripts/check-mutation-pins.py`，而跑那道门的
`mutation-pin-integrity.yml` **当初故意没加 `paths`**，所以它在那条 PR 上跑了并通过。
顺手问了一句「别人踩没踩」，于是有了这次审计。

## 审计判据

对每个「workflow × 它 run 的 scripts/ 脚本」组合，问：**该脚本在不在这个 workflow 自己的 `paths` 里**。
全仓 27 个 workflow 跑 scripts/ 下脚本，其中 7 个带 `paths` 过滤，共 13 个组合。

## 结果：4 → 3 → 2（每次下调都来自「还有谁调它」）

```
初判                                                    4 条未覆盖
-1  check-docs-site-drift.py 已在本 workflow 的 paths 里（我第一遍读漏）
-1  check-doc-version-claims.py 由 docs-site-build.yml 的
    `pull_request:`（**无 paths 过滤**）在每个 PR 上跑 ⇒ 覆盖比加进这里更充分
= 2  check-published-build-paths.py · docs-site-drift-notify.sh
     两者的**唯一**调用方就是本 workflow
```

## 准确后果（不是「PR 全绿而门坏了」）

本 workflow 的 push 触发是 `branches: [main]`，本来就不在 PR 上跑。所以后果是：

> 改这两个脚本 → 合进 main → **那次 push 不会跑本 workflow**，
> 最长空窗到**次日 03:17 UTC** 的定时跑。

## 改动

`paths` 里加两行，并在 YAML 注释里写明为什么只加 2 条、
以及另外两个"疑似漏掉"的其实有第二入口 —— 否则下一个跑同样审计的人会以为是漏了。

## 验证：前后同一把尺子

用同一段审计代码分别跑 `origin/main` 版本与改后版本：

```
改前未覆盖  check-published-build-paths.py, docs-site-drift-notify.sh, check-doc-version-claims.py
改后未覆盖  check-doc-version-claims.py        ← 有意不加，理由见上
```

门：check-workflow-structure / check-action-pins / check-qa-paths-symmetry 均 rc=0；
YAML 解析通过（验的是**改过的**文件）。