### PR TITLE
fix(cli): 把 --force / --yes 登记成布尔标志 —— 它们会吃掉下一个参数

### DIFF
--- a/agent-network/src/cli-args.test.ts
+++ b/agent-network/src/cli-args.test.ts
@@ -11,6 +11,11 @@ const formerlyMissingBooleanFlags = [
   "resume-latest",
   "self",
   "f",
+  // #1736 —— 同一类 bug 的第二批。--force 的后果尤其重:
+  // cli.ts 取 args[1] 当节点名,吞掉之后落到默认名 daemon,
+  // 于是「命令成功了,但作用在别的机器上」。
+  "force",
+  "yes",
 ];
 
 describe("CLI argument parsing", () => {
@@ -24,6 +29,7 @@ describe("CLI argument parsing", () => {
       "--dry-run",
       "--f",
       "--follow",
+      "--force",
       "--grok-headless",
       "--new-session",
       "--no-auto-self",
@@ -31,6 +37,7 @@ describe("CLI argument parsing", () => {
       "--resume-latest",
       "--self",
       "--tmux",
+      "--yes",
       "--yes-danger-full-access",
     ]);
   });

--- a/agent-network/src/cli-args.ts
+++ b/agent-network/src/cli-args.ts
@@ -16,6 +16,18 @@ export const BOOLEAN_FLAGS = new Set([
   "--dry-run",
   "--f",
   "--follow",
+  // 🔴 #1736 —— 这两个以前**没登记**,于是 `--force <token>` / `--yes <token>`
+  //    会把下一个 token 当成它们的值吃掉。实测:
+  //      parseCliOptions(["init","--force","myname"]) → {"force":"myname"}
+  //    后果不是「标志没生效」,是**命令作用在别的对象上**:
+  //    cli.ts 的 `args[1] && !args[1].startsWith("--") ? args[1] : DAEMON_DEFAULT_NAME`
+  //    于是落到默认名 `daemon` —— 用户以为在改 myname。
+  //    而且同一个 --force 在两处判真法相反:
+  //      cli.ts:8495/:8512  `!opts.force`            → "myname" 是真值 ⇒ 认为开了
+  //      cli.ts:11044       `opts.force !== "true"`  → 认为没开
+  //    登记进来之后值恒为 "true",两种判法同时正确,也不再吞参数。
+  //    已核:全仓没有任何一处读它们的**值**(force 3 处、yes 2 处,全是布尔式)。
+  "--force",
   "--grok-headless",
   "--new-session",
   "--no-auto-self",
@@ -23,6 +35,7 @@ export const BOOLEAN_FLAGS = new Set([
   "--resume-latest",
   "--self",
   "--tmux",
+  "--yes",
   "--yes-danger-full-access",
 ]);
 


### PR DESCRIPTION
## 实测（只跑纯解析器，没有跑 `daemon init`：它会连 hub 签 token）

```
parseCliOptions(["init","--force","myname"])  →  {"force":"myname"}   ← 名字被吞掉
parseCliOptions(["init","myname","--force"])  →  {"force":"true"}     ← 正常
```

`"--force"` / `"--yes"` 都不在 `BOOLEAN_FLAGS` 里，于是落到
`cli-args.ts:44` 的「下一个非 `--` token 就是它的值」分支。

## 后果不是「标志没生效」，是**命令作用在别的对象上**

`cli.ts` 的 `daemonInitCommand`：

```ts
const id = args[1] && !args[1].startsWith("--") ? args[1] : DAEMON_DEFAULT_NAME;
```

`anet daemon init --force myname` ⇒ `args[1]` 是 `"--force"` ⇒ 落到默认名 **`daemon`**。
**用户以为在改 `myname`，实际改的是 `daemon`。**

## 而且同一个 `--force` 在两处判真法相反

```
cli.ts:8495 / :8512   `!opts.force`             → "myname" 是真值 ⇒ 认为**开了**
cli.ts:11044          `opts.force !== "true"`   → 认为**没开**
```

登记之后值恒为 `"true"`，**两种判法同时正确**，也不再吞参数。

## 为什么至今没炸

标志放在**最后**时 `opts.force === "true"`，两种判法都对。
只有 `--force <token>` 这个顺序会翻车。

## 安全性核对

全仓**没有任何一处读它们的值**：`opts.force` 3 处、`opts.yes` 2 处，全是布尔式
（`!opts.force` / `opts.X !== "true"`）。所以登记不会破坏任何现有调用。

## 测试：接进仓里既有的机制，不另起一套

`cli-args.test.ts` 早就有 `formerlyMissingBooleanFlags` 清单 +
模板测试「`--<flag>` does not swallow a following positional operand」
（用 `positionalArgs` 断言）——**这类 bug 修过一轮**（`resume-latest` / `self` / `f`）。
我先手写了 5 条断言，发现这套机制后**把自己那套删了**，改为：

- 把 `force` / `yes` 加进 `formerlyMissingBooleanFlags`（模板测试自动覆盖）
- **如实更新**「pins the complete presence-only flag set」那条被钉住的集合
  —— 它在我加标志时红了，那正是它存在的理由。

`bun test cli-args.test.ts` 26 pass / 0 fail；`cli-args-wiring.test.ts` 1 pass。
test-suite-registration / doc-symbol-anchors / docs-integrity 三道门 rc=0。

Closes #1736

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>