### PR TITLE
fix(docs): 再修两个指错地方的行号锚 —— db.ts 那处连「建表」这个说法也是错的

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -165,7 +165,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
 | 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2063 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2063) + [tools.ts:2077 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2077) |
-| 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L161)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
+| 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:193（列定义数组）+ db.ts:206（`ALTER TABLE inbox ADD COLUMN`）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L193)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |
 

--- a/docs/node-lifecycle.md
+++ b/docs/node-lifecycle.md
@@ -193,7 +193,7 @@ register() → callCommHub("report_status", {
 - config.json: 不变（session 已写回）
 - 进程退出
 
-**CommHub 超时检测**: 心跳 3 分钟间隔（[`agent-node/src/cli.ts:6341`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L6341) `setInterval(() => reportStatus("idle"), 3 * 60 * 1000)`），超过 **10 分钟**无心跳 → 自动标记 offline（[`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) `Date.now() - 10 * 60 * 1000` cutoff，惰性触发于 `/api/status` 调用时）。R219 校准：原 doc 5 分钟错。
+**CommHub 超时检测**: 心跳 3 分钟间隔（[`agent-node/src/cli.ts:6620`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L6620) `setInterval(() => reportStatus("idle"), 3 * 60 * 1000)`），超过 **10 分钟**无心跳 → 自动标记 offline（[`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) `Date.now() - 10 * 60 * 1000` cutoff，惰性触发于 `/api/status` 调用时）。R219 校准：原 doc 5 分钟错。
 
 ### 9. 删除 (deleted) — R219 校准
 


### PR DESCRIPTION
承接 #1708。8 个 blind pin 全部核完，结论：**5 个真漂 / 2 个指对了 / 1 个是历史记录**。
#1708 修了前三个，这条修剩下两个。

## ① docs/node-lifecycle.md:`cli.ts:6341` → `6620`（漂 279 行）

锚逐字引 `setInterval(() => reportStatus("idle"), 3 * 60 * 1000)`。
L6341 实际是 `warn(\`stop-daemon failed: …\`)`；真身在 L6620：

```
6620  setInterval(() => reportStatus("idle").catch(() => {}), 3 * 60 * 1000);
```

## ② docs/message-lifecycle.md:`db.ts:161/195` → `193/206`，**并且改了说法**

原文：`db.ts:161（inbox 列表）+ db.ts:195（inbox 建表）`。

L161 实际是一行 SQL 注释，L195 是 `{ name: "expires_at", def: "TEXT" }`。真身：

```
191  // inbox: add in_reply_to, requires_response, expires_at, scope, node identity
193    { name: "in_reply_to", def: "TEXT" },          ← 「列定义数组」
206    try { db.exec(`ALTER TABLE inbox ADD COLUMN ${col.name} ${col.def}`); } catch {}
```

🔴 **「inbox 建表」这个说法本身就不成立**：`inbox` 的 `CREATE TABLE` 在 L41，
**不含** `in_reply_to`；该字段是 L206 `ALTER TABLE` 加上去的。
只改行号不改说法，读者点过去看到一个 `ALTER TABLE` 而文档说那是「建表」——
**行号对了、说法错了，比两个都错更让人怀疑自己看错了地方。**

## 🔴 差点踩的坑：`db.ts:227` 也有 `in_reply_to TEXT,`

字段名逐字对得上，但那一段的表头是 `task_id TEXT PRIMARY KEY` —— **那是 tasks 表**。
按「哪一行有这个字段」去改，会把 inbox 的锚指到另一张表上，
**比现在的漂移更隐蔽**（看起来完全合理）。定位必须回到「这一段属于哪个语句」。

## 不声称门的覆盖率变化

改前改后都是 `判定 7 / 跳过 8`（新门分解：blind 8 / other-gate 0 / ioerror 0）。
这 5 个 pin 修的是**正确性**，不是可判定性 —— `judge()` 的路② 要求符号名出现在
**链接标签**里，而本仓 15 个 pin 都是 `文件:行号` 形态。改写法是独立议题。

## 见证

check-home-path-baseline / check-docs-integrity / check-no-memory-slugs /
check-doc-symbol-anchors / check-doc-symbol-pins 均 rc=0（git add 后跑）。