### PR TITLE
fix(daemon): 存量 daemon 的 runtime 清单不会自愈，而且没有任何东西说得出这件事

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2170,6 +2170,7 @@ import {
   type ReusedLogin,
   type RuntimeName,
 } from "../src/normalize-runtime";
+import { describeStaleRuntimeSupport } from "../src/daemon-runtime-staleness";
 import { findEnvironAliasMatches } from "../src/environ-alias";
 import { describeGrokBuildDrift, parseGrokBuildFromLog, parseGrokBuildFromVersionOutput } from "../src/grok-build-drift";
 export { normalizeRuntime, type RuntimeName };
@@ -8741,6 +8742,15 @@ async function daemonListCommand() {
     const nid = (profile as any)?.node_id || "(missing)";
     const runtimes = ((profile as any)?.runtimes_supported || []).join(",") || "(default)";
     console.log(`  ${padDisplayEnd(id, 24)} node_id=${nid}  runtimes=[${runtimes}]`);
+    // #1298 只改了**写入**路径：在它之前 init 的 daemon，配置里仍是旧的三元组，
+    // 而在此之前没有任何东西说得出这件事 —— 用户在客户端「选服务器」里看到
+    // 某台机器少几个 runtime，既不知道为什么，也不知道该做什么。
+    const staleHint = describeStaleRuntimeSupport(
+      (profile as any)?.runtimes_supported,
+      SUPPORTED_RUNTIME_NAMES,
+      id,
+    );
+    if (staleHint) console.log(`    ${staleHint}`);
     console.log(`    ${daemonCreateCapabilityLine(nid, fetched, Date.now())}`);
   }
 }

--- a/agent-network/src/daemon-runtime-staleness.test.ts
+++ b/agent-network/src/daemon-runtime-staleness.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { describeStaleRuntimeSupport } from "./daemon-runtime-staleness";
+import { SUPPORTED_RUNTIME_NAMES } from "./normalize-runtime";
+
+const ALL = [...SUPPORTED_RUNTIME_NAMES];
+
+describe("describeStaleRuntimeSupport", () => {
+  test("声明了全集 → 不报", () => {
+    expect(describeStaleRuntimeSupport(ALL, ALL)).toBeNull();
+  });
+
+  test("🔴 #1298 之前写的那三个 → 报，且点名缺的是谁", () => {
+    const old = ["claude-agent-sdk", "codex-sdk", "grok-build-acp"];
+    const msg = describeStaleRuntimeSupport(old, ALL);
+    expect(msg).not.toBeNull();
+    for (const r of ALL.filter((x) => !old.includes(x))) {
+      expect(msg).toContain(r);
+    }
+    // 已有的那三个不该出现在「缺」的名单里
+    expect(msg).toContain(`少 ${ALL.length - old.length} 个`);
+  });
+
+  test("没声明（undefined / 空数组）→ 不报：那是「用默认」，不是「少了」", () => {
+    expect(describeStaleRuntimeSupport(undefined, ALL)).toBeNull();
+    expect(describeStaleRuntimeSupport([], ALL)).toBeNull();
+    expect(describeStaleRuntimeSupport(null, ALL)).toBeNull();
+  });
+
+  test("声明里有支持集之外的名字 → 不影响判定（只看「缺不缺」）", () => {
+    expect(describeStaleRuntimeSupport([...ALL, "some-future-runtime"], ALL)).toBeNull();
+  });
+
+  test("判据取自 SUPPORTED_RUNTIME_NAMES 而非写死的数字", () => {
+    // 反推：拿一个人造的支持集，缺口数必须跟着它变，而不是固定 4
+    const msg = describeStaleRuntimeSupport(["a"], ["a", "b", "c"]);
+    expect(msg).toContain("少 2 个");
+    expect(msg).toContain("b, c");
+  });
+});
+
+describe("建议动作的后果必须写在文案里（#1298 存量 daemon）", () => {
+  test("🔴 提示里必须同时出现 --force、token 重新签发、要重启", () => {
+    const msg = describeStaleRuntimeSupport(["claude-agent-sdk"], ALL, "daemon-vanisn")!;
+    expect(msg).toContain("--force");
+    expect(msg).toContain("重新签发 token");
+    expect(msg).toContain("重启");
+  });
+
+  test("🔴 daemon 名要出现在命令里，用户能直接复制（不是 <name> 占位）", () => {
+    const msg = describeStaleRuntimeSupport(["claude-agent-sdk"], ALL, "daemon-vanisn")!;
+    expect(msg).toContain("anet daemon init daemon-vanisn --force");
+    expect(msg).not.toContain("<name>");
+  });
+
+  test("不传名字时退回占位符（不编一个假名字）", () => {
+    const msg = describeStaleRuntimeSupport(["claude-agent-sdk"], ALL)!;
+    expect(msg).toContain("anet daemon init <name> --force");
+  });
+});

