### PR TITLE
feat(cli): #1698 anet node edit --runtime —— 产品给出的修法，现在有命令可以执行

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9275,6 +9275,79 @@ async function verifyNodeRestarted(
 // PHASE 1 (prepare) is fully rollback-safe: copy-not-move + rename.lock +
 // commhub prepared rename_txn row, old node untouched. PHASE 2 (commit) is the
 // non-rollbackable point: commhub routing switch → restart agent → delete old.
+// #1698 —— 改一个已存在节点的 runtime。
+//
+// 在此之前 `anet node` 有十个子命令，没有一个能改 runtime：想换只能手改
+// `<project>/.anet/nodes/<name>/config.json` 或删掉重建。而这不是假设的场景 ——
+// `grok-build-cli` 在 Ubuntu 24.04+ 上撞 uid_map 墙时，**产品自己的预检**
+// (agent-node/src/runtime/grok-build-cli.ts) 给出的首选修法就是
+// 「改用 grok-build-acp runtime」。产品给出的修复动作，产品自己没有命令去做。
+//
+// 🔴 校验走 `normalizeRuntimeStrict`，**不在这里写第四份白名单**。
+//    同一个 runtime 全集现在已经有四处（hub 的 create-node-validate.ts、
+//    本文件用的 normalize-runtime.ts、agent-node 的 VALID_RUNTIMES、
+//    桌面端的 CreateNodeWizardScreen.tsx —— 后者今天才补齐第 7 个）。
+//    再抄一份就是给下一次「四处不一致」预定位置。
+//
+// 🔴 空值不当默认：`normalizeRuntimeStrict` 对空串返回 DEFAULT_RUNTIME，
+//    那是给「配置里没写」用的语义。用户显式敲 `--runtime ""` 是打错了，
+//    不该被悄悄解释成 claude-agent-sdk —— 所以这里先自己挡掉空值。
+async function nodeEditCommand() {
+  const ref = args[1];
+  const flagIdx = args.indexOf("--runtime");
+  const raw = flagIdx >= 0 ? args[flagIdx + 1] : undefined;
+  if (!ref || flagIdx < 0) {
+    console.log(`
+anet node edit <node-id|node-name> --runtime <id>
+
+  Change an existing node's runtime. Supported ids:
+    ${SUPPORTED_RUNTIME_NAMES.join(", ")}
+
+  Note: the change is written to the node's config; a running node keeps its
+  current runtime until it is restarted (anet node restart <name>).
+`);
+    return;
+  }
+  if (raw === undefined || raw.trim() === "" || raw.startsWith("--")) {
+    console.error(`--runtime needs a value. Supported: ${SUPPORTED_RUNTIME_NAMES.join(", ")}`);
+    process.exit(1);
+  }
+  const resolved = resolveNodeRef(ref);
+  if (!resolved) {
+    console.error(nodeNotFound(ref));
+    process.exit(1);
+  }
+  const profile = loadProfile(resolved.id);
+  if (!profile) {
+    console.error(`Node "${resolved.id}" has no readable config.json — nothing to edit.`);
+    process.exit(1);
+  }
+  let next: RuntimeName;
+  try {
+    next = normalizeRuntimeStrict(raw);
+  } catch (e: any) {
+    console.error(String(e?.message || e));
+    process.exit(1);
+  }
+  const current = normalizeRuntime(profile);
+  if (current === next) {
+    console.log(`${resolved.id} is already on runtime ${next} — nothing to change.`);
+    return;
+  }
+  (profile as any).runtime = next;
+  saveProfile(resolved.id, profile);
+  console.log(`${resolved.id}: runtime ${current} -> ${next}`);
+  // 🔴 说清「什么时候生效」。同 `anet goal edit` 的先例:改配置不等于改运行中的进程。
+  const running = findNodeStopCandidates(resolved.id);
+  if (running === null) {
+    console.log(`  (could not read the process table — if ${resolved.id} is running, restart it: anet node restart ${resolved.id})`);
+  } else if (running.length > 0) {
+    console.log(`  ${resolved.id} is running on the old runtime. Apply it with: anet node restart ${resolved.id}`);
+  } else {
+    console.log(`  It is not running; the new runtime applies on: anet node start ${resolved.id}`);
+  }
+}
+
 async function renameCommand() {
   const fromRef = args[1];
   const newName = args[2];
@@ -16271,7 +16344,7 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
         await nodeLoopCommand();
         process.exit(0);
       } else {
-        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
+        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|edit|loop|migrate-token-to-envref> [name]`);
       }
       break;
     default:
@@ -16297,6 +16370,7 @@ switch (command) {
       case "resume": args.splice(0, 1); await resumeCommand(); break;
       case "delete": args.splice(0, 1); await deleteCommand(); break;
       case "rename": args.splice(0, 1); await renameCommand(); break;
+      case "edit": args.splice(0, 1); await nodeEditCommand(); break;
       case "loop": args.splice(0, 1); await nodeLoopCommand(); break;
       case "ls": case "list": await lsCommand(); break;
       case "restart": {
@@ -16320,7 +16394,7 @@ switch (command) {
             if (suggestion) console.log(`Unknown node subcommand "${sub}". Did you mean: anet node ${suggestion}?`);
           }
         }
-        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
+        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|edit|loop|migrate-token-to-envref> [name]`);
         break;
       }
     }

