### PR TITLE
feat(daemon): `daemon start` 在启动那一刻打出 workdir 和它管得到的节点目录 (#1722 建议 2)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8656,6 +8656,19 @@ async function daemonStartCommand() {
     console.error(w);
   }
 
+  // 2026-09-02 #1722 —— 在启动的那一刻说清「这台 daemon 管得到哪些节点」。
+  //
+  //   daemon 的 workDir 就是它**启动那一刻所在的目录**(process.cwd())，它 fork 出的
+  //   子节点全部落在 `<workDir>/.anet/nodes/` 下(start-daemon.ts 的
+  //   `nodesRoot = join(deps.workDir, ".anet", "nodes")`)。**别处的存量节点够不着** ——
+  //   不是权限问题，是不在搜索范围里，而 Dashboard 上点它们只会毫无反应。
+  //
+  //   `anet daemon list` 已经打了 `scanned:`(#1725)，但**启动**这一刻才是 workDir 被
+  //   固定下来的时刻 —— 与上面那段 PATH 警告同一个道理:在这里说一句，
+  //   胜过用户在 Dashboard 上点半天再回头猜 daemon 是从哪个目录起的。
+  console.error(`  workdir: ${process.cwd()}`);
+  console.error(`  (它只管得到 ${nodesDir()} 里的节点;别处的存量节点够不着 —— 见 #1722)`);
+
   // Delegate to existing startCommand — it reads args[1] for the node name,
   // which is what we have after the `daemon start` splice in daemonCommand.
   await startCommand();


### PR DESCRIPTION
#1722 建议 2：「daemon 在启动横幅 / `daemon list` 里打印它的 workDir —— 现在要判断
『这个 daemon 能管哪些节点』，只能去猜它是从哪个目录起的。」

查了现状，这条**已经完成了一半**：

```
cli.ts:8738/8744  daemonListCommand  console.log(`  scanned: ${nodesDir()}`)
cli.ts:8739                          console.log("  (节点配置按目录存放 —— 换个目录跑，看到的是另一份清单)")
```

那是 #1725（今晚已合进 main）做的。**缺的是 `daemon start` 这一半** ——
而**启动那一刻正是 workDir 被固定下来的时刻**。

## 加了两行，与 `daemon list` 同口径

```
  workdir: <process.cwd()>
  (它只管得到 <nodesDir()> 里的节点;别处的存量节点够不着 —— 见 #1722)
```

复用同一个 `nodesDir()`（cli.ts:232，模块顶层 `function`，该作用域可见），
**不自己拼路径**。用 `console.error`，与紧邻那段 PATH 警告同一个输出流。

放在 `daemonPathWarnings` 之后，理由照抄它上面那段注释的论证：

> 在这里说，修起来只要一行 export；等节点报错再说，已经绕了一大圈。

workDir 完全同理 —— 在这里说一句，胜过用户在 Dashboard 上点半天再回头猜
daemon 是从哪个目录起的。

## 验证

```
bun build --target node --external '*'   rc=0   ← 整文件解析（不解析 import）
check-doc-symbol-anchors                 rc=0   ← 符号级，不受行号影响
check-docs-integrity                     rc=0
check-no-escaped-comments                rc=0   ← 本次没动 .py，但它扫得到
check-home-path-baseline                 rc=0
```

🔴 **行号 pin 影响 = 0，这是查过的不是赌的**：本仓有 **161 处**指向 `cli.ts` 的
行号引用，我插在第 8669 行，之后只有 2 处 —— 而那 2 处是
`docs/tests/report-test226.txt` 里一条**历史异常堆栈**
（`at async main (…/cli.ts:15194:23)`），是记录不是引用，**不该跟着当前行号变**。
其余 159 处都在插入点之前，不受影响。

（顺带：正因为如此，往 `cli.ts` 尾部附近插入是最安全的位置；插在文件前部会挤漂 159 处。）

Refs #1722

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)