### PR TITLE
docs(contributing): Quick start 的第一条命令必然失败 —— 仓库根没有 package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,44 @@ Thanks for considering a contribution. This document covers how to set up, propo
 ```bash
 git clone https://github.com/sleep2agi/agent-network.git
 cd agent-network
-bun install
+
+# 🔴 仓库根目录**没有** package.json —— 依赖是按子包各装各的。
+# 在根目录跑 `bun install` 会直接失败:
+#   error: Bun could not find a package.json file to install from
+cd agent-network && bun install     # anet CLI(这个子目录与仓库同名)
 ```
 
-Each subproject (`agent-network/`, `server/`, `agent-node/`) has its own `bun run` scripts — see the `package.json` in that directory.
+装哪个子包取决于你要改什么 —— 五个子包各有自己的 `package.json`、依赖和 `bun run` 脚本：
+
+| 子包 | 是什么 | 常用脚本 |
+|---|---|---|
+| `agent-network/` | `anet` CLI | `build` / `typecheck` |
+| `server/` | CommHub 服务端 | `dev` / `start` / `test` |
+| `agent-node/` | 节点运行时 | `build` |
+| `channel/` | MCP channel | — |
+| `docs-site/` | https://anet.sh 文档站 | — |
+
+脚本以那个目录的 `package.json` 为准，上表只是索引。
+
+### 🔴 在新建的 `git worktree` 里跑测试之前
+
+`git worktree add` **不会**带上 `node_modules`。忘了装依赖时，失败长这样：
+
+```
+(fail) #518 node start help ... > real `anet node start --help` names ...
+       expect(result.code).toBe(0)
+```
+
+**报错里一个字都不会提依赖** —— 因为那几个用例 `spawnSync` 真 CLI，拿到的只是退出码。
+自己手跑一次才看得见真因：
+
+```bash
+$ bun bin/cli.ts node start --help
+error: Cannot find module '@inquirer/prompts'
+```
+
+判据:失败**全部**集中在会 spawn 真 CLI 的用例上,纯读源码的测试照常全绿。
+先 `cd <子包> && bun install` 再跑。
 
 ## Found a bug?
 

--- a/agent-network/CONTRIBUTING.md
+++ b/agent-network/CONTRIBUTING.md
@@ -7,10 +7,21 @@ Thanks for considering a contribution. This document covers how to set up, propo
 ```bash
 git clone https://github.com/sleep2agi/agent-network.git
 cd agent-network
-bun install
+
+# 🔴 仓库根目录**没有** package.json —— 依赖是按子包各装各的。
+# 在根目录跑 `bun install` 会直接失败:
+#   error: Bun could not find a package.json file to install from
+cd <子包目录> && bun install
 ```
 
