### PR TITLE
fix(qa): 看门狗别留孤儿 —— 我在 #1732 引入的写法每跑一次泄漏 70 个 sleep

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -567,7 +567,29 @@ note "L1 单套件 wait 超时 = ${L1_WAIT_TIMEOUT}s(用 L1_WAIT_TIMEOUT 覆盖)
     #    **仍然返回成功** ⇒ 轮询版会让每个套件都白等满 300s,把 14 分钟变成几小时。
     #    而那个失效**在本地测不出来**(本地跑得快,僵尸窗口极短),只会在 CI 上
     #    表现成"又打满守卫"——与它本要修的症状一模一样。
-    ( sleep "$L1_WAIT_TIMEOUT"; kill -9 "$pid" 2>/dev/null ) & _l1_wd=$!
+    # 🔴 2026-09-01 修我自己在 #1732 引入的泄漏:原写法是
+    #        ( sleep "$L1_WAIT_TIMEOUT"; kill -9 "$pid" ) & _l1_wd=$!
+    #    收尾 `kill "$_l1_wd"` 杀的是**子 shell**,而它阻塞在 sleep 上时
+    #    那个 sleep 会被孤儿化 —— 实测:改动前 `Terminate orphan process` = 0,
+    #    改动后 = **70**(= L1 套件数),全是 `(sleep)`,日志从 55K 涨到 352K。
+    #    它不会让任何 job 变红,所以只能靠对比两份日志才看得见。
+    #
+    #    换成「标志文件 + 短 sleep 循环」:收尾 `rm -f` 之后看门狗 1 秒内自退,
+    #    残留的 `sleep 1` 也会自己结束。本地两向见证(基线 6 个 sleep):
+    #      快任务 rc=0   残留回到 6      ← 不误杀、不泄漏
+    #      慢任务 rc=137 耗时=阈值 残留 6 ← 准时开火、事后仍不泄漏
+    #    ⚠️ 试过但被否掉的写法:`sleep N & _sl=$!; { wait "$_sl" && kill …; } &`
+    #       —— 不泄漏,但**永不开火**:那个 `wait` 等的是**兄弟进程**,
+    #       而 `wait` 只能等自己的孩子,立即返回错误于是 && 短路。
+    _l1_wd_flag="/tmp/qa-l1-wd-$$-$t"
+    : > "$_l1_wd_flag"
+    (
+      _i=0
+      while [ -e "$_l1_wd_flag" ]; do
+        sleep 1; _i=$(( _i + 1 ))
+        [ "$_i" -ge "$L1_WAIT_TIMEOUT" ] && { kill -9 "$pid" 2>/dev/null; break; }
+      done
+    ) & _l1_wd=$!
     if wait "$pid"; then
       ok "L1 $t ($(tail -1 /tmp/qa-l1-$t-run.log))${_w:+ [$_w]}"
     else
@@ -582,7 +604,7 @@ note "L1 单套件 wait 超时 = ${L1_WAIT_TIMEOUT}s(用 L1_WAIT_TIMEOUT 覆盖)
       FAILED=$((FAILED+1))
     fi
     # 看门狗还活着就收掉它,别让它在后面某个时刻打死一个无关的 pid。
-    kill "$_l1_wd" 2>/dev/null || true
+    rm -f "$_l1_wd_flag"          # ← 看门狗看到标志没了,1 秒内自退,不留孤儿
     wait "$_l1_wd" 2>/dev/null || true
   done
   # 汇总一张按开始偏移排序的表:红的时候一眼看出「它排在第几批、L1 跑了多久时炸的」。


### PR DESCRIPTION
## 是我自己引入的

`#1732` 里我写的是：

```sh
( sleep "$L1_WAIT_TIMEOUT"; kill -9 "$pid" 2>/dev/null ) & _l1_wd=$!
...
kill "$_l1_wd" 2>/dev/null || true
```

`kill "$_l1_wd"` 杀的是**子 shell**，而它正阻塞在 `sleep` 上时，
那个 `sleep` 会被**孤儿化**。实测（同一个 job，三份日志）：

```
#1731 重跑（#1732 之前）   Terminate orphan process = 0
main 78241773（含 #1732）  Terminate orphan process = 70   全是 (sleep)
#1733（含 #1732）          Terminate orphan process = 70   全是 (sleep)
```

**70 = L1 套件数**，一个套件泄一个。日志从 ~55K 涨到 **352K**。

🔴 **它不会让任何 job 变红** —— main 那次是 `success`。
只能靠**对比两份日志**才看得见，所以写进注释，让下次改这段的人知道该看什么。

## 改法：标志文件 + 短 sleep 循环

```sh
_l1_wd_flag="/tmp/qa-l1-wd-$$-$t"; : > "$_l1_wd_flag"
( _i=0
  while [ -e "$_l1_wd_flag" ]; do
    sleep 1; _i=$(( _i + 1 ))
    [ "$_i" -ge "$L1_WAIT_TIMEOUT" ] && { kill -9 "$pid" 2>/dev/null; break; }
  done ) & _l1_wd=$!
...
rm -f "$_l1_wd_flag"          # 看门狗 1 秒内自退
wait "$_l1_wd" 2>/dev/null || true
```

收尾从「杀它」变成「让它自己走」，残留的 `sleep 1` 也会自己结束。

## 两向见证（基线 6 个 sleep 进程）

```
快任务   rc=0     事后残留回到 6     ← 不误杀、不泄漏
慢任务   rc=137   耗时=阈值  残留 6  ← 准时开火、事后仍不泄漏
```

## ⚠️ 试过但被否掉的写法（一并记下，省下一个人的时间）

```sh
sleep N & _sl=$!
{ wait "$_sl" 2>/dev/null && kill -9 "$pid" 2>/dev/null; } & _wd=$!
```

**不泄漏，但永不开火。** 那个 `wait` 等的是**兄弟进程** ——
`wait` 只能等自己的孩子，对非子进程立即返回错误，于是 `&&` 短路。
实测：慢任务 `rc=0`、耗时 30s（阈值 2s），看门狗一次都没触发。
**只验泄漏那一侧会把它当成更好的方案。**

门：test-suite-registration / docs-integrity / doc-symbol-anchors /
qa-trigger-coverage / public-script-safety 五道本地 rc=0；`bash -n` rc=0。

Refs #1593 #1732

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>