### PR TITLE
[control][勿合] 当前 main 过不过 Windows Codex smoke —— #1695 的单变量对照

### DIFF
--- a/agent-node/src/runtime/opencode-acp/child-env.ts
+++ b/agent-node/src/runtime/opencode-acp/child-env.ts
@@ -1334,3 +1334,7 @@ export function buildOpencodeChildEnv(opts: BuildOpencodeChildEnvOptions): NodeJ
     throw error;
   }
 }
+
+// ci-control(临时): 本行只为触发 QA 的 agent-node/** paths 过滤,用于回答
+// 「当前 main 本身能不能过 Windows Codex co-presence native smoke」。
+// 这条分支/PR 是一次性对照,读到结论后即关闭删除。


### PR DESCRIPTION
**这是一次性对照实验，读到结论即关闭，请勿合并。**

#1695 上 `Windows Codex co-presence native smoke` 连红两次（失败签名逐字相同：`PTY failed (1): node start windows-picker` / `TUI second-client health failed`），而今天 11 条其他 PR 上这条 job 全绿。

但那 11 条的 base 都更早。main 自己从 **07:58:33Z** 起就没再跑过这条 job（之后只进了两个 CI-only 提交：#1694 的门脚本、#1696 的 workflow）。所以「只有我的 PR 红」这个统计**分不开**两件事：

1. 是 #1695 的代码改动（`create-node-daemon.ts` 的两条 `Fix:` 串改成多行）；
2. 还是当前 main 本身。

本分支**只加了一段注释**（用于命中 QA 的 `agent-node/**` paths 过滤），不含任何行为改动。

- 这条 job **绿** ⇒ 当前 main 没问题，嫌疑落回 #1695 的改动；
- 这条 job **红** ⇒ 与 #1695 无关，是 main 上已有的问题。

顺带说明我为什么不再重跑 #1695：同一签名连红两次，第三次的信息量接近零，而重跑会把失败记录从统计里抹掉。