### PR TITLE
docs(arch): 指向随包发布的那份 commhub-channel —— 另一份是分叉副本（C3）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -506,7 +506,10 @@ R256 校准：旧 doc 用 `send_task(hub, result)` 回复任务结果 —— 这
 ```
 方式 A: Claude Code + Channel（最优, 现役）
   Agent ←SSE Push→ CommHub    实时，零延迟
-  通过 channel/commhub-channel.ts 暴露 5 个 commhub_* MCP tool 给 Claude Code
+  通过 commhub-channel MCP server 暴露 5 个 commhub_* MCP tool 给 Claude Code
+  🔴 实际随包发布并运行的是 agent-network/src/node-server.ts（本机 ~/.anet/node-server.js）；
+     channel/commhub-channel.ts 是同名的**分叉副本**，不在任何包的 files: 里、无源码 import，
+     只被文档引用。改行为请改前者。分叉已登记为 docs/claude-code-cleanup-review.md 的 C3。
 
 方式 B: agent-node SDK runtime（现役）
   Agent ←SSE Push→ CommHub    实时，agent-node 内部用 claude-agent-sdk / codex-sdk 跑


### PR DESCRIPTION
## 问题

`docs/architecture.md:509` 写「通过 `channel/commhub-channel.ts` 暴露 5 个
commhub_* MCP tool 给 Claude Code」。**那不是随包发布并运行的那一份。**

仓里有两个文件都把 MCP server 命名为 `commhub-channel`:

```
agent-network/src/node-server.ts     ← 随 agent-network 发布(files: ["dist"]),
                                       本机跑的是 ~/.anet/node-server.js(590KB, 08-30 更新)
channel/commhub-channel.ts           ← 不在任何包的 files: 里
                                       非测试引用**全部是文档**,无一处源码 import
```

这个分叉**三个半月前就登记过**:`docs/claude-code-cleanup-review.md` 的 **C3**
(「两套 commhub channel 实现分叉」,`channel/commhub-channel.ts:71-95` 与
`agent-network/src/node-server.ts:72-76`)。本 PR 不清理分叉,只让
`architecture.md` 别再把读者送到那一份上,并把 C3 的位置写进去。

## 🔴 为什么值得改:我自己因为它绕了 7 轮

我在排查 #1648 时读到 `channel/commhub-channel.ts:73` 的 `loadNodeConfig()`:

```ts
const nodes = readdirSync(nodesDir);
if (nodes.length > 0) {
  const p = join(nodesDir, nodes[0], "config.json");   // ← 取目录里第一个
```

而 `ALIAS = process.env.COMMHUB_ALIAS || NODE_CONFIG.alias || …`。
本机 `~/tmteam/.anet/nodes/` 下有 **18** 个节点目录 —— 这个兜底在多节点目录下
几乎必然取错,**而 #203(P0,Vincent 亲测「新节点用老节点身份发消息」)的症状与它完全吻合**。

**一个真实发生过的 P0 + 一段确实有缺陷的代码 = 一份看起来无懈可击的报告。**
唯一错的是:**它不在任何执行路径上**。
我是查了 `files:` 与非测试引用才停住的 —— 而 `architecture.md` 把我送到那里。

(#203 的修法是在 spawn 时显式注入 `COMMHUB_ALIAS`,见
`agent-network/bin/cli.ts:6289` 的 `#203 defense` 注释;那条兜底本身没动,
但它所在的文件不发布。)

## 只改一处,不动 message-lifecycle.md

`docs/message-lifecycle.md:131` 引用同一个文件,但它的注释里写着
「+ node-server.ts 同样格式」—— **作者知情且标注了**,不构成误导,不动它。

## 见证

check-docs-integrity / check-doc-symbol-anchors / check-doc-symbol-pins /
check-doc-claims / check-home-path-baseline / check-no-memory-slugs 均 rc=0(git add 后跑)。