### PR TITLE
test(qa): L1 收尾的 wait 循环不说它在等谁 —— 挂住时只能靠事后 diff 日志去猜

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -533,6 +533,14 @@ if [[ $RUN_L1 -eq 1 ]]; then
   for pid in "${pids[@]}"; do
     t="${pid_to_test[$pid]}"
     _w=$(_l1_window "$t")
+    # 🔴 #1593 —— 这一行只在「wait 挂住」时才有用,而那正是它存在的理由。
+    #    实测两次(run 33486670271,同一 PR 连续两次):所有套件都打完
+    #    `· L1 done … rc=0`,随后这个循环静默 15 分钟,直到 30 分钟守卫把 job 掐死,
+    #    runner 收尾时打出 `Terminate orphan process: pid (bash)/(docker)` ——
+    #    也就是说**有子进程不退出,而 wait 在等它**。当时日志里没有任何东西
+    #    说得出「在等谁」,只能靠事后 diff 两份 30 分钟的日志去猜。
+    #    打出正在等的那个套件名,下次红的时候第一行就能看见。
+    printf '· L1 wait %s\n' "$t"
     if wait "$pid"; then
       ok "L1 $t ($(tail -1 /tmp/qa-l1-$t-run.log))${_w:+ [$_w]}"
     else


### PR DESCRIPTION
承接 #1593 的取证。**只加一行可执行语句，不改 `wait` 的语义。**

## 今天为了得到「挂在哪个套件」，我做了什么

`#1724` 的 `L0 + L1` 连续两次跑到 30 分钟被守卫掐死（`conclusion=cancelled`）。
日志里：`ALL PASS`=1、`L1-TIMING`=**0**、`failed to solve`=0，
末尾 `Terminate orphan process: pid (bash)/(docker)`。

定位过程（三步，每步可复核）：

1. 两次都是 `✓ L1 = 9`、`· L1 done = 69`，**逐字相同**
   （`done` 由子进程自己打；`✓` 由收尾的 wait 循环打）
   ⇒ 69 个套件都跑完了，wait 循环只推进到第 9 个
2. 那 9 个 `✓` 的顺序与 `L1_TESTS` 前 9 项逐字一致 ⇒ pids 顺序 == 数组顺序
3. 数组第 10 项 = **`test225-node-stop-convergence`**

⇒ 它 `done` 了但**进程没退**，`wait "$pid"` 停在它上面。

**这一整套推导，如果 wait 之前有一行「我在等谁」，只需要看一眼。**

## 改动

```bash
printf '· L1 wait %s\n' "$t"     # 放在 if wait "$pid"; then 之前
```

- 新增**非注释可执行行 1 行**，删除 **0** 行，`bash -n` 通过
- 用新前缀 `· L1 wait`，不复用 `✓ L1` / `· L1 done`，避免破坏别处对现有前缀的 grep
- 放在 `if` **之前独立一行**，不碰判定、不影响退出码

## 🔴 没有做的

**没有改 `wait` 的语义** —— 不加超时、不清容器。那会改变所有人的 CI 行为，
应由维护者决定。本条只让红能自我描述。

（顺带：`test225-node-stop-convergence/run.sh` 里有 `trap '' TERM INT` 和三个后台 python
（其一名为 `zombie.pid`）—— 它本来就是故意制造残留来测收敛的。为什么这次没收干净，
我没有查，也没有改它。）

Refs #1593