--- a/agent-network/src/node-edit-runtime.test.ts
+++ b/agent-network/src/node-edit-runtime.test.ts
@@ -1,0 +1,84 @@
+// #1698 —— `anet node edit <node> --runtime <id>` 的契约。
+//
+// 这些断言扫的是 cli.ts 的源码，因为 nodeEditCommand 读 argv / 写盘 / 探进程表，
+// 不是纯函数。**它们管的是接线与设计决定**，不是行为：
+//   · 校验必须走 normalizeRuntimeStrict —— 不许在这里出现第四份 runtime 白名单
+//   · 空值必须先被挡掉 —— normalizeRuntimeStrict 对空串返回 DEFAULT_RUNTIME，
+//     那是「配置里没写」的语义；用户显式敲 `--runtime ""` 是打错了，
+//     不该被悄悄解释成 claude-agent-sdk（兜底不许指向「好」的那一侧）
+//   · 必须说清何时生效 —— 改配置不等于改运行中的进程
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { SUPPORTED_RUNTIME_NAMES, normalizeRuntimeStrict } from "./normalize-runtime.js";
+
+const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8");
+const body = (() => {
+  const i = cli.indexOf("async function nodeEditCommand()");
+  expect(i).toBeGreaterThan(-1);
+  const j = cli.indexOf("\nasync function ", i + 10);
+  return cli.slice(i, j > 0 ? j : undefined);
+})();
+
+describe("#1698 anet node edit —— 接线", () => {
+  test("挂进了 node 的分发表", () => {
+    expect(cli).toContain('case "edit": args.splice(0, 1); await nodeEditCommand(); break;');
+  });
+  test("两条用法行都列了 edit（同一串出现两次，漏一处就不一致）", () => {
+    const m = cli.match(/anet node <create\|start\|stop\|restart\|resume\|delete\|ls\|rename\|edit\|loop\|migrate-token-to-envref>/g);
+    expect(m?.length).toBe(2);
+  });
+  test("用现成件解析节点与读写配置，不自己拼路径", () => {
+    for (const helper of ["resolveNodeRef(", "loadProfile(", "saveProfile(", "nodeNotFound("]) {
+      expect(body).toContain(helper);
+    }
+    // 判据是「有没有自己拼路径」，不是「有没有出现 config.json 这个词」——
+    // 报错文案里正当地提到它（"has no readable config.json"）。
+    expect(body).not.toContain(".anet/nodes");
+    expect(body).not.toContain("nodesDir(");
+  });
+});
+
+describe("#1698 校验判据只有一份", () => {
+  test("走 normalizeRuntimeStrict", () => {
+    expect(body).toContain("normalizeRuntimeStrict(");
+  });
+  // 🔴 本仓同一个 runtime 全集已经有四处（hub / CLI / agent-node / 桌面端）。
+  //    这条断言防的是「第五份」：任何 runtime id 字面量出现在这个函数体里，
+  //    都说明有人开始在这里手写名单。
+  test("函数体里没有硬编码的 runtime id", () => {
+    for (const id of SUPPORTED_RUNTIME_NAMES) {
+      expect(body.includes(`"${id}"`)).toBe(false);
+    }
+  });
+  test("supported 列表从 SUPPORTED_RUNTIME_NAMES 渲染", () => {
+    expect(body).toContain("SUPPORTED_RUNTIME_NAMES.join(");
+  });
+});
+
+describe("#1698 兜底方向", () => {
+  // normalizeRuntimeStrict("") === DEFAULT_RUNTIME —— 先把这个前提钉住，
+  // 否则下面那条「必须先挡空值」的断言会失去理由。
+  test("前提：normalizeRuntimeStrict 对空串返回默认 runtime（不抛）", () => {
+    expect(normalizeRuntimeStrict("")).toBe("claude-agent-sdk");
+  });
+  test("所以 nodeEditCommand 必须在调用前自己挡掉空值", () => {
+    expect(body).toContain('raw.trim() === ""');
+    expect(body).toContain('raw.startsWith("--")');
+  });
+});
+
+describe("#1698 说清何时生效", () => {
+  test("三种现实各有一句话：在跑 / 没在跑 / 读不到进程表", () => {
+    expect(body).toContain("findNodeStopCandidates(");
+    expect(body).toContain("running === null");          // 读不到进程表
+    expect(body).toContain("anet node restart ");        // 在跑
+    expect(body).toContain("anet node start ");          // 没在跑
+  });
+  test("同值是 no-op，不重写配置", () => {
+    expect(body).toContain("current === next");
+    // 切到那一支的 `return;` 为止 —— 用 indexOf("}") 会切在
+    // `${resolved.id}` 的模板闭合括号上（第一版就是这么错的）。
+    const noop = body.slice(body.indexOf("current === next"));
+    expect(noop.slice(0, noop.indexOf("return;"))).toContain("nothing to change");
+  });
+});

