### PR TITLE
fix(node-server): 身份载荷补 config_path —— claude-code 族 63 个节点这一格全空

### DIFF
--- a/agent-network/src/node-server-identity-payload.test.ts
+++ b/agent-network/src/node-server-identity-payload.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `node-server.ts` 在**三个**地方构造同一份「身份载荷」发给 hub 的 report_status:
+//
+//   ① main() 开机注册        「registered as …」
+//   ② reregister()           SSE 重连后
+//   ③ 心跳                    每 3 分钟一次
+//
+// 🔴 而文件里的注释只提到两处(`Mirrors the payload main() sends at boot`)。
+//    2026-08-31 我是靠 `grep -n 'agent: "claude-code"'` 才发现是三处的 ——
+//    照注释改两处,第三条路径会**静默地少一个字段**,且只在走到那条路径时才显现。
+//
+// 所以这道门是**反推**的:凡是构造了 `agent: "claude-code"` 身份载荷的地方,
+// 都必须带上同一组字段。将来有人加第四处注册点,漏了会红。
+//
+// (为什么是 `config_path`:名册里这一格 `claude-code` 族 63 个全空,而
+//  `agent-node:*` 各族 100% 有。排查 offline 节点时第一个问题是「还能不能起回来」,
+//  那要看 config 还在不在 —— #1648 里 11 个节点因此只能写「判不了」。)
+
+const SRC = readFileSync(join(import.meta.dir, "node-server.ts"), "utf-8");
+// 🔴 去掉注释行:源码里既有"东西"也有"关于它的描述",裸 grep 会命中后者。
+const CODE = SRC.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+/** 每个身份载荷块 = 从 `agent: "claude-code"` 起到该对象字面量结束。 */
+function identityPayloads(src: string): string[] {
+  const out: string[] = [];
+  const lines = src.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*agent:\s*"claude-code",\s*$/.test(lines[i]!)) continue;
+    const indent = lines[i]!.match(/^\s*/)![0].length;
+    const block: string[] = [];
+    // 往上收到对象起点(callCommHub 那一行),往下收到缩进变浅
+    for (let j = i - 6; j < i; j++) if (j >= 0) block.push(lines[j]!);
+    for (let j = i; j < Math.min(lines.length, i + 12); j++) {
+      const l = lines[j]!;
+      if (j > i && l.trim() && (l.match(/^\s*/)![0].length < indent)) break;
+      block.push(l);
+    }
+    out.push(block.join("\n"));
+  }
+  return out;
+}
+
+describe("node-server 的身份载荷(三处)", () => {
+  const blocks = identityPayloads(CODE);
+
+  it("取集正控:确实解析出了 3 个身份载荷(空集会让下面恒绿)", () => {
+    expect(blocks.length).toBe(3);
+    for (const b of blocks) expect(b).toContain('agent: "claude-code"');
+  });
+
+  it("三处都带 project_dir —— 这一格本来就有,当基准", () => {
+    for (const b of blocks) expect(b).toContain("project_dir: process.cwd()");
+  });
+
+  it("🔴 三处都带 config_path —— 加第四处注册点时漏了会红", () => {
+    const missing = blocks.filter(b => !b.includes("config_path: CONFIG_PATH"));
+    expect(missing.length).toBe(0);
+  });
+
+  it("config_path 不存在时不发这个字段(发一个不存在的路径比不发更糟)", () => {
+    expect(CODE).toContain("existsSync(p) ? p : undefined");
+  });
+
+  it("路径用的是 cwd + ALIAS,与 activityLog 同源,不另外猜", () => {
+    expect(CODE).toContain('join(process.cwd(), ".anet", "nodes", ALIAS, "config.json")');
+    expect(CODE).toContain("createActivityLogSink(process.cwd(), ALIAS)");
+  });
+});

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -149,6 +149,29 @@ const OUTBOUND_ONLY = process.env.ANET_COMMHUB_MODE === "outbound-only";
 // into .anet/nodes/<ALIAS>/logs/ (UTC-dated file, same as agent-node _log);
 // stderr remains the primary sink and file failures are swallowed inside.
 const activityLog = createActivityLogSink(process.cwd(), ALIAS);
+
+// 🔴 名册里 `config_path` 这一格,`claude-code` 族 63 个节点全是空的
+//    (2026-08-31 实测:agent-node:* 各族 100% 有,claude-code 0/63)。
+//    hub 的 report_status schema 早就收这个字段(`server/src/tools.ts` 里
+//    `config_path: z.string().max(1000).optional()`),只是这边没填。
+//
+//    后果不是"少一格显示":排查一个 offline 节点时,第一个要回答的问题是
+//    **「它还能不能一键起回来」** —— 而那要看 config 还在不在。
+//    #1648 里本机 23 个 offline 的 TM 节点,我能对 12 个给出答案,
+//    剩下 11 个全是这一族,只能写「判不了」。
+//
+//    路径与上面 activityLog 用的是同两个值(cwd + ALIAS),不另外猜。
+//    **不存在就不发这个字段** —— 发一个不存在的路径比不发更糟:
+//    读的人会以为"配置在那儿但坏了",而真相是"这个节点没有本地配置"。
+function nodeConfigPath(): string | undefined {
+  try {
+    const p = join(process.cwd(), ".anet", "nodes", ALIAS, "config.json");
+    return existsSync(p) ? p : undefined;
+  } catch {
+    return undefined;
+  }
+}
+const CONFIG_PATH = nodeConfigPath();
 function log(msg: string) {
   const ts = new Date().toTimeString().slice(0, 8);
   const line = `[${ts}] [commhub] ${msg}`;
@@ -478,6 +501,7 @@ async function reregister(): Promise<void> {
       hostname: hostname(),
       agent: "claude-code",
       project_dir: process.cwd(),
+      config_path: CONFIG_PATH,
       tmux_name: TMUX_NAME || undefined,
     });
     log(`re-registered as "${ALIAS}" after SSE reconnect`);