--- a/agent-network/src/daemon-runtime-staleness.ts
+++ b/agent-network/src/daemon-runtime-staleness.ts
@@ -1,0 +1,35 @@
+/**
+ * daemon 的 `runtimes_supported` 是**写配置那一刻**的支持集快照，之后不会自愈。
+ *
+ * 🔴 这不是假想的：#1298 (2026-08-28) 把新建 daemon 的默认清单从 3 个放开到
+ *    `SUPPORTED_RUNTIME_NAMES` 全体，但**它只改了写入路径**。在那之前 init 过的
+ *    daemon，配置里仍然只有那 3 个，而且没有任何东西会说出这件事 ——
+ *    用户在客户端「选服务器」里看到某台机器少几个 runtime，
+ *    既不知道为什么，也不知道该做什么。
+ *
+ * 判据从**分发处**取（`SUPPORTED_RUNTIME_NAMES`），不在这里手写一份清单：
+ * 抄一份就意味着它会再漂一次（同 #1728 的教训）。
+ */
+export function describeStaleRuntimeSupport(
+  declared: readonly string[] | undefined | null,
+  supported: readonly string[],
+  nameHint = "<name>",
+): string | null {
+  // 没声明 = 用默认，语义与「声明了但少几个」完全不同，不在这里报。
+  if (!Array.isArray(declared) || declared.length === 0) return null;
+  const have = new Set(declared);
+  const missing = supported.filter((r) => !have.has(r));
+  if (missing.length === 0) return null;
+  // 🔴 建议动作的**后果**要一起说，否则用户照做会撞上一个没预告的变化：
+  //    `daemon init` 对已存在的 daemon,不带 --force 时**早退什么都不做**
+  //    (cli.ts 的 `existing.role === "host_supervisor" && !opts.force` 分支,
+  //     它还会打一个绿色 ✓ —— 一个什么都没做的成功)。
+  //    带 --force 才会重写配置;而 --force 路径**无条件重新签发 token**
+  //    (node_id 由 preservedNodeId 保留,不变)。
+  return (
+    `⚠ 这份配置声明的 runtime 少 ${missing.length} 个（缺 ${missing.join(", ")}）—— ` +
+    `多半是旧版本 init 写的，之后新增的 runtime 不会自动补进来。\n` +
+    `      回填：anet daemon init ${nameHint} --force` +
+    `（保留 node_id，但会重新签发 token；改完要重启该 daemon 才生效）`
+  );
+}

--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -266,6 +266,18 @@ The following commands exist in the current preview and must not be presented as
 (`anet daemon list` only lists locally configured daemons and carries no liveness).
 `anet daemon restart` calls that same stop internally.
 
+::: warning Two counter-intuitive things about daemons
+**1. On an existing daemon, `anet daemon init <name>` changes nothing.** It prints
+`✓ "<name>" already a host_supervisor daemon` and returns — a green check mark with
+not one byte written. Changing the config requires `--force` (keeps `node_id`, but
+**re-mints the token**, and the daemon must be restarted for it to take effect).
+
+**2. The runtime list in the config is a write-time snapshot; it does not self-heal.**
+Runtimes added later are not back-filled into existing daemon configs, which shows up
+as that machine offering fewer runtimes in the client's server picker. `anet daemon list`
+now prints which ones are missing and the command to back-fill.
+:::
+
 `--copresence` only applies to `runtime=codex-app-server`. Its default sandbox is read-only. Full filesystem and network access requires `--dangerously-allow-full-access`; a TTY requires typing `yes`, and a non-TTY caller must also pass `--yes-danger-full-access`.
 
 Resume a co-presence node with `anet node start <name> --copresence`; do not replace it with a normal `node start`.

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -261,6 +261,17 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 `anet node ls` 看它在不在跑(`anet daemon list` 只列本机配置过的 daemon,不含活性)。
 `anet daemon restart` 内部调的正是 `anet node stop` 用的那个 stop。
 
