### PR TITLE
fix(docs): 三个行号锚指错了地方（由 --list-skipped 找出），含一处「半对」的描述

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -499,7 +499,7 @@ Agent                    CommHub Server              Hub/指挥室
   ├─────────────────────────►│                          │
 ```
 
-R256 校准：旧 doc 用 `send_task(hub, result)` 回复任务结果 —— 这会触发指挥室 think 循环（A 给 B 派任务，B 给 A 回复，A 又 think 又给 B 派任务，A→B→A→B 无限）。V3 已经引入 `send_reply` MCP tool（[tools.ts:589](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L589)），关联 `in_reply_to=task_id`，SSE 推 `new_reply` 不是 `new_task`，**接收方不触发 think**（R218 chain message-lifecycle.md 校准）。
+R256 校准：旧 doc 用 `send_task(hub, result)` 回复任务结果 —— 这会触发指挥室 think 循环（A 给 B 派任务，B 给 A 回复，A 又 think 又给 B 派任务，A→B→A→B 无限）。V3 已经引入 `send_reply` MCP tool（[tools.ts:2064](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2064)），关联 `in_reply_to=task_id`，SSE 推 `new_reply` 不是 `new_task`，**接收方不触发 think**（R218 chain message-lifecycle.md 校准）。
 
 ### 三种接入方式对比
 

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -38,7 +38,7 @@
 
 **核心规则：只有 `task` 和 `broadcast` 触发 think，其余只展示/记录。**
 
-> 验证：[`agent-node/src/cli.ts:864`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L864) `if (msgType !== "task" && msgType !== "broadcast") { ... continue; }`（R218 校准：原 doc 行号 886，当前 main 实际 864）。Public docs [concepts/task-lifecycle.md 消息类型](https://anet.sh/concepts/task-lifecycle#消息类型) 表里 task / broadcast 两行 ✓ 触发 AI；reply / message / ack 不触发。
+> 验证：[`agent-node/src/inbox-message-policy.ts:12`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/inbox-message-policy.ts#L12) `inboxDeliveryPolicy(type)` 返回 `{deliverToRuntime, replyExpected}` 两个**分开的**字段：`task`/`broadcast` → `{true, true}`；`reply` → `{true, false}`（进 runtime 但不再回复，否则会重建 peer ping-pong）；其余（含 `message`）→ `{false, false}`。（2026-08-31 校准：原钉 `cli.ts:864` 的 `msgType !== "task" && msgType !== "broadcast"` 判断已不在 `cli.ts` —— 决策移到了本文件，且 `reply` 的两个字段不同向。判据取自 `agent-node/src/inbox-message-policy.test.ts` 的逐条断言，非阅读实现的推测）。Public docs [concepts/task-lifecycle.md 消息类型](https://anet.sh/concepts/task-lifecycle#消息类型) 表里 task / broadcast 两行 ✓ 触发 AI；reply / message / ack 不触发。
 
 ## inbox 表改动
 
@@ -139,7 +139,7 @@ sendReply(target, text, taskId)  → send_reply（新 MCP 工具）
 </channel>
 ```
 
-Claude Code 收到 reply 和 message 时只需要阅读，不需要 send_task 回复（agent-node 侧在 [`cli.ts:864`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L864) 直接跳过非 task/broadcast 类型，channel wrapper 走 `notifications/claude/channel` 让 Claude Code 自己决定是否回复）。
+Claude Code 收到 message 时只需要阅读；收到 reply 时**内容会进 runtime**，但**不应再回复**（`replyExpected: false`，否则会重建 peer ping-pong）（agent-node 侧由 [`inbox-message-policy.ts:12`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/inbox-message-policy.ts#L12) 的 `inboxDeliveryPolicy` 决定，`message` 类 `deliverToRuntime: false`，channel wrapper 走 `notifications/claude/channel` 让 Claude Code 自己决定是否回复）。
 
 ## 向后兼容
 


### PR DESCRIPTION
用刚合的 `--list-skipped`(#1707) 列出 8 个 blind pin,逐个核锚文本与目标行,
发现三处**指错地方**(门看不见它们,所以此前一直是绿的)。

## ① docs/architecture.md:`tools.ts:589` → `2064`(漂 1475 行)

锚说那里是 `send_reply` MCP tool;L589 实际是一段 RFC-024 的 zod schema
(`Bounded node-reported external schedule snapshot`)。
真正的注册处是 `server.tool("send_reply", …)`,在 **L2064** —— 用带引号的
`"send_reply"` 才定位得到(裸标识符命中 8 处,全是注释和日志)。
URL(`#L589`)与锚标签(`[tools.ts:589]`)**两种形态都改**,各自断言恰好 1 处。

## ② docs/message-lifecycle.md ×2:`cli.ts:864` → `inbox-message-policy.ts:12`

锚逐字引的 `if (msgType !== "task" && msgType !== "broadcast") { ... continue; }`
在 `agent-node/src/cli.ts` 里**0 命中** —— 这段判断已经不在那个文件里了。

## 🔴 ③ 顺带修一处「半对」的描述,这是本 PR 最实的一条

原文:「Claude Code 收到 **reply 和 message** 时只需要阅读,不需要 send_task 回复」

对着 `inboxDeliveryPolicy` 逐条核(判据取自
`agent-node/src/inbox-message-policy.test.ts` 的断言,非阅读实现的推测):

```
task / broadcast → { deliverToRuntime: true,  replyExpected: true  }
reply            → { deliverToRuntime: true,  replyExpected: false }   ← 两字段不同向
其余(含 message) → { deliverToRuntime: false, replyExpected: false }
```

⇒ 对 `reply` 来说:「不需要回复」**对**,「只需要阅读」**错** —— 它的内容
**会进 runtime**。函数注释写明了理由:reply 是本节点派出去的活的终态结果,
必须立刻进 runtime,但绝不能再回复(否则重建 peer ping-pong)。

**两个字段被压成一句话,成立的那半掩护了不成立的那半。** 现在按两个字段分述。

## 不做什么

- **不声称门的覆盖率变化**。实测:改前 `判定 7 / 跳过 8`,改后仍是 `7 / 8`。
  这三个 pin 修的是**正确性**,不是可判定性 —— `judge()` 的路② 要求
  **符号名出现在链接标签里**,而本仓 15 个 pin 都是 `文件:行号` 形态。
  把符号名写进标签能让它们可判定,但那会引入**与全仓其余 pin 不一致的写法**,
  是一个独立议题,不在本 PR 里定。
- 沿用原文的「校准痕迹」写法(原有 `R218 校准:原 doc 行号 886…`),把本次
  迁移也记上,让下一个人看得到这个锚的历史。

## 见证

- `scripts/check-doc-symbol-pins.py` rc=0(改前改后都 OK —— 因为它判不了这三个)
- check-home-path-baseline / check-docs-integrity / check-no-memory-slugs 均 rc=0
- 🔴 中途发现 worktree 的 `origin/main` 停在 19:50(缺 #1705/#1707),
  用旧门跑出的"跳过 8"曾一度不作数;已 rebase 到 537a69b8 后重跑确认。