### PR TITLE
ci(gate): #1650 hub 无时区时间戳的裸解析只许减少

### DIFF
--- a/.github/scripts/check-hub-timestamp-ratchet.py
+++ b/.github/scripts/check-hub-timestamp-ratchet.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""直接把 hub 的无时区时间戳喂给 `new Date(` / `Date.parse(` 的地方只许减少。
+
+## 背景
+
+hub 的 SQLite 列走 `datetime('now')` —— **UTC，但不带时区标记**（`2026-08-31 09:12:00`）。
+`new Date(s)` / `Date.parse(s)` 遇到这种串会按**本机时区**解析，误差 = 主机偏移，
+而且**不报错**。#1650 一次点出 5 处，其中一处的后果是：
+
+    TZ=America/*  →  ts 偏晚  →  `fresh = ts >= restartStartedAt` **恒 true**
+                                 「重启后心跳有没有刷新」这道校验被静默放行
+
+五处已全部改为走 `server/src/hub-timestamp.ts` 的 `parseHubTimestamp()`（显式补 `Z`）。
+
+## 🔴 为什么这一类**必须**用扫描门兜，而不是靠测试
+
+`bun test` 把测试进程的时区固定成 UTC。在 UTC 下，「按 UTC 解析」和「按本地解析」
+**得到同一个数** —— 也就是说这一整类缺陷在测试进程里**结构上不可见**。
+#1649 实测：把新模块里补 `Z` 的那一步去掉，**11 条针对性测试全绿**，
+只有变异见证才发现了它。
+
+⇒ 不是「大家忘了写测试」，是「**写了也照样绿**」。
+
+## 判据（两条棘轮）
+
+1. **生产代码里 `new Date(x_at)` / `Date.parse(x_at)` 的处数 ≤ 基线** —— 只许减少。
+2. **`parseHubTimestamp(` 的调用点数 ≥ 下限** —— 不许有人把已有的保护摘掉
+   （把一处改回裸 `new Date` 会同时压低这个数，两条判据从相反方向夹住）。
+
+## 这道门不管什么
+
+不判断某一处**是不是**真缺陷。当前基线里的 4 处逐一核过，**没有一处是 #1650 那一类**：
+
+| 位置 | 为什么安全 |
+|---|---|
+| `agent-node/src/goals/self-loop-tools.ts` `g.updated_at` | 本地 goal store 写的是 `toISOString()`，带 `Z` |
+| `server/src/scheduled-tasks.ts` `spec.run_at` | 来自同文件 `iso(when)`，恒带 `Z` |
+| `server/src/scheduled-tasks.ts` `row.next_run_at` | zod `datetime({ offset: true })`，带偏移 |
+| `server/src/scheduled-tasks.ts` `obj.run_at` | 调用方传的 API 入参，**不是 hub 的 TEXT 列**（另一类问题） |
+
+#1650 当时把这道门排在后面，理由是「10 处命中里 5 处真缺陷 ⇒ 50% 误报，
+一道会产生 50% 误报的门大概率第一周就被关掉」—— **那个判断当时是对的**。
+五处修完后重新量：**生产命中 4 处，这一类的真缺陷 0 处**，误报率 0%。
+它说的「先量再定」，量出来的结论变了。
+
+    python3 .github/scripts/check-hub-timestamp-ratchet.py
+    python3 .github/scripts/check-hub-timestamp-ratchet.py --selftest
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# 🔴 rglob，不是 glob。同仓 check-query-token-ratchet.py 记着的教训：
+#    棘轮的输出是一个**数**，一个写在子目录里的新命中不会把数抬高 ——
+#    它根本不在分母里，打印出来的和真绿逐字相同。
+SRC_DIRS = [
+    Path("server/src"),
+    Path("agent-network/bin"),
+    Path("agent-network/src"),
+    Path("agent-node/src"),
+]
+
+# 2026-08-31 实测基线。要改必须在 PR 里说明是哪一条被消掉/新增了。
+RAW_BASELINE = 4      # 生产代码里裸解析 *_at 的处数
+GUARD_FLOOR = 9       # parseHubTimestamp( 的调用点数
+
+# `new Date(<arg>)` / `Date.parse(<arg>)`，且 <arg> 里出现 `_at`。
+RAW_PARSE = re.compile(r'(?:new\s+Date|Date\.parse)\(\s*([A-Za-z_$][\w$.?\[\]"\']*)')
+AT_FIELD = re.compile(r'_at\b|_at[?\]"\']')
+GUARD = re.compile(r'parseHubTimestamp\s*\(')
+
+
+def analyse(files: dict[str, str]) -> tuple[int, int, list[str]]:
+    """→ (裸解析处数, guard 调用点数, 命中明细)"""
+    raw = guard = 0
+    hits: list[str] = []
+    for name, text in files.items():
+        for lineno, line in enumerate(text.split("\n"), start=1):
+            for m in RAW_PARSE.finditer(line):
+                if AT_FIELD.search(m.group(1)):
+                    raw += 1
+                    hits.append(f"{name}:{lineno}  {line.strip()[:88]}")
+            guard += len(GUARD.findall(line))
+    return raw, guard, hits
+
+
+def read_sources() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for d in SRC_DIRS:
+        if not d.is_dir():
+            continue
+        for p in sorted(d.rglob("*.ts")):
+            if p.name.endswith(".test.ts"):
+                continue
+            out[str(p)] = p.read_text(encoding="utf-8", errors="replace")
+    return out
+
+
+def run() -> int:
+    files = read_sources()
+    if not files:
+        print("::error::no non-test .ts under " + ", ".join(str(d) for d in SRC_DIRS)
+              + " — scope regression, refusing to pass", file=sys.stderr)
+        return 2
+    raw, guard, hits = analyse(files)
+    print(f"scanned {len(files)} file(s); raw *_at parses: {raw} (baseline {RAW_BASELINE}); "
+          f"parseHubTimestamp() call sites: {guard} (floor {GUARD_FLOOR})")
+    for h in hits:
+        print(f"  {h}")
+
+    problems = 0
+    if raw > RAW_BASELINE:
+        print(f"::error::{raw} site(s) hand a *_at value straight to new Date()/Date.parse(), "
+              f"above the baseline of {RAW_BASELINE}. hub's TEXT columns are UTC WITHOUT a zone "
+              f"marker, so those parse as LOCAL time — the error equals the host offset and "
+              f"nothing throws. Route it through parseHubTimestamp() "
+              f"(server/src/hub-timestamp.ts). If the value provably carries a zone, say which "
+              f"line proves it in the PR and raise the baseline. #1650")
+        problems += 1
+    if guard < GUARD_FLOOR:
+        print(f"::error::only {guard} parseHubTimestamp() call site(s), below the floor of "
+              f"{GUARD_FLOOR} — an existing protection was removed. #1650")
+        problems += 1
+
+    if problems:
+        print(f"\n{problems} problem(s).")
+        return 1
+    print("hub-timestamp surface did not grow; existing parseHubTimestamp() guards are intact.")
+    return 0
+
+
+# --- selftest ---------------------------------------------------------------
+# 🔴 两层分开自检：**判据**（给它一行，看它报不报）和**取集**（造一棵目录树，
+#    看「该收的收进来了没有」）。同仓实测过：把 rglob 退回 glob，取集自检红，
+#    而判据自检 18/18 仍然全绿 —— 它们测的不是同一件事。
+def selftest() -> int:
+    ok = 0
+    fail = 0
+
+    def ck(name: str, cond: bool) -> None:
+        nonlocal ok, fail
+        if cond:
+            ok += 1
+        else:
+            fail += 1
+            print(f"  selftest FAIL: {name}")
+
+    # 夹具用字符串拼接，避免这个文件被自己的正则扫到。
+    ND = "new " + "Date("
+    DP = "Date." + "parse("
+    PH = "parseHubTimestamp" + "("
+
+    def one(line: str) -> tuple[int, int]:
+        r, g, _ = analyse({"x.ts": line})
+        return r, g
+
+    # ── 判据层 ──
+    ck("new Date(row.created_at) 命中", one(f"const a = {ND}row.created_at);")[0] == 1)
+    ck("Date.parse(g.updated_at) 命中", one(f"const a = {DP}g.updated_at);")[0] == 1)
+    ck("可选链 row?.last_seen_at 命中", one(f"const a = {ND}row?.last_seen_at);")[0] == 1)
+    ck("方括号 row['expires_at'] 命中", one(f"const a = {ND}row['expires_at']);")[0] == 1)
+    ck("同一行两处各算一次", one(f"{ND}a.created_at); {ND}b.updated_at);")[0] == 2)
+    # 反例：不含 _at 的参数不该命中，否则这道门会把所有 new Date() 都扫进来
+    ck("new Date(now) 不命中", one(f"const a = {ND}now);")[0] == 0)
+    ck("new Date(ms + 1000) 不命中", one(f"const a = {ND}ms);")[0] == 0)
+    ck("裸 new Date() 不命中", one(f"const a = {ND});")[0] == 0)
+    # 🔴 朝**正确**方向变异也要验：走了 guard 的写法不该被算成裸解析
+    ck("parseHubTimestamp(row.created_at) 不算裸解析",
+       one(f"const a = {PH}row.created_at);")[0] == 0)
+    ck("parseHubTimestamp 计入 guard 数", one(f"const a = {PH}row.created_at);")[1] == 1)
+    ck("裸解析不计入 guard 数", one(f"const a = {ND}row.created_at);")[1] == 0)
+    # `_at` 必须是词尾/边界，`_atom` 不算
+    ck("_atom 不误命中", one(f"const a = {ND}cfg._atom);")[0] == 0)
+
+    # ── 取集层 ──（判据全对也可能扫不到文件）
+    import tempfile, os
+    with tempfile.TemporaryDirectory() as td:
+        cwd = os.getcwd()
+        try:
+            os.chdir(td)
+            for rel in [
+                "server/src/a.ts",              # 顶层
+                "server/src/deep/nested/b.ts",  # 🔴 子目录 —— glob 会漏，rglob 不漏
+                "agent-node/src/c.ts",
+                "server/src/d.test.ts",         # 测试，应排除
+                "server/src/e.md",              # 非 .ts，应排除
+                "docs/f.ts",                    # 不在 SRC_DIRS，应排除
+            ]:
+                p = Path(rel)
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(f"const a = {ND}row.created_at);\n", encoding="utf-8")
+            got = read_sources()
+            ck("取集：收了顶层文件", "server/src/a.ts" in got)
+            ck("取集：收了子目录文件（rglob 而非 glob）", "server/src/deep/nested/b.ts" in got)
+            ck("取集：收了第二个根目录", "agent-node/src/c.ts" in got)
+            ck("取集：排除 .test.ts", "server/src/d.test.ts" not in got)
+            ck("取集：排除非 .ts", "server/src/e.md" not in got)
+            ck("取集：排除 SRC_DIRS 之外", "docs/f.ts" not in got)
+            ck("取集：分母正好 3", len(got) == 3)
+            raw, _, _ = analyse(got)
+            ck("取集+判据：3 个文件各 1 处 = 3", raw == 3)
+        finally:
+            os.chdir(cwd)
+
+    print(f"selftest: {ok}/{ok + fail} ok")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
+    sys.exit(run())

--- a/.github/workflows/hub-timestamp-ratchet.yml
+++ b/.github/workflows/hub-timestamp-ratchet.yml
@@ -1,0 +1,37 @@
+# 直接把 hub 的无时区时间戳喂给 `new Date(` / `Date.parse(` 的地方只许减少。
+#
+# hub 的 SQLite 列走 `datetime('now')` —— **UTC，但不带时区标记**。`new Date(s)` 遇到
+# 这种串会按**本机时区**解析，误差 = 主机偏移，而且**不报错**。#1650 一次点出 5 处，
+# 其中一处让「重启后心跳有没有刷新」这道校验在西半球主机上恒 true（静默放行）。
+#
+# 🔴 为什么必须是扫描门，而不是测试：**`bun test` 把测试进程时区固定成 UTC**，
+#    在 UTC 下「按 UTC 解析」和「按本地解析」得到同一个数 —— 这一整类缺陷在测试进程里
+#    **结构上不可见**。#1649 实测：拿掉补 `Z` 那一步，11 条针对性测试全绿。
+#    不是「大家忘了写测试」，是「写了也照样绿」。
+#
+# 这道门不改任何行为，也不判断某一处是不是真缺陷（当前基线里的 4 处逐一核过，
+# 没有一处属于这一类）—— 只保证今天的数字是上限，不是起点。
+#
+# 不加 paths 过滤：它守的是四个源码目录的一个不变量，秒级脚本没有省的必要。
+
+name: lint (hub-timestamp ratchet)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ratchet:
+    name: hub-timestamp-ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # selftest 先跑，而且它分**两层**：
+      #   判据层 —— 给它一行，看它报不报（含反例：`new Date(now)` 不许命中，
+      #             否则这道门会把所有 new Date() 都扫进来）
+      #   取集层 —— 造一棵目录树，看「该收的收进来了没有」
+      # 同仓实测过：把 rglob 退回 glob，取集自检红而判据自检全绿 ——
+      # 两层测的不是同一件事，缺一层就有一整类盲区。
+      - run: python3 .github/scripts/check-hub-timestamp-ratchet.py --selftest
+      - run: python3 .github/scripts/check-hub-timestamp-ratchet.py


### PR DESCRIPTION
关联 #1650（那五处已全部修完；本 PR 只装一道防止复发的棘轮）。

## #1650 里那条建议当时被否，**理由的前提现在变了**

原文写得很清楚：

> **先量再定**：现在是 10 处命中、5 处真缺陷、1 处安全、1 处未核、3 处在测试里 ——
> 一道会产生 50% 误报的门大概率第一周就被关掉，所以这条建议排在 1、2 之后。

**那个判断当时完全正确。** 五处真缺陷此后全部改走 `parseHubTimestamp`
（#1687 + 其余）。于是按它说的「先量再定」重新量：

```
生产代码命中 4 处   |   这一类的真缺陷 0 处   ⇒  误报率 50% → 0%
```

四处**逐一追了值的来源**（问「这个值从哪来」，不是「谁调用它」）：

| 命中 | 为什么安全 |
|---|---|
| `self-loop-tools.ts` `g.updated_at` | 本地 goal store，`store.ts` 写的是 `toISOString()`，**带 `Z`** |
| `scheduled-tasks.ts` `spec.run_at` | 来自同文件 `iso(when)`，恒带 `Z` |
| `scheduled-tasks.ts` `row.next_run_at` | zod `datetime({ offset: true })`（#1650 已核） |
| `scheduled-tasks.ts` `obj.run_at` | **调用方传的 API 入参，不是 hub 的 TEXT 列** |

最后一条我**刻意不混进 #1650**：同一个正则命中，但机制不同（入参格式校验 vs
hub 列格式）。混着报会把两件事的修法搅在一起。

## 为什么这一类**必须**用扫描门兜，而不是补测试

#1650 里的关键观察：

> **`bun test` 把测试进程时区固定成 UTC。** 在 UTC 下「按 UTC 解析」和「按本地解析」
> 得到同一个数 —— 这一整类缺陷在测试进程里**结构上不可见**。
> #1649 实测：拿掉补 `Z` 那一步，**11 条针对性测试全绿**，只有变异见证发现了它。

⇒ **不是「大家忘了写测试」，是「写了也照样绿」。**

## 三份证据

### ① selftest 20/20 —— 判据层 12 + 取集层 8，**分开**自检

同仓 `check-query-token-ratchet.py` 记着的教训：把 `rglob` 退回 `glob`，
**取集自检红而判据自检全绿** —— 两层测的不是同一件事。

判据层含**反例**（`new Date(now)` 不许命中，否则这门会把所有 `new Date()` 都扫进来、
`_atom` 不许误命中）和**朝正确方向的变异**（`parseHubTimestamp(row.created_at)`
不算裸解析、且计入 guard 数）。
取集层造一棵目录树，钉住：子目录收得到（`rglob`）、排除 `.test.ts` / 非 `.ts` /
`SRC_DIRS` 之外，并核分母恰好为 3。

### ② `origin/main`（已修复的树）—— 绿

```
scanned 355 file(s); raw *_at parses: 4 (baseline 4); parseHubTimestamp() call sites: 9 (floor 9)
hub-timestamp surface did not grow; existing parseHubTimestamp() guards are intact.   rc=0
```

### ③ 🔴 一份**真实的、修复前的**代码树 —— 红，且红在正确的位置

本仓某特性分支落后于这五处修复。把门喂给它：

```
scanned 309 file(s); raw *_at parses: 10 (baseline 4); parseHubTimestamp() call sites: 0 (floor 9)
  server/src/external-schedule-edits.ts:122/123/124/125
  server/src/server.ts:971    new Date(license.expires_at)
  agent-network/bin/cli.ts:8573  Date.parse(node.last_seen_at || node.updated_at || "")
  …
2 problem(s).   rc=1
```

**逐条点名了 #1650 当初点名的那些位置。** 夹具是我写的，这份代码不是 ——
这比任何自造正控都有说服力。

## 这道门不管什么

不改任何行为，也不判断某一处是不是真缺陷。**两条棘轮从相反方向夹**：

- 裸解析处数 **≤ 4**（只许减少）
- `parseHubTimestamp(` 调用点数 **≥ 9**（不许有人把已有保护摘掉）

把一处改回裸 `new Date` 会**同时**越过两条。

## 仓里的门

结构照抄 `check-query-token-ratchet.py` / `query-token-ratchet.yml`（一门一 workflow，
先跑 `--selftest` 再跑本体）。提交前跑过的八道，全部 rc=0：

```
check-workflow-structure       33 workflows / 60 jobs, problems=0
check-action-pins              86 refs / 33 files, 全部 pin 到 SHA
check-home-path-baseline       no file is above its baseline
check-no-memory-slugs          no internal memory-slug references
check-no-escaped-comments      43 python file(s), 0 escaped comment(s)
check-public-script-safety     0 findings across 6 script(s)
check-test-suite-registration  no new unregistered test suite
check-qa-trigger-coverage      all 67 CI-executed test dirs can re-trigger qa.yml
```