+::: warning daemon 的两个反直觉之处
+**① 对已存在的 daemon，`anet daemon init <name>` 什么都不改。** 它打印
+`✓ "<name>" already a host_supervisor daemon` 后直接返回 —— 一个绿色的对勾，
+配置一个字节没动。要改配置必须带 `--force`（保留 `node_id`，但**会重新签发
+token**，且改完要重启该 daemon 才生效）。
+
+**② 配置里的 runtime 清单是写入那一刻的快照，不会自愈。** 之后新增的 runtime
+不会补进已有 daemon 的配置，表现为客户端「选服务器」里那台机器可选的 runtime
+比别人少。`anet daemon list` 发现这种情况时会直接打出缺哪几个和回填命令。
+:::
+
 `--copresence` 只适用于 `runtime=codex-app-server`。默认沙箱为只读；开启完整文件系统和网络访问需要 `--dangerously-allow-full-access`。TTY 会要求输入 `yes`，非 TTY 还必须同时提供 `--yes-danger-full-access`。
 
 恢复共存节点时仍应使用 `anet node start <name> --copresence`，不能改用普通 `node start`。


### PR DESCRIPTION
#1298 (2026-08-28) 把新建 daemon 的默认 runtime 清单从硬编码的三元组放开成
`[...SUPPORTED_RUNTIME_NAMES]`（7 个）—— 但它**只改了写入路径**。

在那之前 init 过的 daemon，配置里仍然只有那三个，且：

- `anet daemon list` 会照实打出 `runtimes=[claude-agent-sdk,codex-sdk,grok-build-acp]`，
  但**不与当前支持集比较** —— 全仓 0 处做这个比较（已 grep 确认）。
- 用户在客户端「选服务器」里看到某台机器少几个 runtime，
  **既不知道为什么，也不知道该做什么**。
- 🔴 而裸 `anet daemon init <已存在的 daemon>` 会打印
  `✓ "<id>" already a host_supervisor daemon` 然后 **early-return** ——
  一个绿色的对勾，配置一个字节都没改。想回填必须带 `--force`。

## 改动

`describeStaleRuntimeSupport(declared, supported, nameHint)`：声明集是当前
支持集的真子集时，返回一行说人话的提示；`daemon list` 每台 daemon 打一行。

判据从**分发处**取 —— `supported` 由调用方传入 `SUPPORTED_RUNTIME_NAMES`，
模块里不抄一份清单。抄一份就意味着它会再漂一次（#1728 的教训）。

## 建议动作的**后果**一起说，并钉成测试

`--force` 路径无条件 `requestNodeToken` ⇒ **token 会被重新签发**
（`node_id` 由 `preservedNodeId` 保留，不变），且改完要重启 daemon 才生效。
提示里把这两点写出来，并有测试钉住「`--force` / 重新签发 token / 重启」
三个词都在 —— 后人改写文案时若删掉后果那段，测试会红。

## 语义边界

「没声明」（`undefined` / `[]` / `null`）**不报** —— 那是「用默认」，
与「声明了但少几个」是两件事。三种空值形态各一条测试。

## 验证

- 新单测 8 pass / 0 fail（含一条**反推**用例：拿人造支持集 `[a,b,c]` 验
  「少 2 个 / b, c」；若把数字写死成 4，这条会红）
- 与 cli.ts 相关的 6 道门本地跑过：4 道 rc=0；
  `check-published-build-paths.py` rc=2 是我没给参数（usage 错误，非判定失败）；
  `check-agent-node-typecheck-ratchet.py` 明说「没装 node_modules ⇒ fail closed」，
  且它管的是 agent-node，本 PR 未触及。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>