### PR TITLE
fix(daemon): #1635 整条 Fix 都要能 bash -n 过 —— 上一版把说明拼进了命令

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -233,8 +233,13 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
         //   一条跑不通的修复建议比没有建议更糟：它让人以为自己已经修过了。
         //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
         //   可能解析到另一个（或找不到）二进制。
-        //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
-        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null Or keep the pin in a file you own (no /etc, no sudo): ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\" (put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart)",
+        //   🔴 说明文字走 `#` 注释行、命令各占一行 —— **整条 Fix 都要能 bash -n 过**。
+        //   2026-08-31 的教训：我曾把说明直接拼在命令后面（`(no /etc, no sudo)` 里的
+        //   括号不配对），整条从 rc=0 变成 rc=2；而当时那条 bash -n 测试只切了我新加的
+        //   那半句去验，**结构上看不见自己要防的缺陷**。现在验的是整条 Fix 尾巴。
+        //   同 CLI 侧 daemon-capability-display.ts 的结论：说明和命令拼成一句之后，
+        //   没有一条能通过 bash -n。
+        : "\n# needs root:\nANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null\n# or keep the pin in a file you own (no /etc, no sudo) — put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart:\nANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\"",
     );
   }
   if (!pin) {
@@ -252,8 +257,13 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
         //   一条跑不通的修复建议比没有建议更糟：它让人以为自己已经修过了。
         //   realpath 先在 sudo **之前**算好并存进变量 —— 否则 root 环境里 `command -v anet`
         //   可能解析到另一个（或找不到）二进制。
-        //   本行 shell 已用 `bash -n`（rc=0）+ 实跑非 sudo 段验证过。
-        : "ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null (needs root). No-root alternative to try first: only `anet daemon init|start|up` auto-declares the pin, so a daemon started via `anet node start` / pm2 / systemd never receives it — restart it with `anet daemon start <name>`. Or keep the pin in a file you own (no /etc, no sudo): ANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\" (put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart)",
+        //   🔴 说明文字走 `#` 注释行、命令各占一行 —— **整条 Fix 都要能 bash -n 过**。
+        //   2026-08-31 的教训：我曾把说明直接拼在命令后面（`(no /etc, no sudo)` 里的
+        //   括号不配对），整条从 rc=0 变成 rc=2；而当时那条 bash -n 测试只切了我新加的
+        //   那半句去验，**结构上看不见自己要防的缺陷**。现在验的是整条 Fix 尾巴。
+        //   同 CLI 侧 daemon-capability-display.ts 的结论：说明和命令拼成一句之后，
+        //   没有一条能通过 bash -n。
+        : "\n# needs root:\nANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && sudo install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" | sudo tee /etc/anet-daemon/path.conf >/dev/null\n# no-root alternative to try first: only `anet daemon init|start|up` auto-declares the pin, so a daemon started via `anet node start` / pm2 / systemd never receives it. Restart it with:\n# anet daemon start <name>\n\n# or keep the pin in a file you own (no /etc, no sudo) — put ANET_DAEMON_PATH_CONF in the daemon environment so it survives a restart:\nANET_BIN_REAL=\"$(node -e 'console.log(require(\"fs\").realpathSync(process.argv[1]))' \"$(command -v anet)\")\" && mkdir -p \"$HOME/.anet\" && printf 'ANET_BIN_ABS=%s\\n' \"$ANET_BIN_REAL\" > \"$HOME/.anet/path.conf\" && export ANET_DAEMON_PATH_CONF=\"$HOME/.anet/path.conf\"",
     );
   }
   // ① absolute — cross-platform. Was `startsWith("/")` which returned

--- a/agent-node/src/runtime/daemon-bin-error-help.test.ts
+++ b/agent-node/src/runtime/daemon-bin-error-help.test.ts
@@ -33,14 +33,37 @@ describe("#1635 anet_bin_source 的报错", () => {
     expect(msg).toContain("no /etc, no sudo");
   });
 
