### PR TITLE
feat(cli): #1698 anet node edit 也放开 --model —— 触发它的是 TM 的一条真实 P0

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9297,20 +9297,39 @@ async function nodeEditCommand() {
   const ref = args[1];
   const flagIdx = args.indexOf("--runtime");
   const raw = flagIdx >= 0 ? args[flagIdx + 1] : undefined;
-  if (!ref || flagIdx < 0) {
+  // #1698 —— `--model` 与 `--runtime` 同一条路：都复用**创建路径已经在用的**那个
+  // 校验器，不新增第 N 份判据。`anet node create` 走的是
+  // `validateModel`（cli.ts 的 create 分支，#1469 finding-3），这里照用。
+  //
+  // 🔴 触发这一格的是 TM 的一条真实 P0：节点撞上
+  //    "Selected model is at capacity"，而**换模型没有命令可用** ——
+  //    与 #1698 里 grok 撞 uid_map 墙时「产品给出的修法产品自己做不到」同形。
+  const modelIdx = args.indexOf("--model");
+  const rawModel = modelIdx >= 0 ? args[modelIdx + 1] : undefined;
+  if (!ref || (flagIdx < 0 && modelIdx < 0)) {
     console.log(`
-anet node edit <node-id|node-name> --runtime <id>
+anet node edit <node-id|node-name> [--runtime <id>] [--model <id>]
 
-  Change an existing node's runtime. Supported ids:
+  Change an existing node's runtime and/or model. Supported runtime ids:
     ${SUPPORTED_RUNTIME_NAMES.join(", ")}
 
+  --model takes any id the runtime accepts; it is validated the same way
+  'anet node create --model' validates it (non-empty, no whitespace).
+
   Note: the change is written to the node's config; a running node keeps its
-  current runtime until it is restarted (anet node restart <name>).
+  current runtime/model until it is restarted (anet node restart <name>).
 `);
     return;
   }
-  if (raw === undefined || raw.trim() === "" || raw.startsWith("--")) {
+  if (flagIdx >= 0 && (raw === undefined || raw.trim() === "" || raw.startsWith("--"))) {
     console.error(`--runtime needs a value. Supported: ${SUPPORTED_RUNTIME_NAMES.join(", ")}`);
+    process.exit(1);
+  }
+  // 🔴 同 --runtime：先自己挡掉空值/漏值。validateModel 对空串是**抛错**的，
+  //    但 `--model --runtime x` 这种漏值形态会把下一个 flag 当成模型名，
+  //    那是 validateModel 看不出来的（"--runtime" 没有空白、非空）。
+  if (modelIdx >= 0 && (rawModel === undefined || rawModel.trim() === "" || rawModel.startsWith("--"))) {
+    console.error("--model needs a value (an id the runtime accepts).");
     process.exit(1);
   }
   const resolved = resolveNodeRef(ref);
@@ -9323,29 +9342,53 @@ anet node edit <node-id|node-name> --runtime <id>
     console.error(`Node "${resolved.id}" has no readable config.json — nothing to edit.`);
     process.exit(1);
   }
-  let next: RuntimeName;
-  try {
-    next = normalizeRuntimeStrict(raw);
-  } catch (e: any) {
-    console.error(String(e?.message || e));
-    process.exit(1);
+  // 🔴 两个字段都可能改,所以先把「改成什么」全算出来、全校验完,**再一次写盘**。
+  //    分两次写会在第二次校验失败时留下一个只改了一半的 config。
+  const changes: string[] = [];
+  if (flagIdx >= 0) {
+    let next: RuntimeName;
+    try {
+      next = normalizeRuntimeStrict(raw);
+    } catch (e: any) {
+      console.error(String(e?.message || e));
+      process.exit(1);
+    }
+    const current = normalizeRuntime(profile);
+    if (current !== next) {
+      (profile as any).runtime = next;
+      changes.push(`runtime ${current} -> ${next}`);
+    }
   }
-  const current = normalizeRuntime(profile);
-  if (current === next) {
-    console.log(`${resolved.id} is already on runtime ${next} — nothing to change.`);
+  if (modelIdx >= 0) {
+    let nextModel: string;
+    try {
+      // 与 `anet node create --model` 同一个校验器(#1469 finding-3):
+      // 非字符串 / trim 后为空 / 含空白 → 抛错。**不在这里另写一套。**
+      nextModel = validateModel(rawModel as string);
+    } catch (e: any) {
+      console.error(String(e?.message || e));
+      process.exit(1);
+    }
+    const currentModel = (profile as any).model as string | undefined;
+    if (currentModel !== nextModel) {
+      (profile as any).model = nextModel;
+      changes.push(`model ${currentModel ?? "(unset)"} -> ${nextModel}`);
+    }
+  }
+  if (changes.length === 0) {
+    console.log(`${resolved.id} already matches what you asked for — nothing to change.`);
     return;
   }
-  (profile as any).runtime = next;
   saveProfile(resolved.id, profile);
-  console.log(`${resolved.id}: runtime ${current} -> ${next}`);
+  for (const c of changes) console.log(`${resolved.id}: ${c}`);
   // 🔴 说清「什么时候生效」。同 `anet goal edit` 的先例:改配置不等于改运行中的进程。
   const running = findNodeStopCandidates(resolved.id);
   if (running === null) {
     console.log(`  (could not read the process table — if ${resolved.id} is running, restart it: anet node restart ${resolved.id})`);
   } else if (running.length > 0) {
-    console.log(`  ${resolved.id} is running on the old runtime. Apply it with: anet node restart ${resolved.id}`);
+    console.log(`  ${resolved.id} is still running with the old settings. Apply them with: anet node restart ${resolved.id}`);
   } else {
-    console.log(`  It is not running; the new runtime applies on: anet node start ${resolved.id}`);
+    console.log(`  It is not running; the new settings apply on: anet node start ${resolved.id}`);
   }
 }
 

--- a/agent-network/src/node-edit-runtime.test.ts
+++ b/agent-network/src/node-edit-runtime.test.ts
@@ -55,6 +55,33 @@ describe("#1698 校验判据只有一份", () => {
   });
 });
 
+describe("#1698 --model：与 --runtime 走同一条路", () => {
+  // 触发这一格的是 TM 的一条真实 P0：节点撞上
+  // "Selected model is at capacity"，而换模型**没有命令可用**。
+  test("挂在同一个子命令上，两个 flag 至少给一个", () => {
+    expect(body).toContain('args.indexOf("--model")');
+    expect(body).toContain("flagIdx < 0 && modelIdx < 0");
+  });
+  // 🔴 复用创建路径已经在用的那个校验器（#1469 finding-3），不新写一套。
+  test("校验走 validateModel，不自造", () => {
+    expect(body).toContain("validateModel(");
+    // 自己写长度/字符判断就是新开一份判据
+    expect(body).not.toMatch(/model[^\n]*\.length\s*[<>]/);
+  });
+  test("--model 也先自己挡掉空值/漏值", () => {
+    expect(body).toContain('rawModel.startsWith("--")');
+  });
+  // 🔴 两个字段都可能改 ⇒ 必须**先全校验完再一次写盘**，
+  //    否则第二个字段校验失败时会留下只改了一半的 config。
+  test("先全校验再一次写盘：saveProfile 只出现一次，且在两次校验之后", () => {
+    expect((body.match(/saveProfile\(/g) || []).length).toBe(1);
+    const iModel = body.indexOf("validateModel(");
+    const iSave = body.indexOf("saveProfile(");
+    expect(iModel).toBeGreaterThan(-1);
+    expect(iSave).toBeGreaterThan(iModel);
+  });
+});
+
 describe("#1698 兜底方向", () => {
   // normalizeRuntimeStrict("") === DEFAULT_RUNTIME —— 先把这个前提钉住，
   // 否则下面那条「必须先挡空值」的断言会失去理由。
@@ -74,11 +101,15 @@ describe("#1698 说清何时生效", () => {
     expect(body).toContain("anet node restart ");        // 在跑
     expect(body).toContain("anet node start ");          // 没在跑
   });
-  test("同值是 no-op，不重写配置", () => {
-    expect(body).toContain("current === next");
-    // 切到那一支的 `return;` 为止 —— 用 indexOf("}") 会切在
-    // `${resolved.id}` 的模板闭合括号上（第一版就是这么错的）。
-    const noop = body.slice(body.indexOf("current === next"));
-    expect(noop.slice(0, noop.indexOf("return;"))).toContain("nothing to change");
+  // 🔴 第一版这条钉的是 `current === next` 这个**变量名** —— 实现从单字段
+  //    （只改 runtime）扩成多字段（runtime + model）之后它就红了，而**行为没变**。
+  //    断言要钉的是「同值时不写盘、并且说清没有变化」这个行为，不是某一行的写法。
+  test("同值是 no-op：不调 saveProfile，并说清没有变化", () => {
+    const noop = body.slice(body.indexOf("nothing to change"));
+    // 「nothing to change」那句之后必须紧跟 return —— 也就是这条路径不落盘。
+    const upToReturn = noop.slice(0, noop.indexOf("return;"));
+    expect(upToReturn).not.toContain("saveProfile(");
+    // 而正常路径是会落盘的（否则上面那条会因为整段都没有 saveProfile 而恒真）。
+    expect(body).toContain("saveProfile(");
   });
 });

--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -114,7 +114,7 @@ See [Token model](/en/concepts/tokens) for token types, scopes, and compatibilit
 | `anet node resume <name> [--session <id>]` | Resume the saved or specified session |
 | `anet node delete <name> --force` | Delete local node configuration |
 | `anet node rename <ref> <new>` | Rename a node already registered with the Hub |
-| `anet node edit <ref> --runtime <id>` | Change an existing node's runtime; **takes effect on restart** |
+| `anet node edit <ref> [--runtime <id>] [--model <id>]` | Change an existing node's runtime / model; **takes effect on restart** |
 | `anet node ls` | List local nodes and network state |
 | `anet info <name>` | Show node configuration, process, and recent tasks |
 | `anet logs <name> [--follow]` | Read or follow node logs |

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -114,7 +114,7 @@ Token 类型、作用域与兼容规则见 [Token 体系](/concepts/tokens)。
 | `anet node resume <name> [--session <id>]` | 使用保存的会话或指定会话恢复 |
 | `anet node delete <name> --force` | 删除本地节点配置 |
 | `anet node rename <ref> <new>` | 重命名已在 Hub 注册的节点 |
-| `anet node edit <ref> --runtime <id>` | 改已存在节点的 runtime；**要重启才生效** |
+| `anet node edit <ref> [--runtime <id>] [--model <id>]` | 改已存在节点的 runtime / 模型；**要重启才生效** |
 | `anet node ls` | 列出本地节点及网络状态 |
 | `anet info <name>` | 显示节点配置、进程和近期任务 |
 | `anet logs <name> [--follow]` | 查看或追踪节点日志 |


### PR DESCRIPTION
#1698 里我把 `--model` 留给 owner 定，理由是「产品判断」。今天两件事把它变成了
一个可以做的决定：

1. **有真实需求**：TM 的节点 `TMA门户牛` 撞上
   `Selected model is at capacity. Please try a different model.` ——
   而**换模型没有命令可用**，只能手改那台机器上的 config.json 再重启。
   这与 #1698 的起点（grok 撞 uid_map 墙时「产品给出的修法产品自己做不到」）**同形**。
2. **不需要新判据**：`anet node create --model` 早就在用 `validateModel`
   （`agent-network/src/tool-allowlist.ts`，#1469 finding-3）。edit 复用同一个，
   **不新增第 N 份判据** —— 这正是我上一条 PR 拒绝抄 runtime 白名单的同一条理由。

`--flags` **仍然不做**：它能改安全姿态，那才是真正需要 owner 拍板的那一格。

## 改动

`anet node edit <ref> [--runtime <id>] [--model <id>]` —— 两个 flag 至少给一个。

🔴 **两个字段都可能改 ⇒ 先把「改成什么」全算出来、全校验完，再一次写盘。**
分两次写会在第二次校验失败时留下一个**只改了一半的 config**。
断言把这条钉住：`saveProfile(` 在函数体里**只出现一次**，且**在 validateModel 之后**。

🔴 `--model` 也先自己挡掉漏值：`--model --runtime x` 这种形态会把下一个 flag
当成模型名，而 `validateModel` **看不出来**（`"--runtime"` 非空、无空白）。

## 顺带修正一条断言的形状

原「同值是 no-op」那条钉的是 `current === next` 这个**变量名**。实现从单字段扩成
多字段后它红了，而**行为没变**。改成钉行为：no-op 路径不含 `saveProfile(`，
**并且**正常路径含 `saveProfile(` —— 没有后半句，前半句会在「整段都没有
saveProfile」时恒真。

## 验证

- 14/14（原 10 条 + `--model` 契约 4 条）
- 🔴 四向见证：
    拆成两次写盘                    13 pass 1 fail
    去掉 --model 漏值守卫           13 pass 1 fail
    自写长度判断替代 validateModel   12 pass 2 fail（同时违反两条）
    退回「必须给 --runtime」         13 pass 1 fail
    还原                            14 pass 0 fail
- 🔴 变异时锚点断言 `count==1` 拦下一次跨命令误改：`  if (changes.length === 0) {`
  在 cli.ts 里命中 **2 次** —— 12786 行是**另一个命令**里同形状的代码（4 空格缩进，
  2 空格的串是它的子串）。直接 sed 会改坏那个命令**而本文件的测试全绿**。
  换成带上下文的唯一锚点。
- 文档中英两版同步（`docs-locale-parity` rc=0）
- 门：doc-symbol-anchors / test-suite-registration / test-file-coverage /
  home-path-baseline / no-memory-slugs / public-script-safety / no-escaped-comments /
  l1-sha-binding / l1-paths-sync / doc-claims / mutation-pins / docs-locale-parity
  全 rc=0；help-column-alignment 3 pass

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>