### PR TITLE
feat(cli): anet daemon list 的「locally」其实是「当前目录」—— 把它扫的目录打出来

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8709,12 +8709,21 @@ async function daemonListCommand() {
   const daemons = ids
     .map(id => ({ id, profile: loadProfile(id) }))
     .filter(({ profile }) => profile && profile.role === "host_supervisor");
+  // #1722 —— 这条命令的「locally」指的是**当前目录**,不是这台机器:
+  // `listProfileIds()` 读的是 `nodesDir()` = `join(process.cwd(), ".anet", "nodes")`。
+  // 在别的目录跑,同一台机器上的 daemon 就一个都看不见 —— 而原来的输出里
+  // 没有任何东西说得出这一点,读的人会以为「这台机器上没有 daemon」。
+  // 🔴 "No host_supervisor daemons" 这个子串被 tests/qa-anet-daemon-cmd/run.sh
+  //    钉着,只能在其后追加行,不能改它。
   if (daemons.length === 0) {
     console.log("No host_supervisor daemons configured locally.");
+    console.log(`  scanned: ${nodesDir()}`);
+    console.log("  (节点配置按目录存放 —— 换个目录跑，看到的是另一份清单)");
     console.log("Create one: anet daemon init <name>");
     return;
   }
   console.log(`Local host_supervisor daemons (${daemons.length}):`);
+  console.log(`  scanned: ${nodesDir()}`);
 
   // #1545 —— 除了"本机配了哪些 daemon",还要说出**它们现在能不能建节点**。
   //

--- a/agent-network/src/daemon-list-scope-visibility.test.ts
+++ b/agent-network/src/daemon-list-scope-visibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1722 —— `anet daemon list` 的 "locally" 指的是**当前目录**,不是这台机器:
+//   listProfileIds() 读 nodesDir() = join(process.cwd(), ".anet", "nodes")
+// 在别的目录跑,同机的 daemon 一个都看不见,而原来的输出里没有任何东西
+// 说得出这一点 —— 读的人会得出「这台机器上没有 daemon」这个更强的结论。
+//
+// 🔴 "No host_supervisor daemons" 这个子串被 tests/qa-anet-daemon-cmd/run.sh
+//    用 grep -q 钉着。本测试同时钉住「它还在」和「后面补了目录」,
+//    这样以后谁想改文案,两边会一起红,而不是悄悄破坏那个 QA 套件。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+// 源码里既有「东西」也有「关于它的注释」——判之前去掉注释行。
+const CODE = CLI.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+
+describe("#1722 daemon list 要说清它扫的是哪个目录", () => {
+  it("取集正控：daemonListCommand 还在，且仍从 listProfileIds 取集", () => {
+    expect(CODE).toContain("async function daemonListCommand()");
+    expect(CODE).toContain("listProfileIds()");
+  });
+
+  it("🔴 QA 套件钉着的子串没有被改掉", () => {
+    // tests/qa-anet-daemon-cmd/run.sh 用 grep -q "No host_supervisor daemons"
+    expect(CODE).toContain("No host_supervisor daemons");
+  });
+
+  it("空清单和非空清单都打印扫描目录", () => {
+    const n = [...CODE.matchAll(/scanned: \$\{nodesDir\(\)\}/g)].length;
+    expect(n).toBe(2); // 两个分支各一处
+  });
+
+  it("并且说明「按目录存放」——否则用户不知道换个目录会看到别的清单", () => {
+    expect(CODE).toContain("节点配置按目录存放");
+  });
+
+  it("nodesDir 仍然是 cwd 相对的（这条结论的前提）", () => {
+    expect(CODE).toContain('join(process.cwd(), ".anet", "nodes")');
+  });
+});


### PR DESCRIPTION
承接 #1722 的**第 2 档建议**（三档里最便宜、且不foreclose另外两档）。

## 问题

`daemonListCommand` 用 `listProfileIds()` 取集，而那读的是

```ts
nodesDir() = join(process.cwd(), ".anet", "nodes")
```

⇒ **换个目录跑，同一台机器上的 daemon 一个都看不见。**
而原来的输出只有一句 `No host_supervisor daemons configured locally.` ——
读的人会从「我这儿没有」得出「**这台机器上**没有」，一个比观察到的更强的结论。

（这是今晚同一形状的第五处：一句自信的文案，断言了它观察不到的事。）

## 改动

两个分支各打一行 `scanned: <目录>`；空清单那支再补一句
「节点配置按目录存放 —— 换个目录跑，看到的是另一份清单」。

🔴 **不改判定逻辑、不改取集。**

## 兼容性（先查了才动）

`"No host_supervisor daemons"` 这个子串被 `tests/qa-anet-daemon-cmd/run.sh`
用 `grep -q` 钉着 ⇒ 只在其后**追加行**，一个字都没动它。
新测试把「它还在」和「后面补了目录」**一起**钉住，以后谁改文案两边同时红，
而不是悄悄破坏那个 QA 套件。

## 见证（三向变异，基线 5 pass 0 fail）

| 变异 | 结果 |
|---|---|
| 删掉空清单那支的 `scanned` 行 | 3 pass **2 fail** |
| 改掉 QA 钉着的子串 | 4 pass **1 fail** |
| `nodesDir` 改成 home 相对（推翻前提） | 4 pass **1 fail** |
| 还原后 `cli.ts` md5 | 逐字一致 |

## 门

`check-test-suite-registration` / `check-home-path-baseline` /
`check-doc-symbol-anchors` 均 `rc=0`；#1716 的 daemon 帮助反推门 **6 pass 0 fail**。

Refs #1722