### PR TITLE
chore(qa): 让 L1 的 build 自己报耗时 —— 现在这个数只能靠相邻日志行的时间差去推

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -447,11 +447,20 @@ note "L1 单套件 wait 超时 = ${L1_WAIT_TIMEOUT}s(用 L1_WAIT_TIMEOUT 覆盖)
       _qa_blob="$(git rev-parse "HEAD:tests/$t/run.sh" 2>/dev/null || true)"
       [ -n "$_qa_blob" ] && build_args="$build_args --build-arg RUNSH_BLOB=$_qa_blob"
     fi
+    # 🔴 #1593 —— build 的耗时必须**自己报**,不能靠相邻 note 行的时间差去推。
+    #    2026-09-01 整晚我都在用「相邻 `build` 行的间隔」当作单个套件的 build 耗时,
+    #    那个数把 build **和它后面那段发射/等待逻辑**混在一起 —— 够用来分「今天整体慢没慢」
+    #    (绿 11.9-12.3s vs 撞守卫 25.2-29.0s,两簇分得很开),但**答不了「慢在谁身上」**。
+    #    当晚 9 次 L0+L1 里 5 次撞 30 分钟守卫、152 分钟零产出(74%),
+    #    而唯一能下钻的量都还是推出来的。加这一行,下次就是读数不是推算。
+    _b0=$SECONDS
     if ! dockerrun "docker build -q $build_args -t anet-$t -f tests/$t/Dockerfile ." >/tmp/qa-l1-$t-build.log 2>&1; then
+      printf '· build fail %s  [%ss]\n' "$t" "$(( SECONDS - _b0 ))"
       fail "L1 $t — build failed, see /tmp/qa-l1-$t-build.log"
       FAILED=$((FAILED+1))
       continue
     fi
+    printf '· build done %s  [%ss]\n' "$t" "$(( SECONDS - _b0 ))"
     # Run in background —— 但要有并发上限。
     #
     # 原来这里是无节制后台化:L1_TESTS 有多少条,就同时拉起多少个容器。


### PR DESCRIPTION
## 为什么

2026-09-01 整晚排查 `#1593`（`L0 + L1` 反复撞 30 分钟守卫）时，
我唯一能用来下钻的量是**相邻 `build` note 行的时间差**。

那个数把 build **和它后面那段发射逻辑**混在一起。它够用来分"今天整体慢没慢"——
绿跑三次 avg 是 **11.9 / 12.1 / 12.3s**（极差 0.4s），撞守卫的两次是 **25.2 / 29.0s**，
两簇分得很开 —— 但它**答不了"慢在谁身上"**，因为每个数都不是纯 build。

当晚 9 次 `L0 + L1`：**5 次撞守卫、152 分钟零产出（74%）**。
一次失败 30.4 分钟 vs 一次成功 14.0 分钟，贵 2.2 倍，且失败时**那一轮所有套件的结果一起丢失**。
在这个成本下，"能下钻的量还是推出来的"是说不过去的。

## 改动

`docker build` 前后取 `SECONDS`，成功/失败**两条路径都打**：

```
· build done <suite>  [Ns]
· build fail <suite>  [Ns]
```

9 行，无新依赖（`SECONDS` 是 bash 内建）。

## 与既有断言的相容性（实测，非推断）

`test823-l1-concurrency-cap` 跑的是**真的 `qa.sh --l1`**，它有三条 sed 断言：

```
:124  L1 并发上限 = \([0-9]*\)          ← 不同文本
:161  · L1 done .* rc=\([0-9]*\)        ← 我的既非 "L1 done" 也无 rc=
:166  同上
```

**三条都不与新行冲突。**

`bash -n` rc=0；test-suite-registration / docs-integrity / doc-symbol-anchors /
qa-trigger-coverage 四道门本地 rc=0。

Refs #1593

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>