-  it("🔴 消息里那条 shell 必须真能跑 —— 验的是消息本身,不是源码里的字符串", () => {
+  // 🔴 2026-08-31:这一条原本切的是「no sudo): … (put ANET_DAEMON_PATH_CONF」之间那一小段,
+  //    也就是**只验我新加的那半句**。于是当我把说明文字直接拼在命令后面之后
+  //    (`(no /etc, no sudo)` 里的括号不配对),**整条 Fix 从 bash -n rc=0 变成 rc=2,
+  //    而这条测试照样绿** —— 它的提取形状结构上观察不到自己要防的缺陷。
+  //    用户复制的是整条 `Fix:` 尾巴,所以判据必须是整条。
+  it("🔴 整条 Fix 都必须是合法 shell —— 用户复制的是整条,不是其中一段", () => {
     const msg = messageFor({ ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
-    const m = /no sudo\): ([\s\S]*?) \(put ANET_DAEMON_PATH_CONF/.exec(msg);
-    expect(m).not.toBeNull();
-    const cmd = m![1];
-    expect(cmd.length).toBeGreaterThan(80);
+    const i = msg.indexOf("Fix: ");
+    expect(i).toBeGreaterThan(-1);
+    const whole = msg.slice(i + "Fix: ".length);
+    expect(whole.length).toBeGreaterThan(200);
     // bash -n:只查语法,不执行
+    expect(() => execFileSync("bash", ["-n", "-c", whole], { stdio: "pipe" })).not.toThrow();
+  });
+
+  // 保留原来的子串断言:它管的是**免 root 那条命令本身**能不能单独粘贴跑。
+  // 两层各管各的 —— 整条合法 ≠ 其中那条免 root 的命令还在。
+  it("免 root 那条命令单独拿出来也必须能跑", () => {
+    const msg = messageFor({ ANET_DAEMON_PATH_CONF: "/nonexistent-xyz-1635" });
+    const m = /so it survives a restart:\n([\s\S]*)$/.exec(msg);
+    expect(m).not.toBeNull();
+    const cmd = m![1].trim();
+    expect(cmd.length).toBeGreaterThan(80);
+    expect(cmd).toContain("ANET_DAEMON_PATH_CONF=");
     expect(() => execFileSync("bash", ["-n", "-c", cmd], { stdio: "pipe" })).not.toThrow();
+  });
+
+  // 🔴 正控:证明上面那条整条断言真的能红。把一段不配对的括号塞进去,必须被 bash -n 拒。
+  it("正控 —— 括号不配对的说明文字拼进命令后,bash -n 必须拒", () => {
+    const bad = 'echo ok (no /etc, no sudo): echo more';
+    expect(() => execFileSync("bash", ["-n", "-c", bad], { stdio: "pipe" })).toThrow();
   });
 
   it("另一条 reason(设了 ANET_BIN_ABS 但没开 ALLOW_ENV_BIN)也给同一条免 root 路", () => {


### PR DESCRIPTION
## 我自己引入的回归

#1682 里我把免 root 那条路**追加在命令后面**：

    … | sudo tee /etc/anet-daemon/path.conf >/dev/null Or keep the pin in a file
    you own (no /etc, no sudo): ANET_BIN_REAL=…

`(no /etc, no sudo)` 里的括号不配对 ⇒ **整条 Fix 从 bash -n rc=0 变成 rc=2**。
A/B 对照过（同一把量具）：上一版 688692c9 第一条 rc=0，我那版 rc=2。

这正是 #1521 修过的同一个形状，而它的教训就写在隔壁包里 ——
`agent-network/src/daemon-capability-display.ts`：「分成两格而不是拼成一句，
是因为拼起来之后**没有一条能通过 bash -n**」。

## 🔴 更严重的一半：我为它写的测试**结构上看不见它**

daemon-bin-error-help.test.ts 里那条 bash -n 断言（也是 #1682 我写的）切的是

    /no sudo\): ([\s\S]*?) \(put ANET_DAEMON_PATH_CONF/

也就是**只验我新加的那半句**，从没验过用户真正会复制的那整条 `Fix:`。
所以整条坏掉之后，这条测试照样绿。**一条看不见自己要防的缺陷的回归测试，
比没有测试更糟：它把「已经守住了」的错觉留了下来。**

## 改法

两处 reason 的 fix 串改成**多行**：说明走 `#` 注释行、命令各占一行。
于是整条既是合法 shell、又整条可粘贴。

换行是安全的，查过不是假设：`probeAnetBinReadiness` 的 `detail` 只进
`deps.log(...)` 一次日志调用，**不上报 hub**（原文带真实机器路径，按设计不上报，
见 daemon-create-capability.ts:62）。

顺带修掉那两句已经变假的注释（「本行 shell 已用 bash -n（rc=0）验证过」——
对它现在标注的那行不成立），把这次的教训写进去。

## 测试改成三层，各管各的

1. **整条 `Fix:` 尾巴** bash -n —— 用户复制的是整条
2. **免 root 那条命令单独** bash -n + 含 `ANET_DAEMON_PATH_CONF=`
   —— 整条合法 ≠ 那条命令还在（有人把它整段删掉，整条仍然合法）
3. **正控**：括号不配对的串必须被 bash -n 拒，证明前两条不是恒绿

两向见证（变异覆盖两处 reason，只改一处的红说明不了问题）：

    把命令改回「拼成一句」的旧形状  → rc=1  4 pass / 2 fail
       红的是：🔴 整条 Fix 都必须是合法 shell
    还原                            → rc=0  6 pass / 0 fail

**同一个变异，老断言是绿的。** 判据一样、提取形状不同，能不能看见缺陷就不同。

验证：整条 bash -n 两条都 rc=0；agent-node/src/runtime 全量
**1125 pass / 0 fail**（81 文件）。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>