### PR TITLE
fix(daemon): 已存在的 daemon 上跑 init，那个绿勾要说清「我一个字节都没改」

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8493,9 +8493,20 @@ async function daemonInitCommand() {
   const existing = loadProfile(id);
   if (existing) {
     if (existing.role === "host_supervisor" && !opts.force) {
+      // 🔴 这个绿勾以前会被读成「配置是新的」——它只说明「这个名字已经是 daemon」。
+      //    本分支**一个字节都没写**：token 没重签、runtime 清单没刷新、
+      //    max_concurrent_children 没动。而 #1298（2026-08-28）把默认 runtime 清单
+      //    从 3 个放开到 SUPPORTED_RUNTIME_NAMES 全体之后，**在那之前 init 的 daemon
+      //    永远停在旧清单上** —— 症状是客户端「选服务器」里那台机器可选 runtime 比别人少。
+      //    (#1731 让 `anet daemon list` 会主动报这件事；这里补上另一半:
+      //     用户手里最可能敲的就是 `daemon init`,那它自己得说清「我没改」。)
       console.log(`[anet daemon] ✓ "${id}" already a host_supervisor daemon`);
       console.log(`              config: .anet/nodes/${id}/config.json`);
       console.log(`              start:  anet daemon start ${id}`);
+      console.log(`              ⚠ 本次**没有改动配置** —— token / runtime 清单 / 并发上限都保持原样。`);
+      console.log(`                要用当前默认值重写（含 ${SUPPORTED_RUNTIME_NAMES.length} 个 runtime 的清单）:`);
+      console.log(`                  anet daemon init ${id} --force`);
+      console.log(`                （保留 node_id，但会重新签发 token；改完要重启该 daemon 才生效）`);
       return;
     }
     if (existing.role !== "host_supervisor" && !opts.force) {

--- a/tests/qa-anet-daemon-cmd/run.sh
+++ b/tests/qa-anet-daemon-cmd/run.sh
@@ -102,6 +102,21 @@ TOK_BEFORE="$TOK"
 NID_BEFORE="$NODE_ID"
 OUT=$(anet daemon init "$DAEMON_NAME" 2>&1)
 echo "$OUT" | grep -q "already a host_supervisor" && ok "init reports 'already a daemon' on second run" || bad "re-init didn't surface idempotence: $OUT"
+
+# 🔴 那个绿勾以前只说「这个名字已经是 daemon」,读的人会当成「配置是新的」。
+#    实际这一支 early-return,**一个字节都没写** —— token 没重签、runtime 清单
+#    没刷新。#1298 把默认 runtime 清单放开到 SUPPORTED_RUNTIME_NAMES 全体之后,
+#    在那之前 init 的 daemon 永远停在旧清单上,症状是客户端「选服务器」里
+#    那台机器可选 runtime 比别人少。所以这条提示必须在,且必须说清后果。
+echo "$OUT" | grep -q "没有改动配置" \
+  && ok "re-init 明说本次没有改动配置" \
+  || bad "re-init 只报了幂等,没说清「一个字节都没改」: $OUT"
+echo "$OUT" | grep -q -- "--force" \
+  && ok "re-init 给出了重写配置的命令(--force)" \
+  || bad "re-init 没有给出 --force 的出口: $OUT"
+echo "$OUT" | grep -q "重新签发 token" \
+  && ok "re-init 说清了 --force 的后果(重签 token)" \
+  || bad "re-init 没说 --force 会重签 token,用户照做会撞上没预告的变化: $OUT"
 TOK_AFTER=$(jq -r '.token' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
 NID_AFTER=$(jq -r '.node_id' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
 [[ "$TOK_BEFORE" == "$TOK_AFTER" ]] && ok "token NOT re-minted on idempotent init (no churn)" || bad "token churned despite idempotence"


### PR DESCRIPTION
## 现状

对一个**已经是 host_supervisor** 的 daemon 跑 `anet daemon init <name>`：

```
[anet daemon] ✓ "<name>" already a host_supervisor daemon
              config: .anet/nodes/<name>/config.json
              start:  anet daemon start <name>
```

然后 early-return。**一个绿色的对勾，配置一个字节没动** ——
token 没重签、runtime 清单没刷新、`max_concurrent_children` 没动。

## 为什么这条重要

`#1298`（2026-08-28）把新建 daemon 的默认 runtime 清单从硬编码三元组放开成
`SUPPORTED_RUNTIME_NAMES` 全体。**它只改了写入路径** ——
在那之前 init 的 daemon 永远停在旧清单上，症状是**客户端「选服务器」里
那台机器可选的 runtime 比别人少**。

`#1731` 让 `anet daemon list` 会主动报这件事。**这里补上另一半**：
用户手里最可能敲的就是 `daemon init`，那它自己得说清「我没改」。

## 改动

绿勾后面补四行：

```
⚠ 本次**没有改动配置** —— token / runtime 清单 / 并发上限都保持原样。
  要用当前默认值重写（含 7 个 runtime 的清单）:
    anet daemon init <name> --force
  （保留 node_id，但会重新签发 token；改完要重启该 daemon 才生效）
```

数量取自 `SUPPORTED_RUNTIME_NAMES.length`，**不写死** —— 抄一份就会再漂一次
（#1728 的教训）。`--force` 的后果（重签 token、要重启）也写进去，
免得用户照做后撞上一个没预告的变化。

## 门

doc-symbol-anchors / docs-integrity / test-suite-registration 三道本地 rc=0
（往 `cli.ts` 加行会挤漂被 pin 的行号，所以这三道必跑）。
`tsc --noEmit` 在本 worktree 报 900+ 条，全部是缺 `node_modules` 的
TS2591/TS2503/TS2307 一类；我插入的那几行没有新增报错。

Refs #1298 #1731

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>