--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -114,6 +114,7 @@ See [Token model](/en/concepts/tokens) for token types, scopes, and compatibilit
 | `anet node resume <name> [--session <id>]` | Resume the saved or specified session |
 | `anet node delete <name> --force` | Delete local node configuration |
 | `anet node rename <ref> <new>` | Rename a node already registered with the Hub |
+| `anet node edit <ref> --runtime <id>` | Change an existing node's runtime; **takes effect on restart** |
 | `anet node ls` | List local nodes and network state |
 | `anet info <name>` | Show node configuration, process, and recent tasks |
 | `anet logs <name> [--follow]` | Read or follow node logs |

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -114,6 +114,7 @@ Token 类型、作用域与兼容规则见 [Token 体系](/concepts/tokens)。
 | `anet node resume <name> [--session <id>]` | 使用保存的会话或指定会话恢复 |
 | `anet node delete <name> --force` | 删除本地节点配置 |
 | `anet node rename <ref> <new>` | 重命名已在 Hub 注册的节点 |
+| `anet node edit <ref> --runtime <id>` | 改已存在节点的 runtime；**要重启才生效** |
 | `anet node ls` | 列出本地节点及网络状态 |
 | `anet info <name>` | 显示节点配置、进程和近期任务 |
 | `anet logs <name> [--follow]` | 查看或追踪节点日志 |


### PR DESCRIPTION
`anet node` 原有十个子命令（create|start|stop|restart|resume|delete|ls|rename|
loop|migrate-token-to-envref），**没有一个能改已存在节点的 runtime**。想换只能
手改 `<project>/.anet/nodes/<name>/config.json` 或删掉重建。
而 /goal 要的是「傻瓜式监控/创建/**编辑**/删除」——「编辑」这一格是空的。

这不是假想场景。今天节点 `A站Grok` 报：

    grok CLI exited with code 1: unshare: write failed /proc/self/uid_map: Operation not permitted

这是 grok-build-cli 在 Ubuntu 24.04+ 上的已知墙。而**产品自己的预检**
（agent-node/src/runtime/grok-build-cli.ts 的 assertUnprivilegedUserNsUsable）
给出的首选修法就是「改用 grok-build-acp runtime」——
**产品给出的修复动作，产品自己没有命令去做**，用户下一步只能打开 JSON 编辑器。

## 两个刻意的决定，都做成了会红的断言

**① 校验走 normalizeRuntimeStrict，不在这里写第四份白名单。**
同一个 runtime 全集已经有四处：hub 的 create-node-validate.ts、CLI 的
normalize-runtime.ts、agent-node 的 VALID_RUNTIMES、桌面端的
CreateNodeWizardScreen.tsx（后者今天才补齐第 7 个，见 app#223）。
断言：函数体里不许出现**任何** runtime id 字面量；supported 列表必须由
SUPPORTED_RUNTIME_NAMES 渲染。

**② 空值先自己挡掉。**
`normalizeRuntimeStrict("")` 返回 DEFAULT_RUNTIME（claude-agent-sdk）——
那是「配置里没写」的语义。用户显式敲 `--runtime ""` 是打错了，
不该被悄悄解释成 claude-agent-sdk（兜底不许指向「好」的那一侧）。
测试先把「空串返默认」这个**前提**钉住，再断言必须提前挡 —— 前提不钉，
主断言就没有理由。

## 说清何时生效

改配置 ≠ 改运行中的进程。按三种现实各给一句话，复用 rename 用的
`findNodeStopCandidates`：在跑 → `anet node restart`；没在跑 → `anet node start`；
**读不到进程表 → 如实说读不到**，不假装知道。
同值是 no-op，不重写配置。

## 验证

- 新套件 10/10；agent-network 全量 1013 tests / 113 files
- **A/B**：那 3 个 error 在未改动的 origin/main 上**逐格相同**
  （`Cannot find module '@larksuiteoapi/node-sdk'`，可选依赖未安装，不是断言失败）。
  差值 +10 tests / +1 file 正好是新套件 —— 这个差值本身证明它被跑到了。
- 🔴 **三向见证**，每次恰好红 1 条（各打各的，不是被同一条前置断言拦住）：
    拿掉空值守卫              → 9 pass 1 fail
    函数体硬编码一个 runtime id → 9 pass 1 fail
    两条用法行删掉一处 edit    → 9 pass 1 fail
    还原                      → 10 pass 0 fail
- 改 cli.ts 会咬的门：check-doc-source-pins rc=0、check-doc-symbol-anchors rc=0
  （83 anchors / 480 docs）、help-column-alignment 3 pass
- 另跑：test-suite-registration / test-file-coverage / home-path-baseline /
  no-memory-slugs / public-script-safety 全 rc=0

## 范围

只放开 `--runtime`。要不要连 `--model` / `--flags` 一起放开是产品判断，留在 #1698。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>