### PR TITLE
test(win751): 夹具只多活 5s，而检查器愿意等 25s —— 探测慢时它已正常退出

### DIFF
--- a/tests/test751-codex-copresence-windows/fake-codex.mjs
+++ b/tests/test751-codex-copresence-windows/fake-codex.mjs
@@ -125,7 +125,24 @@ if (args[0] === "app-server") {
   // WMI CreationDate and Get-NetTCPConnection snapshots. This applies after
   // both the short probe and the long-turn fixture: completing the synthetic
   // human turn must not make the second client disappear before attestation.
-  await Bun.sleep(5_000);
+  // 🔴 #1342 —— 这个窗口必须**盖住检查器的预算**,不是随手取的 5 秒。
+  //
+  //   检查器(agent-network/bin/cli.ts):
+  //     const TUI_HEALTH_MS = 25_000;
+  //     while (Date.now() < tuiHealthDeadline && tui.exitCode === null) { …probe… }
+  //                                              ↑ TUI 一退出,循环立刻结束
+  //   同一段代码里记着一次实测:**单次探测 9963ms**(占 waited 的 96%)。
+  //
+  //   于是:检查器愿意等 25 秒,而这个夹具原来只多活 5 秒。探测慢的那些跑
+  //   (~10s 一次)还没探完,夹具已经**正常退出**了 —— 检查器看到 exitCode 非 null,
+  //   报「exited (code=0) before it connected」。那句话是**推论**:它其实连上了,
+  //   只是没活到被拍到。快的跑里探测在 5 秒内返回,于是绿 —— 这就是那条 ~8% 的尾巴。
+  //
+  //   窗口取 25s + 5s 余量。改 TUI_HEALTH_MS 时**这里要跟着改**,两个数是一对。
+  const HOLD_MS = 30_000;
+  log(`tui-hold:enter ms=${HOLD_MS} ${new Date().toISOString()}`);
+  await Bun.sleep(HOLD_MS);
+  log(`tui-hold:leave ${new Date().toISOString()}`);
   ws.close();
 } else if (args[0] === "--version") {
   console.log("codex-cli 1.0.0");

--- a/tests/test751-codex-copresence-windows/windows-e2e.mjs
+++ b/tests/test751-codex-copresence-windows/windows-e2e.mjs
@@ -93,7 +93,22 @@ function terminal(args, onData, timeoutMs = 45_000) {
         const rpcDiagnostics = readLog("fake rpc log", rpcLog);
         reject(new Error(`PTY failed (${exitCode}): ${args.join(" ")}${ptyOutput}${diagnostics}${rpcDiagnostics}`));
       }
-      else resolvePromise(output);
+      else {
+        // 🔴 #1342 —— 成功路径上把**耗时那一行**捞出来。
+        //
+        //   cli.ts 已经有意把 probeMs 打在成功路径上(那里的注释写着:「一个只在
+        //   坏的时候说话的仪表,没法告诉你好是不是真的变好了」),但它写在 PTY
+        //   输出里,而 PTY 输出**只在失败时**被 dump —— 于是那half 好意在这里被
+        //   吞掉了:仪表说了话,收集它的人没转述。
+        //
+        //   量成本的数必须两侧都有样本,否则「改完之后变快了没有」永远答不了。
+        for (const line of String(output).split(/\r?\n/)) {
+          if (line.includes("client-health") && line.includes("probeMs")) {
+            console.log(`  [health] ${line.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "").trim()}`);
+          }
+        }
+        resolvePromise(output);
+      }
     });
   });
 }


### PR DESCRIPTION
针对 #1342 那条**把每个 PR 都判红**的 flake。分析见 [issue 评论串](https://github.com/sleep2agi/agent-network/issues/1342#issuecomment-5490845843)。

## 四个数（全部读自仓里现有代码）

| 谁 | 值 | 出处 |
|---|---|---|
| 检查器等待预算 | `25_000ms` | `cli.ts` `TUI_HEALTH_MS` |
| 检查器循环条件 | `… && tui.exitCode === null` | **TUI 一退出立刻结束** |
| 单次探测实测 | **9963ms** | `cli.ts` 里**已经记着**的实测（占 waited 96%） |
| 夹具退出前停留 | **5_000ms** | `fake-codex.mjs` |

⇒ 探测慢的跑（~10s 一次）还没探完，夹具已**正常退出**；检查器看到 `exitCode` 非 null，
报「exited (code=0) before it connected」。

🔴 **那句是推论不是观察** —— 它其实连上了，只是没活到被拍到。
探测快的跑在 5 秒内返回就绿。**这就是 ~8% 的尾巴。**

## 改动

`HOLD_MS` `5_000 → 30_000`（25s 预算 + 5s 余量），把两个数的耦合写进注释；
另加 `enter`/`leave` 两条时间戳，下次红时日志自己能说出是不是这一条。

**代价**：成功路径上每次 TUI 启动多等 ~25s。job 超时 10 分钟，当前该阶段约 32s。

## 🔴 我证伪掉的那个候选（没有写进代码）

上一版我在 issue 里提过「连接 Promise 少一个 `close` 分支 ⇒ Promise 永不 settle ⇒ 退出 0」。
**做了实验，它不成立**：Bun 下 close-before-open **会先触发 `error`**，
经文件顶部的 `unhandledRejection` 退出码是 **1 不是 0**。

所以那个分支**不加** —— 它防的是一条已排除的路径，加上只会得到一个永不触发的分支，
而那种分支和「没写」长得一模一样。

⚠️ 实验在 **Linux / Bun 1.4.0**，CI 是 **Windows**：证据不是证明，边界已在 issue 写明。

## 验收判据（预注册）

- 若本 PR 后该 job 仍红且日志里 **有 `tui-hold:enter` 没有 `leave`** ⇒ 本诊断错，另找。
- 若 **两条都有** 且仍红 ⇒ 夹具活够了，问题在探测侧（`probeWindowsOwnedLoopbackConnection`）。

Refs #1342