### PR TITLE
fix(cli): node stop/rename 的失败文案宣称发过 SIGKILL，而非 --force 时根本没发

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8946,9 +8946,17 @@ async function terminateNodeProcess(pid: number, force: boolean): Promise<boolea
   if (!pidAlive(pid)) return true;
   try { process.kill(pid, "SIGTERM"); } catch {}
   if (await waitForPidExit(pid, 8000)) return true;
+  // #1422 — everything below here is the diagnosable path, and until now it
+  // was silent: a reader of the logs could not tell how long we waited, nor
+  // whether a SIGKILL was ever sent. Both branches now say so, because
+  // SIGKILL is --force-only and the absence of one is the more surprising
+  // half. Quiet on the happy path (SIGTERM reaped within 8s) by design.
   if (force) {
+    console.warn(`[anet] ⚠ pid ${pid} outlived the 8s SIGTERM grace — escalating to SIGKILL (--force).`);
     try { process.kill(pid, "SIGKILL"); } catch {}
     if (await waitForPidExit(pid, 3000)) return true;
+  } else {
+    console.warn(`[anet] ⚠ pid ${pid} outlived the 8s SIGTERM grace. No SIGKILL was sent — escalation requires --force.`);
   }
   return !pidAlive(pid);
 }
@@ -9748,7 +9756,7 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
       }
       if (!(await terminateNodeProcess(pid, force))) {
         oldSurvivors.push(pid);
-        console.error(`[anet] ✗ old agent process (pid ${pid}) did not exit after SIGTERM + SIGKILL.`);
+        console.error(`[anet] ✗ old agent process (pid ${pid}) did not exit after SIGTERM${force ? " + SIGKILL" : " (no SIGKILL — that needs --force)"}.`);
       }
     }
     oldProcessConfirmedDead = oldSurvivors.length === 0;

