### PR TITLE
fix(daemon): 权限闸建议 chmod go-w，但下次 npm install -g 会原样改回去

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -303,11 +303,23 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env, platf
       );
     }
     // ④ not group/other writable
+    //
+    // 🔴 #1353 —— `chmod go-w` 修的是**结果**,不是原因。若这个二进制是 npm 装的,
+    //    它的权限由**安装时那个 shell 的 umask** 决定:npm 以 0777/0666 建文件再由
+    //    umask 掩掉,所以 `umask 0002` 恒得 775/664(实测:775 的可执行 + 664 的
+    //    package.json 就是这一对的指纹),而 775 & 0o022 !== 0 必然落到这里。
+    //    ⇒ chmod 之后**下一次 `npm install -g` 会原样改回去**。持久修法是让安装
+    //    发生在 `umask 0022` 下。两条都给,让读的人知道自己在选哪一种。
     if ((st.mode & 0o022) !== 0) {
       const before = (st.mode & 0o777).toString(8);
+      const groupWritable = (st.mode & 0o020) !== 0;
       throw unsafePathHelp("anet_bin_permission",
         `writable by group/other (mode=${before})`,
-        `chmod go-w ${quoteSh(pin.abs)}`,
+        `chmod go-w ${quoteSh(pin.abs)}` +
+        (groupWritable
+          ? `   # 立即可用,但若它是 npm 装的,下次 \`npm install -g\` 会按安装时的 umask 改回去;` +
+            ` 持久修法是在 \`umask 0022\` 下重装(见 #1353)`
+          : ""),
       );
     }
     // ⑤ executable

--- a/agent-node/src/runtime/daemon-bin-permission-hint.test.ts
+++ b/agent-node/src/runtime/daemon-bin-permission-hint.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1353 —— 那条闸原来的建议只有 `chmod go-w <abs>`。它**立即可用，但不持久**：
+// 若该二进制是 npm 装的，权限由**安装时那个 shell 的 umask** 决定（npm 以 0777/0666
+// 建文件再由 umask 掩掉），`umask 0002` 恒得 775/664 —— 2026-09-01 实测：
+//
+//     umask 0002 → 可执行 775  普通 664     ← 与生产实际逐字相同
+//     umask 0022 → 可执行 755  普通 644     ← 755 & 0o022 === 0，过闸
+//
+// 而 775 & 0o022 !== 0 必然落到这条闸。⇒ chmod 之后**下一次 `npm install -g`
+// 会原样改回去**。#1353 正文记着这个坑「历史上已经把人误导过两次」。
+//
+// 🔴 本测试只钉**源码文本**（建议里同时给出即时修法和持久修法），
+//    它不执行那条闸 —— 触发它需要一个真实的 group-writable anet 安装。
+
+const SRC = readFileSync(
+  join(import.meta.dir, "create-node-daemon.ts"),
+  "utf-8",
+);
+// 源码里既有「东西」也有「关于它的注释」——去掉注释行再判，否则会命中说明文字。
+const CODE = SRC.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+describe("#1353 group/other 可写这条闸的建议既要能立即用，也要说清它会回退", () => {
+  it("取集正控：这条闸还在，且判据仍是 mode & 0o022", () => {
+    expect(CODE).toContain("writable by group/other");
+    expect(CODE).toContain("(st.mode & 0o022) !== 0");
+  });
+
+  it("仍然给出立即可用的 chmod（不要为了讲道理把可执行的那条删掉）", () => {
+    expect(CODE).toContain("chmod go-w ");
+  });
+
+  it("🔴 同时点名持久修法 umask 0022，并说明 chmod 会被重装改回去", () => {
+    expect(CODE).toContain("umask 0022");
+    expect(CODE).toContain("npm install -g");
+  });
+
+  it("只在 group 可写时追加那段说明（other-only 可写与 umask 无关）", () => {
+    // umask 0002 的指纹是 group 位;仅 other 可写是另一回事,不该被塞同一段解释。
+    expect(CODE).toContain("(st.mode & 0o020) !== 0");
+  });
+
+  it("指向 issue，让读的人能查到那两组实测数字", () => {
+    expect(CODE).toContain("#1353");
+  });
+});


### PR DESCRIPTION
承接 #1353 的实测（[评论](https://github.com/sleep2agi/agent-network/issues/1353#issuecomment-5490992335)）。

## 问题

第 ④ 条闸（group/other 可写）给的建议是 `chmod go-w <abs>` —— **立即可用，但不持久**。

npm 以 `0777`/`0666` 建文件、由**安装时那个 shell 的 umask** 掩掉。实测：

| umask | 可执行 | 普通文件 |
|---|---|---|
| `0002` | **775** | **664** | ← 与本机生产安装**逐字相同** |
| `0022` | 755 | 644 | ← `755 & 0o022 === 0`，过闸 |

`775 & 0o022 !== 0` ⇒ **必然**落到这条闸。
⇒ **chmod 修的是结果，umask 才是原因**；chmod 之后下一次 `npm install -g` 改回去。

#1353 正文记着这个坑「历史上已经把人误导过两次」，#1298 记过同一族。

## 改动

建议里在 chmod 之后追加一句：说明它会被重装改回去，持久修法是在 `umask 0022` 下重装。
**两条都给**，让读的人知道自己在选哪一种。

只在 **group 可写**时追加（`st.mode & 0o020`）——仅 other 可写与 umask 无关，
不该被塞进同一段解释。

🔴 **不改任何判定逻辑**：闸的判据仍是 `(st.mode & 0o022) !== 0`。

## 见证（三向变异，基线 5 pass 0 fail）

| 变异 | 结果 |
|---|---|
| 去掉 umask 那段（回到只有 chmod） | 2 pass **3 fail** |
| 删掉 chmod 那条（只讲道理不给命令） | 4 pass **1 fail** |
| 判据 `0o022` 改坏 | 4 pass **1 fail** |
| 还原后 md5 | 逐字一致 |

## 它证明不了什么

测试只钉**源码文本**，不执行那条闸 —— 触发它需要一个真实的 group-writable anet 安装。

Refs #1353