### PR TITLE
test(qa-cli-02): 让 141 那种零诊断猝死自己报出行号 (#990)

### DIFF
--- a/tests/qa-cli-02-network-create/run.sh
+++ b/tests/qa-cli-02-network-create/run.sh
@@ -6,6 +6,14 @@
 # 测的是 CLI binary 这一层 — 输出格式 + 本地 config 落地 + REST 调用。
 # REST 本身已被 qa-hub-05 覆盖，这条专测 CLI 包装层。
 set -euo pipefail
+
+# 🔴 死得出声（#990）：本文件 set -e + pipefail，任何一条管道返回非零都会
+#    **当场打死脚本，且一个字都不打印** —— 2026-09-01 这个套件就这么红过一次：
+#    退出码 141（=128+13 SIGPIPE），run.log 只有 7 行，「failure markers」段全空。
+#    没有行号，只能靠人去猜是哪条管道，而三条候选实测各 20000 次都不会触发。
+#    这个 trap 不改任何判据、不吞任何退出码（`exit $_rc` 原样传出），
+#    只保证下一次同样的红**自己说出是第几行**。
+trap '_rc=$?; echo "🔴 run.sh 第 $LINENO 行以 rc=$_rc 非零退出（141=128+13 即 SIGPIPE，见 #990）"; exit $_rc' ERR
 # 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
 printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 


### PR DESCRIPTION
2026-09-01,这个套件在 PR #1733 的 L0+L1 里红过一次:

    · L1 done qa-cli-02-network-create [L1+269s..289s, 20s] rc=141
    ✗ 1 test(s) failed in 893s
    ---- failure markers ----        ← 空的

141 = 128+13 = SIGPIPE。本文件是 set -euo pipefail,任何一条管道返回
非零都会当场打死脚本**且一个字都不打印** —— run.log 只有 7 行,停在
`[1] anet login` 的输出之后,没有任何断言说过话。

我试过靠读代码定位那一行,失败了。停止点之前只有三条管道,全是
`echo "$SMALL" | …` 这种形态,而 #990 正文断言这种形态不会触发 SIGPIPE。
实测支持 #990:

    echo "$LOGIN_OUT(6行)" | head -3 | sed    非零 0 / 20000
    echo "$LOGIN_OUT(6行)" | grep -qE …       非零 0 / 20000
    正控 seq 1 2000000 | head -3              rc = 141   ✅ 量具是活的

(正控这一格是必需的:没有它,`0/20000` 和「我的量具坏了」逐字相同。)

所以这个提交**不猜是哪一行,而是让下一次的红自己说**。加一个 ERR trap,
打印 $LINENO 和 rc,然后用 `exit $_rc` 把退出码原样传出去。

它不改任何判据、不让任何门变绿、不吞任何退出码。

两向见证(用的是**这个文件真实的前 17 行**,不是玩具脚本):

    阳性 注入必炸管道  → 🔴 run.sh 第 18 行以 rc=141 非零退出   脚本 rc=141
    阴性 换成必成管道  → 无 🔴 行                                脚本 rc=0

🔴 本仓没有任何一道门覆盖这个改动。24 个 check-*.py 里:
  - check-no-escaped-comments  只收 `git ls-files "*.py"`
  - check-public-script-safety 自己印的分母是 `6 script(s)`(只扫 public/)
  两道都做了正控:朝它们各自的判据变异,**都没有变红** —— 它们的 rc=0
  对本改动零信息量。其余 4 道判的是路径/注册/SHA 绑定,而本次没有增删
  任何文件,结构上无从反应。上面那两向见证是唯一的证据。

Refs #990

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)