### PR TITLE
chore(deps): 仓里的 dev lockfile 把 linkify-it 钉在 5.0.1，公告要求 ≥5.0.2

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -2510,9 +2510,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
承接 #893。

## 我上一条只量了两棵树中的一棵

#893 里我写「`linkify-it` 装到 `5.0.2`、要求 `≥5.0.2`，零余量」。
**那句说的是用户装到的生产树。** 今天量了另一棵：

| 对象 | linkify-it | |
|---|---|---|
| 仓里 `agent-network/package-lock.json`（dev 树） | **5.0.1** | 🔴 在门槛**之下** |
| 用户实际安装（`npm i --omit=dev` 解析 `@latest`） | 5.0.2 | 刚好在门槛上 |

**同名不同物** —— #893 正文本来就区分了这两棵树，而我只量了其中一棵就下了结论。

## 改动范围（逐包比对 lock，不是看 diff 行数）

```
版本变化的包数 = 1
  node_modules/linkify-it: 5.0.1 -> 5.0.2
```

`git diff --stat` = 3 insertions / 3 deletions，**无连带升级**。
`markdown-it@14.3.1` 声明 `^5.0.1`，5.0.2 满足，不动 markdown-it。

## 门

`check-action-pins` / `check-bun-install-pin` / `check-copresence-profile-pin` /
`check-test-suite-registration` / `check-home-path-baseline` 均 `rc=0`。

## 🔴 它没有解决的

**仍然零余量**：上游 5.x 线最高就是 `5.0.2`（再往上是 `6.0.0`/`6.1.0`，major）。
这条只是把仓里那棵树**补到门槛上**，不是给它留空间 —— 任何把它拉回 `5.0.1`
的改动仍会真实中招。要有余量得等 markdown-it 支持 6.x。

Refs #893