### PR TITLE
docs(cli): --force 的帮助只说了它一半的用途,而缺的那一半正是产品自己给出的修法

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8442,7 +8442,11 @@ Subcommands:
   list                 List locally-configured daemon nodes
 
 Options:
-  --force              Overwrite an existing non-daemon config (init only)
+  --force              init only。两种用法,第二种是产品自己给出的修法却没人写在这里:
+                       ① 覆盖一个**非** daemon 的同名配置;
+                       ② 对**已经是** daemon 的配置重跑一次 init —— 回填后来新增的
+                          runtime(\`anet daemon list\` 报「少 N 个」时走这条)。
+                       保留 node_id,但**会重新签发 token**,改完要重启该 daemon 才生效。
   --allow-secret KEY   Pre-populate allowed_secret_keys (repeatable; init only)
 
 Daemon 就是一个 role=host_supervisor 的 agent-node,所以停 / 删 / 看**没有** daemon 版,


### PR DESCRIPTION
`anet daemon list` 会报「⚠ 这份配置声明的 runtime 少 N 个」(#1731,已在 main),
它给出的修法是:

    anet daemon init <name> --force

`anet daemon init` 早退时的绿勾提示(#1735)给的也是这一句。

而 `anet daemon --help` 里这一行写的是:

    --force              Overwrite an existing non-daemon config (init only)

**一个已经是 daemon 的用户读到这里,会认为这条跟自己无关** —— 于是走不通
产品刚刚告诉他的那条路。帮助文本描述的是 `--force` 的两种用途里的一种,
而缺的恰好是被告警指向的那一种。

改成把两种都写出来,并写清代价(保留 node_id、**重新签发 token**、要重启)。

反引号按本文件模板串里已有的写法转义(`Run \`anet hub start\` first` 就在同一段里),
不自造。

## 验证

本仓没有任何一道门覆盖这个改动(它是模板字符串里的文案)。
`agent-network` 的 `npm run typecheck` 在一次性 worktree 里返回 rc=127
(`tsc: not found`,依赖没装)—— **127 不是通过**。

所以用 `bun build --target node --external '*'`(整文件解析,但不解析 import)
做两向见证:

    阴性(转义后 \`)   rc=0
    阳性(裸反引号 `)  rc=1
       8448 |  runtime(`anet daemon list` 报「少 N 个」时走这条)。
                        ^ error: Expected ")" but found "anet"

阳性那一格精确指到本次改动的那一行。

(过程记录:前四个量具阴阳两侧都红或都绿,分辨力为 0 —— 依赖未装、
`${DAEMON_DEFAULT_NAME}` 未定义、抽出的片段本身合法。每一次都是阳性那一格
把「红的不是我要测的那一维」暴露出来的。)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)