-Each subproject (`agent-network/`, `server/`, `agent-node/`) has its own `bun run` scripts — see the `package.json` in that directory.
+仓库有五个子包,各有自己的 `package.json`、依赖和 `bun run` 脚本 ——
+`agent-network/`(anet CLI)、`server/`(CommHub 服务端)、`agent-node/`(节点运行时)、
+`channel/`、`docs-site/`(https://anet.sh)。脚本以那个目录的 `package.json` 为准。
+
+🔴 `git worktree add` **不带 `node_modules`**。忘了装依赖时,失败签名
+**看起来像功能坏了**(`expect(result.code).toBe(0)`,一个字不提依赖) ——
+判据:失败全部集中在会 `spawnSync` 真 CLI 的用例上,纯读源码的测试照常全绿。
+完整说明见仓库根的 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## Found a bug?
 

--- a/agent-node/CONTRIBUTING.md
+++ b/agent-node/CONTRIBUTING.md
@@ -7,10 +7,21 @@ Thanks for considering a contribution. This document covers how to set up, propo
 ```bash
 git clone https://github.com/sleep2agi/agent-network.git
 cd agent-network
-bun install
+
+# 🔴 仓库根目录**没有** package.json —— 依赖是按子包各装各的。
+# 在根目录跑 `bun install` 会直接失败:
+#   error: Bun could not find a package.json file to install from
+cd <子包目录> && bun install
 ```
 
-Each subproject (`agent-network/`, `server/`, `agent-node/`) has its own `bun run` scripts — see the `package.json` in that directory.
+仓库有五个子包,各有自己的 `package.json`、依赖和 `bun run` 脚本 ——
+`agent-network/`(anet CLI)、`server/`(CommHub 服务端)、`agent-node/`(节点运行时)、
+`channel/`、`docs-site/`(https://anet.sh)。脚本以那个目录的 `package.json` 为准。
+
+🔴 `git worktree add` **不带 `node_modules`**。忘了装依赖时,失败签名
+**看起来像功能坏了**(`expect(result.code).toBe(0)`,一个字不提依赖) ——
+判据:失败全部集中在会 `spawnSync` 真 CLI 的用例上,纯读源码的测试照常全绿。
+完整说明见仓库根的 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## Found a bug?
 

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -7,10 +7,21 @@ Thanks for considering a contribution. This document covers how to set up, propo
 ```bash
 git clone https://github.com/sleep2agi/agent-network.git
 cd agent-network
-bun install
+
+# 🔴 仓库根目录**没有** package.json —— 依赖是按子包各装各的。
+# 在根目录跑 `bun install` 会直接失败:
+#   error: Bun could not find a package.json file to install from
+cd <子包目录> && bun install
 ```
 
-Each subproject (`agent-network/`, `server/`, `agent-node/`) has its own `bun run` scripts — see the `package.json` in that directory.
+仓库有五个子包,各有自己的 `package.json`、依赖和 `bun run` 脚本 ——
+`agent-network/`(anet CLI)、`server/`(CommHub 服务端)、`agent-node/`(节点运行时)、
+`channel/`、`docs-site/`(https://anet.sh)。脚本以那个目录的 `package.json` 为准。
+
+🔴 `git worktree add` **不带 `node_modules`**。忘了装依赖时,失败签名
+**看起来像功能坏了**(`expect(result.code).toBe(0)`,一个字不提依赖) ——
+判据:失败全部集中在会 `spawnSync` 真 CLI 的用例上,纯读源码的测试照常全绿。
+完整说明见仓库根的 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## Found a bug?
 


### PR DESCRIPTION
## 新人照 CONTRIBUTING 做，第一步就 rc=1

```
$ git show origin/main:package.json
fatal: path 'package.json' does not exist in 'origin/main'

$ cd <空目录> && bun install
rc=1
error: Bun could not find a package.json file to install from
note: Run "bun init" to initialize a project
```

而 Quick start 现在是这三行：

```bash
git clone https://github.com/sleep2agi/agent-network.git
cd agent-network
bun install          # ← 必然失败
```

🔴 **先说清严重度**：它**大声报错**，不会静默装出半个环境。所以这不是数据损坏级的坑，是**「开箱第一步走不通，且文档没说该去哪装」**。（我第一版把它写重了，实测之后降了一档。）

依赖实际按子包各装各的，仓库有五个，脚本还各不相同：

| 子包 | 是什么 | 常用脚本 |
|---|---|---|
| `agent-network/` | `anet` CLI | `build` / `typecheck` |
| `server/` | CommHub 服务端 | `dev` / `start` / `test` |
| `agent-node/` | 节点运行时 | `build` |
| `channel/` | MCP channel | — |
| `docs-site/` | https://anet.sh 文档站 | — |

## 改三处

1. 点名根目录没有 `package.json`，**贴上实测报错原文** —— 新人一眼对得上
2. 上面这张索引表，并写明「**以那个目录的 `package.json` 为准，上表只是索引**」—— 不让它变成第二份会漂的真相
3. 新增 **「在新建的 `git worktree` 里跑测试之前」**

## 第 3 条才是真正省时间的部分

本仓现有 **300+ 个 worktree**，`git worktree add` **不带 `node_modules`**。忘了装依赖的失败签名**看起来像功能坏了**：

```
(fail) #518 node start help ... > real `anet node start --help` names ...
       expect(result.code).toBe(0)
```

**报错里一个字都不提依赖** —— 那几个用例 `spawnSync` 真 CLI，拿到的只有退出码。手跑一次才看得见真因：

```
$ bun bin/cli.ts node start --help
error: Cannot find module '@inquirer/prompts'
```

文档里给了判据：**失败全部集中在会 spawn 真 CLI 的用例上，纯读源码的测试照常全绿。**

🔴 这条是我今晚亲自踩出来的 —— 我先把那 19 个失败误判成「main 上的已知失败」，还写进了 #1716 的正文（已贴更正）。追一条命令才看见 `Cannot find module`。

## 门

`home-path` / `test-suite-registration` / `docs-integrity` / `no-memory-slugs` / `doc-claims` / `doc-symbol-anchors` / `docs-locale-parity` —— **全 rc=0**。

查重：三组机制词搜 issue，**0 命中**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)