### PR TITLE
docs(cli): 写清 anet node stop 只发 SIGTERM、不会强杀

### DIFF
--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -122,6 +122,13 @@ See [Token model](/en/concepts/tokens) for token types, scopes, and compatibilit
 
 `node delete` does not automatically revoke the node's issued `ntok_`. To invalidate it completely, also run `anet token revoke <token-id>`.
 
+`anet node stop` sends **SIGTERM** only and waits up to **8 seconds**. It never escalates to
+SIGKILL — there is no `--force` on `stop`. If the node has not exited by then, anet prints
+`pid <n> survived SIGTERM`, **keeps the pidfile**, and exits 1: it reports the failure rather
+than claiming the node stopped, because a surviving process keeps heart-beating and would
+revert a rename. For the same reason `node restart` and `node delete` refuse to proceed.
+The only command that sends SIGKILL is `anet node rename --force`.
+
 `COMMHUB_TOKEN` is not a CLI option, and there is no `anet node start --token`. Node authentication resolves in this order: node config, global config, then the legacy `COMMHUB_TOKEN` environment fallback. `anet login --token` logs in the CLI user; it does not inject a temporary node token into `node start`.
 
 Common creation options:

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -122,6 +122,12 @@ Token 类型、作用域与兼容规则见 [Token 体系](/concepts/tokens)。
 
 `node delete` 不会自动撤销该节点已签发的 `ntok_`；需要彻底失效时另行执行 `anet token revoke <token-id>`。
 
+`anet node stop` 只发 **SIGTERM**，最多等 **8 秒**，**不会升级到 SIGKILL**（它没有 `--force`）。
+节点在 8 秒内没退出时，anet 打印 `pid <n> survived SIGTERM`、**保留 pidfile**、退出码 1 ——
+它宁可报错也不谎称已停，因为一个还活着的旧进程会继续心跳并把 rename 顶回去。
+同样的原因，`node restart` 和 `node delete` 这时也会**拒绝执行**。
+唯一会主动发 SIGKILL 的是 `anet node rename --force`。
+
 `COMMHUB_TOKEN` 不是 CLI 参数，也不存在 `anet node start --token`。节点鉴权按节点配置、全局配置、legacy `COMMHUB_TOKEN` 环境变量的顺序取值；`anet login --token` 登录的是 CLI 用户，不是向 `node start` 临时注入节点 token。
 
 创建节点时常用参数：


### PR DESCRIPTION
配套 #1718（那条修的是**文案说反了**，这条补的是**文档里根本没写**）。

## 用户此刻的处境

CLI 参考里 `anet node stop <name>` 只有一行「停止节点及其同名 tmux session」。
节点停不掉时，他看到的是 `pid <n> survived SIGTERM` + 退出码 1，
而**文档里没有任何一句话解释这是什么、下一步该做什么**。

## 补的四件事（都逐行读源码确认过）

| 事实 | 出处 |
|---|---|
| 只发 SIGTERM，最多等 **8 秒** | `terminateNodeProcess` 的 `waitForPidExit(pid, 8000)` |
| **不会升级到 SIGKILL** | `stop` 分支是 `terminateNodeProcess(pid, false)`，写死 false；`node stop` 没有 `--force` |
| 超时 ⇒ 保留 pidfile + 退出码 1；`restart`/`delete` 同时拒绝执行 | #146 R1：活着的旧进程会继续心跳并把 rename 顶回去 |
| 唯一会发 SIGKILL 的是 `anet node rename --force` | 同一函数的 `if (force)` 分支 |

## 为什么原来查不到

仓里唯一描述过信号语义的是 `RFC-027`，但那写的是 **daemon 派发**那条路
（`grace_seconds` 默认 10）——**不是 CLI 这条**。同名不同物，
用户照着读会以为 `stop` 一定会强杀。

## 门

locale-parity / integrity / site-orphans / symbol-anchors / home-path-baseline /
test-suite-registration 均 `rc=0`。zh + en 成对改。

⚠️ 合并后**站点不会自己更新** —— `deploy-anet-sh` 因 `VERCEL_TOKEN` 未配一直在静默跳过，见 #1619。