### PR TITLE
feat(gate): doc-symbol-pins 的「跳过」分三桶 + --list-skipped（只读，判据不动）

### DIFF
--- a/scripts/check-doc-symbol-pins.py
+++ b/scripts/check-doc-symbol-pins.py
@@ -354,6 +354,15 @@ def main() -> int:
 
     do_fix = "--fix" in sys.argv
     pins = skipped = unresolved = 0
+    # 🔴 「跳过」此前是一个数，而它底下是**三种含义完全不同**的东西：
+    #   blind      —— 锚文本没点名符号，机器分不清「改名了」和「那不是符号」。**这是真盲区。**
+    #   other-gate —— 文件不存在 / 行号越界，设计上归 check-doc-source-pins.py。**不是盲区。**
+    #   ioerror    —— 读不了，环境问题。
+    # 并成一个数之后，输出里那句「跳过的不是通过」读者**无法据以行动** ——
+    # 他不知道该去补哪一类。这里只做分桶与列表，判据与退出码一个字没动。
+    skipped_by: dict[str, list[str]] = {"blind": [], "other-gate": [], "ioerror": []}
+    def skip(kind: str, doc, rel, lineno) -> None:
+        skipped_by[kind].append(f"{doc.relative_to(repo)}: {rel}#L{lineno}")
     findings: list[str] = []
     fixes: list = []
     for doc in tracked_docs(repo, doc_root):
@@ -374,24 +383,29 @@ def main() -> int:
                 judged_here = judge(doc, repo, anchor, rel, int(lineno), lines_at_ref, findings, label_only, fixes)
                 if not judged_here:
                     skipped += 1
+                    skip("blind", doc, rel, lineno)
                 continue
             target = repo / rel
             if not target.is_file():
                 # 文件不存在是另一道门的活（check-doc-source-pins.py），
                 # 在这里重复报会让两道门的数字互相污染。
                 skipped += 1
+                skip("other-gate", doc, rel, lineno)
                 continue
             try:
                 lines = target.read_text(encoding="utf-8", errors="replace").split("\n")
             except OSError:
                 skipped += 1
+                skip("ioerror", doc, rel, lineno)
                 continue
             n = int(lineno)
             if not (1 <= n <= len(lines)):
                 skipped += 1  # 越界同样归另一道门
+                skip("other-gate", doc, rel, lineno)
                 continue
             if not judge(doc, repo, anchor, rel, n, lines, findings, label_only, fixes):
                 skipped += 1
+                skip("blind", doc, rel, lineno)
 
 
     if pins == 0:
@@ -407,9 +421,28 @@ def main() -> int:
         print("   改完请重跑一次不带 --fix 的本门确认。")
     elif do_fix:
         print("\n--fix: 没有可自动修的漂移(要么没漂,要么全是需要人消歧的多处命中)。")
+    # 🔴 各桶之和必须等于 skipped:将来有人加了新的 skip 点却忘了打标,
+    #    分解会静默少数 —— 那正是「分桶」最容易坏掉又最难发现的方式。
+    _bucketed = sum(len(v) for v in skipped_by.values())
+    if _bucketed != skipped:
+        print(f"::error::SYMBOL-PIN: 跳过分桶不自洽（skipped={skipped} 但分桶只有 {_bucketed} 条）"
+              f"—— 有 skip 点没调 skip()，分解不可信")
+        return 2
     verdict = "RED" if findings else "OK"
     print(f"SYMBOL-PIN: {verdict}（扫到 {pins} 个 pin，判定 {pins - skipped - unresolved} 个，"
           f"跳过 {skipped} 个，取不到 ref {unresolved} 个，漂移 {len(findings)} 个）")
+    if skipped:
+        # 🔴 分桶只为让上面那句「跳过的不是通过」可被据以行动:
+        #    blind 是这道门**真正看不见**的部分,other-gate 是设计上的分工。
+        #    把两者并成一个数,读者会把后者也当成隐患。
+        nb, no_, ni = (len(skipped_by[k]) for k in ("blind", "other-gate", "ioerror"))
+        print(f"   跳过分解：锚文本没点名符号 {nb} 个（**这是本门的真盲区**）、"
+              f"归 check-doc-source-pins.py {no_} 个（文件不存在/行号越界）、读不了 {ni} 个"
+              f"{'' if '--list-skipped' in sys.argv else ' —— 加 --list-skipped 看是哪些'}")
+        if "--list-skipped" in sys.argv:
+            for kind in ("blind", "other-gate", "ioerror"):
+                for item in skipped_by[kind]:
+                    print(f"   [{kind}] {item}")
     if unresolved:
         # 🔴 单列一格,不并进「跳过」。「我没拿到那个 commit」和「锚文本没点名符号」
         #    是两件事,并成一个数之后,浅克隆导致的**全体取不到**会伪装成


### PR DESCRIPTION
这道门在输出里诚实地写着「🔴 跳过的那些不是通过」,但**只给了一个数**:
`跳过 8 个`。读者据此**无法行动** —— 不知道是哪 8 个、也不知道该补哪一类。

## 改了什么(全部是只读增量)

1. **跳过分三桶**,五个 skip 点各自打标:
   - `blind`      锚文本没点名符号 ⇒ **这道门真正看不见的**(skip@376/394)
   - `other-gate` 文件不存在 / 行号越界 ⇒ 设计上归 check-doc-source-pins.py(skip@382/391)
   - `ioerror`    读不了(skip@387)
2. **汇总多打一行分解**;`--list-skipped` 列出每一条。
3. **分桶自洽校验**:各桶之和 != `skipped` ⇒ `::error::` + rc=2。
   将来有人加了 skip 点却忘了打标,分解会**静默少数** —— 那正是分桶最容易坏、
   又最难发现的方式。

判据、退出码、原有汇总行**一个字没动**。

## 🔴 实测结果推翻了我做这件事的部分动机,如实写出来

本仓当前:`blind 8 · other-gate 0 · ioerror 0`。

我原本的理由是「读者会把 other-gate 那类也当成隐患,分桶能纠正高估」——
**当前 other-gate 是 0,不存在这种高估**。仍然成立的只有三条:
① `--list-skipped` 让"是哪 8 个"可查;
② 自洽校验挡住将来忘打标;
③ 一旦出现 other-gate 类,分解立刻显形。

⇒ 这是**为将来准备的仪表**,不是"修了一个现存的误导"。

## 🔴 自洽校验的有效覆盖只有 1/5,这是数据决定的

两向见证:
- 拿掉 `skip@394`(live-pin 路径,本仓 8 个 blind 全走这里)⇒ rc=2,
  `::error::…skipped=8 但分桶只有 0 条`
- 还原 ⇒ rc=0

但**第一次我变异的是 `skip@376`(IMMUTABLE_REF 路径),rc=0 没红** ——
因为本仓没有 pin 走那条路径,**它一次都没执行**。同理 skip@382/387/391
当前也跑不到。**所以这道自检眼下只真正保护 skip@394 一处。**
不假装它保护了五处。

## 顺带:`--list-skipped` 第一版打的是绝对路径,含 `/home/<人名>`

会进公开仓的 CI 日志。已改用门原有的 `doc.relative_to(repo)` 写法
(与 findings 的 216/244 行一致)。

⚠️ 值得记一笔:同仓的 `check-home-path-baseline` 扫的是**文件内容**,
扫不到**运行时打印**。这半边目前没有门 —— 本 PR 不顺手加,只记录。