### PR TITLE
docs(daemon): 说清 daemon 只管得到自己工作区里的节点 (#1722 建议 1)

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -341,6 +341,35 @@ tail -f ~/daemon-<name>.log        # 或你启动时重定向到的那个文件
 在 #1290 修好之前，Windows 机器可以跑 daemon，但**不要指望它 fork 出子节点**。
 :::
 
+::: warning ⚠️ daemon 管得到哪些节点：**只有它自己工作区里的**
+
+这一条最容易误解，而且踩到时**不像故障、像功能没做**。
+
+daemon 的工作区（`workDir`）**是它启动那一刻所在的目录**（`process.cwd()`），
+它创建和启动的子节点都落在 `<workDir>/.anet/nodes/` 下
+（`agent-node/src/runtime/start-daemon.ts` 里 `nodesRoot = join(deps.workDir, ".anet", "nodes")`）。
+
+⇒ **你在别的目录里手工建的存量节点，daemon 够不着** —— 不是权限问题，是**根本不在它的搜索范围里**。
+Dashboard 上再加什么按钮都拉不起它们。真实形状见
+[#1648](https://github.com/sleep2agi/agent-network/issues/1648)：一台机器上 daemon 在线、
+CWD 是用户主目录，而三个离线节点的 `project_dir` 分别在两个别的盘符和一个 WSL 路径里。
+
+**怎么判断某个 daemon 的工作区是哪儿**（Linux/macOS，`<pid>` 用 `anet node list` 或 `ps` 拿）：
+
+```bash
+ls -l /proc/<pid>/cwd            # Linux：直接看它的 cwd
+lsof -a -p <pid> -d cwd          # macOS
+ls <workDir>/.anet/nodes/        # 它管得到的节点就是这里面的
+```
+
+⇒ **同一台机器上从不同目录起两次 daemon，会得到两个互相看不见的节点集合。**
+要让 daemon 管某批节点，就**从那批节点所在的工作区启动它**。
+
+（RFC-026 原本规定 `workDir` 固定在 `~/.anet/daemon/workspaces/<network_id>/`；
+当前实现取 `process.cwd()`。差异与三条改法见
+[#1722](https://github.com/sleep2agi/agent-network/issues/1722)。）
+:::
+
 ---
 
 

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -373,6 +373,41 @@ and [#1290](https://github.com/sleep2agi/agent-network/issues/1290). Until #1290
 Windows machine can run a daemon, but **do not expect it to fork child nodes**.
 :::
 
+::: warning ⚠️ Which nodes a daemon can reach: **only the ones in its own workspace**
+
+This is the easiest thing to misread here, and when you hit it, it does not look like a
+failure — it looks like the feature was never built.
+
+A daemon's workspace (`workDir`) is **whatever directory it happened to be started from**
+(`process.cwd()`). Every child node it creates or starts lives under
+`<workDir>/.anet/nodes/` — see `nodesRoot = join(deps.workDir, ".anet", "nodes")` in
+`agent-node/src/runtime/start-daemon.ts`.
+
+⇒ **Pre-existing nodes you created by hand somewhere else are out of reach.** It is not a
+permission problem; they are simply not in the directory the daemon searches. No amount of
+Dashboard buttons will start them. For a real-world shape see
+[#1648](https://github.com/sleep2agi/agent-network/issues/1648): daemon online with its CWD
+at the user's home directory, while three offline nodes had `project_dir` on two other
+drives and a WSL path.
+
+**How to tell which workspace a given daemon has** (`<pid>` from `anet node list` or `ps`):
+
+```bash
+ls -l /proc/<pid>/cwd            # Linux: read its cwd directly
+lsof -a -p <pid> -d cwd          # macOS
+ls <workDir>/.anet/nodes/        # the nodes it can reach are exactly these
+```
+
+⇒ **Starting two daemons from two different directories on the same machine gives you two
+node sets that cannot see each other.** To have a daemon manage a given set of nodes,
+start it from that workspace.
+
+(RFC-026 specifies `workDir` as a fixed `~/.anet/daemon/workspaces/<network_id>/`; the
+current implementation uses `process.cwd()`. The gap and three possible fixes are tracked
+in [#1722](https://github.com/sleep2agi/agent-network/issues/1722).)
+:::
+
+
 ---
 
 


### PR DESCRIPTION
#1722 量出来的差距：RFC-026:426 规定 daemon 的 `WORK_DIR` 是固定隔离工作区，
实现里它是 daemon 启动那一刻的 `process.cwd()`。该 issue 的三条建议里，
第 1 条是「先改文档，最便宜且立刻消除误解」——这个提交就是它。

## 为什么必须写在文档里

用户读到「从 Dashboard 远程操作它」这一节时，最自然的期待是「装了 daemon
就能在 Dashboard 上管这台机器上的所有节点」。**实际上它只管得到
`<workDir>/.anet/nodes/` 里的那些**，而存量节点大多不在那儿。

踩到时**不像故障、像功能没做**：点了没反应，Dashboard 不报错，日志也没有异常。
#1648 是真实形状——daemon 在线、CWD 是用户主目录，而三个离线节点的 `project_dir`
分别在两个别的盘符和一个 WSL 路径里。

实测这台开发机上有 **95 棵 `.anet` 树**（其中 71 棵是真实工作树，24 棵是
`anet-pin`/`clean-tmp` 临时的）。一个 daemon 只覆盖其中一棵。

## 查过：用户会读的那两页，一个字都没提

```
docs-site/docs/deploy/daemon.md      工作区 0 · workDir 0 · WORK_DIR 0 · 存量 0
docs-site/docs/en/deploy/daemon.md   同上（全 0）
docs/rfcs/RFC-026-…                  WORK_DIR 5   ← 只有 RFC 里有，而用户不读 RFC
```

## 写进去的东西

中英各一段 `::: warning`，插在第 5 节「从 Dashboard 远程操作它」那个
`::: danger ok:true 不是成功判据` 之后（用户正读到远程建节点时立刻看到）：

- `workDir` = 启动那一刻的 `process.cwd()`；子节点落在 `<workDir>/.anet/nodes/`
  （引 `agent-node/src/runtime/start-daemon.ts` 的
  `nodesRoot = join(deps.workDir, ".anet", "nodes")` 原文，不是推的路径）
- 存量节点够不着 —— **不是权限问题，是不在搜索范围里**
- **同机不同目录起两次 daemon = 两个互相看不见的节点集合**
- 怎么查某个 daemon 的工作区（三条命令，`/proc` 那条我在本机跑过才写）
- 附 RFC-026 差异与 #1722

## 验证

```
check-docs-locale-parity   rc=0   ← 中英成对
check-docs-integrity       rc=0
check-docs-site-orphans    rc=0
check-home-path-baseline   rc=0   ← 正控:塞 /home/<name>/ 进去 → rc=1 ✅ 它真扫到这两个文件
check-no-memory-slugs      rc=0
两份文档里 -F '/home/' 命中 **0**
```

🔴 最后那条是自查，不是靠门：我为了验 `ls -l /proc/<pid>/cwd` 这条命令，
在本机真跑过一次，输出里带着真实主目录路径。**验证动作本身制造了泄漏风险** ——
所以直接 grep 两份文档确认写进去的是命令、不是那次的输出。

英文版的插入点是 grep 出来再 `assert lines[373].strip()==":::"` 校验过的，
不是按中文行号平移——两份文档结构不同（中文 545 行 / 英文 594 行）。

Refs #1722

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)