### PR TITLE
docs(cli): daemon init 的注释还写着 #1298 之前的三元组

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8281,14 +8281,16 @@ Example:
 //   - profile exists with different/no role → REFUSE unless --force
 //   - profile absent → mint ntok + write config + log next step
 //
-// Defaults (matching RFC-026 §9.3 daemon-self-declare scaffolding —
-// PR3 will land the schema for `runtimes_supported` / `allowed_secret_keys`
-// to be reported via report_status; we already write the fields so
-// the daemon ships ready for the next PR's hub-side wiring):
+// Defaults (RFC-026 §9.3 daemon-self-declare):
 //   role: "host_supervisor"
 //   runtime: "claude-agent-sdk"  (lightest, just the SSE doorbell loop)
-//   runtimes_supported: [claude-agent-sdk, codex-sdk, grok-build-acp]
-//     (declares; PR3 daemon-side fail-fast catches binary-missing at spawn)
+//   runtimes_supported: [...SUPPORTED_RUNTIME_NAMES]
+//     🔴 不要在这里重抄那个列表。#1298 之前它是硬编码的三元组,于是
+//     grok-build-cli / codex-app-server / opencode-cli 三个共存 runtime
+//     永远不出现在 daemon 的能力声明里,hub 据此把 create_node 拒掉。
+//     唯一真源是 agent-network/src/normalize-runtime.ts 的
+//     SUPPORTED_RUNTIME_NAMES —— 抄一份在注释里,它就会再漂一次。
+//     (声明 ≠ 真能跑;daemon 侧 spawn 时 fail-fast 兜住 binary-missing。)
 //   allowed_secret_keys: []
 //     (fail-closed; operator adds via `anet daemon init --allow-secret KEY`
 //     or by hand-editing — strict-by-default per RFC-026 §9.7)


### PR DESCRIPTION
## 注释与代码不一致

`agent-network/bin/cli.ts` 的 `anet daemon init` 「Defaults」注释：

```
runtimes_supported: [claude-agent-sdk, codex-sdk, grok-build-acp]
```

27 行之外的**代码**：

```ts
runtimes_supported: [...SUPPORTED_RUNTIME_NAMES]     // 7 个
```

同段还有两处未来时（「PR3 **will land**」「the **next PR's** hub-side wiring」），
而那个 next PR 就是 #1298 / #1376，**早已合并**。

## 它落在排查路径上

今天有人问「为什么某台 daemon 只声明 3 种 runtime、界面上选不到共存 TUI」。
读这段注释会得出「`daemon init` 现在就写 3 种」—— 错的。
真相是那台 daemon **建于 #1298 之前**。我自己差点据此报一个假缺陷。

## 改法：删掉重抄的列表，不是把 3 改成 7

再抄一遍 7 个，加第 8 个 runtime 时**还会漂**。改成指向唯一真源
（`agent-network/src/normalize-runtime.ts` 的 `SUPPORTED_RUNTIME_NAMES`），
并把「当初为什么错」留在原地：#1298 之前的硬编码三元组让
`grok-build-cli` / `codex-app-server` / `opencode-cli` 永不出现在能力声明里，
hub 据此拒掉 `create_node`。

## 只改注释

`git diff` 过滤掉 `+++/---` 与 `//` 开头的行后 **剩 0 行** —— 零行为风险。

行号 pin 类的门本地全跑过：`check-doc-source-pins` / `check-doc-symbol-pins` /
`check-doc-symbol-anchors` / `check-doc-claims` 均 `rc=0`
（我的改动让该文件 8290 行之后行号 +4，所以这一步是必须的）。