--- a/agent-network/src/node-stop-signal-message-accuracy.test.ts
+++ b/agent-network/src/node-stop-signal-message-accuracy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `anet node stop` / `anet node rename` 的杀进程路径原本是**静默**的，而它的
+// 报错文案又比实际做的事多说了一步：
+//
+//   agent-network/bin/cli.ts  terminateNodeProcess(pid, force)
+//     SIGTERM → 等 8000ms → if (force) { SIGKILL → 等 3000ms }
+//                            ↑ SIGKILL **只在 --force 时发**
+//
+//   而 renameCommand 里的失败文案原文是：
+//     `✗ old agent process (pid …) did not exit after SIGTERM + SIGKILL.`
+//                                                              ↑ 非 force 时根本没发
+//
+// 后果不是"文案不好看"：test225 的诊断行据此写了「拆卸链没跑完就被 SIGKILL 了」，
+// 而那次是否发过 SIGKILL **日志里读不到**（#1422 复现记录）。
+// 一个说反的报错会把每一个读它的人朝同一个方向带偏。
+//
+// 🔴 这条测试只钉**源码文本**（文案与分支的对应关系），它证明不了命令真能跑 ——
+//    `terminateNodeProcess` 未导出，只有真跑 CLI 才能验行为。别把它当行为测试。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+
+/** 取集：把 terminateNodeProcess 的函数体单独取出来，避免命中文件里别处的同名字串。 */
+function terminateBody(src: string): string {
+  const start = src.indexOf("async function terminateNodeProcess(");
+  if (start < 0) throw new Error("找不到 `terminateNodeProcess(` —— 函数被改名或删了");
+  const end = src.indexOf("\n}\n", start);
+  if (end < 0) throw new Error("取不到 `terminateNodeProcess` 的函数边界");
+  return src.slice(start, end);
+}
+
+describe("node stop / rename 的信号文案与实际分支一致", () => {
+  it("取集正控：函数体取到了，且包含它那三个已知常量", () => {
+    const body = terminateBody(CLI);
+    // 分母不是从"我打算扫什么"算的 —— 这三个是独立已知的事实。
+    expect(body).toContain('process.kill(pid, "SIGTERM")');
+    expect(body).toContain("8000");
+    expect(body).toContain("3000");
+    expect(body.length).toBeLessThan(2000); // 取到的是一个函数，不是半个文件
+  });
+
+  it("🔴 没有任何文案在非 force 分支上无条件宣称发过 SIGKILL", () => {
+    // 原缺陷形态：`did not exit after SIGTERM + SIGKILL.` 是死字串。
+    expect(CLI).not.toContain("did not exit after SIGTERM + SIGKILL");
+  });
+
+  it("该文案按 force 分叉，并在没发时明确说出「要 --force 才升级」", () => {
+    expect(CLI).toContain('did not exit after SIGTERM${force ? " + SIGKILL"');
+    expect(CLI).toContain("no SIGKILL — that needs --force");
+  });
+
+  it("两个分支都会说话 —— 8s 宽限走完之后不再静默", () => {
+    const body = terminateBody(CLI);
+    const warns = [...body.matchAll(/console\.warn\(/g)].length;
+    expect(warns).toBe(2); // force 一条、非 force 一条
+    expect(body).toContain("escalating to SIGKILL (--force)");
+    expect(body).toContain("escalation requires --force");
+  });
+
+  it("happy path 仍然安静：SIGTERM 在 8s 内收掉时不打日志", () => {
+    const body = terminateBody(CLI);
+    // 第一个 return true（8000ms 那次）必须出现在第一条 console.warn 之前。
+    const firstReturn = body.indexOf("if (await waitForPidExit(pid, 8000)) return true;");
+    const firstWarn = body.indexOf("console.warn(");
+    expect(firstReturn).toBeGreaterThan(-1);
+    expect(firstWarn).toBeGreaterThan(firstReturn);
+  });
+
+  it("钉住 SIGKILL 仍是 --force 专属（行为没被这次改动带偏）", () => {
+    const body = terminateBody(CLI);
+    const kill = body.indexOf('process.kill(pid, "SIGKILL")');
+    const forceGate = body.indexOf("if (force) {");
+    expect(forceGate).toBeGreaterThan(-1);
+    expect(kill).toBeGreaterThan(forceGate);
+  });
+});


### PR DESCRIPTION
## 缺陷

`terminateNodeProcess(pid, force)`（`agent-network/bin/cli.ts`）的实际行为：

```
SIGTERM → 等 8000ms → if (force) { SIGKILL → 等 3000ms }
```

**SIGKILL 只在 `--force` 时发。** 而 `renameCommand` 的失败文案是死字串：

```
✗ old agent process (pid …) did not exit after SIGTERM + SIGKILL.
```

非 force 路径上这句**是假的**。而同一个文件里 27 行外的注释反而是对的
（`SIGTERM → 8s wait → SIGKILL (--force) → 3s`）——
**错的正是用户会读到的那一份。**

## 它已经误导过一次

8s 宽限走完之后这条路径**完全静默**：等了多久、发没发 SIGKILL、force 是不是 true，
日志里一个都读不到。#1422 里 test225 的诊断行据此写了
「拆卸链这次没跑完就被 SIGKILL 了」—— 那是**推论不是观察**。

## 改动

- 文案按 `force` 分叉；没发 SIGKILL 时明说「要 `--force` 才升级」
- 8s 宽限走完后两个分支各打一条 `console.warn`
- **happy path 保持安静**（SIGTERM 8s 内收掉时不打任何日志）
- 新增 `agent-network/src/node-stop-signal-message-accuracy.test.ts`（6 用例）

🔴 **不改变任何信号行为**：SIGKILL 仍是 `--force` 专属，`8000`/`3000` 原样保留。

## 见证（三向变异，基线 6 pass 0 fail）

| 变异 | 结果 |
|---|---|
| 文案改回旧死字串 | 4 pass **2 fail** |
| 删掉非 force 那条 warn | 5 pass **1 fail** |
| SIGKILL 挪出 force 门 | 5 pass **1 fail** |
| 还原后 `cli.ts` md5 | `4f5ef70d…` 逐字一致 |

## 门

`check-test-suite-registration` / `check-doc-symbol-anchors` /
`check-home-path-baseline` 均 `rc=0`。

## 这条测试证明不了什么

它只钉**源码文本**（文案与分支的对应关系）。`terminateNodeProcess` 未导出，
**只有真跑 CLI 才能验行为** —— 别把它当行为测试，测试文件顶部也写了这句。

Refs #1422