@@ -659,6 +683,7 @@ async function main() {
     hostname: hostname(),
     agent: "claude-code",
     project_dir: process.cwd(),
+    config_path: CONFIG_PATH,
     tmux_name: TMUX_NAME || undefined,
   })
     .then(() => log(`registered as "${ALIAS}" (${RESUME_ID.slice(0, 8)})`))
@@ -674,6 +699,7 @@ async function main() {
       hostname: hostname(),
       agent: "claude-code",
       project_dir: process.cwd(),
+      config_path: CONFIG_PATH,
       tmux_name: TMUX_NAME || undefined,
     }).catch((e) => log(`heartbeat failed: ${e}`));
   }, 3 * 60 * 1000);


### PR DESCRIPTION
## 实测

```
全 272 个会话,按 runtime 看「有/无 config_path」(2026-08-31 生产名册只读快照)
  agent-node:claude              有=68  无=0
  agent-node:codex               有=66  无=0
  claude-code                    有=0   无=63     ← 100%,无例外
  agent-node:codex-app-server    有=39  无=0
  agent-node:grok                有=13  无=0
  agent-node:grok-build-cli      有=12  无=0
  agent-node:opencode            有=3   无=0
```

hub 的 schema **早就收这个字段**(`server/src/tools.ts`:
`config_path: z.string().max(1000).optional().describe("Config file path")`),
`agent-node/src/cli.ts:1440/1491` 一直在填,只有 `node-server.ts` 没填。

## 🔴 后果不是"少一格显示"

排查一个 offline 节点时,第一个要回答的问题是**「它还能不能一键起回来」** ——
那要看 config 还在不在。今天在 #1648 里,本机 23 个 offline 的 TM 节点:

```
9 个  config_path 有且文件在   → 可直接重启
3 个  config_path 有但文件没了 → 目录被清理过
11 个 名册无 config_path       → **只能写「判不了」**,而这 11 个全是 claude-code 族
```

而它们的 config **是存在的** —— 我抽全 49 个本机 claude-code 节点验过:
45 个有 `.anet/nodes/<alias>/config.json`(其余 4 个是目录已被清理的)。
**信息就在本地,只是没进名册。**

## 改动

`node-server.ts` 在**三处**构造同一份身份载荷:
`main()` 开机注册 / `reregister()`(SSE 重连) / 心跳(每 3 分钟)。
三处各加一行 `config_path: CONFIG_PATH`。

🔴 **文件里的注释只提到两处**(`Mirrors the payload main() sends at boot`) ——
我是靠 `grep -n 'agent: "claude-code"'` 才发现是三处的。改的时候用
`assert n + n4 == 3` 钉住,不是默默 replace。

路径取 `join(process.cwd(), ".anet", "nodes", ALIAS, "config.json")` ——
与同文件 `createActivityLogSink(process.cwd(), ALIAS)` **同两个值**,不另外猜。
**`existsSync` 才带**:发一个不存在的路径比不发更糟,读的人会以为
"配置在那儿但坏了",而真相是"这个节点没有本地配置"。

🔴 心跳也带这份载荷 ⇒ **升级后无需重启,在线节点 3 分钟内自动补齐这一格。**

## 门:反推,防第四处

新增 `node-server-identity-payload.test.ts`:凡是构造了 `agent: "claude-code"`
身份载荷的地方,都必须带同一组字段。将来加第四处注册点,漏了会红。

## 见证

- **逐处**变异(不是只变一处):拿掉第 1/2/3 处 → 每次都 `4 pass 1 fail`,
  且红的都是同一条断言;还原 → `5 pass 0 fail`。
  只变一处只能证明"至少有一处被检查",逐处才证明三处各自在取集里。
- 取集正控:断言解析出的身份载荷**恰好 3 个**(空集会让差集恒绿)。
- 全量单测对照基线:改动前后都是 `11 fail / 3 errors`(**既有,与本改动无关**),
  测试数 1047→1052、文件 115→116,正好是我新增的 5 条断言 / 1 个文件。
- check-home-path-baseline / check-no-memory-slugs /
  check-test-suite-registration / check-public-script-safety /
  check-doc-symbol-pins 均 rc=0(git add 后跑)。

关联:#171(同一族缺 `model`,三个多月未动)、#1648(11 个节点因此判不了)。