### PR TITLE
feat(doctor): 盘点「非 claude-agent-sdk 的 runtime 配了飞书通道」 (#1259)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -16124,6 +16124,19 @@ async function doctorCommand() {
     })();
     const alive = localState.kind === "alive";
     info(`  ${name}`, `${runtime} ${describeLocalProcess(localState)} node_id=${p?.node_id || "-"}`);
+    // #1259 —— 飞书桥经 parent IPC 交给 think()，而 think() 是所有 runtime 共用的入口：
+    //   **没有任何东西阻止** codex / opencode 节点开飞书通道，**也没有任何东西验证过它能工作**。
+    //   更要紧的是该 issue 评论里的一格：飞书的工具拒绝层在其余 runtime 上根本不会触发。
+    //   #1575 是预防性的（挡住新配），**已经配好的组合仍在裸奔** —— 所以要有一条只读盘点。
+    //
+    // 🔴 用 ⚠ 不用 ❌：这是「没验过 + 拦截层不生效」，不是「一定坏」。
+    // 🔴 判据用目录存在性（channels/feishu/），与 cli.ts 里 channelDir 的算法同源，不另拼路径。
+    if (p && runtime !== "claude-agent-sdk"
+        && existsSync(join(nodesDir(), id, "channels", "feishu"))) {
+      warning(`    ↳ ${name} feishu`,
+        `runtime=${runtime} 配了飞书通道，而只有 claude-agent-sdk 验过；`
+        + `其余 runtime 上飞书的工具拒绝层不会触发（#1259）`);
+    }
     if (p && runtime === "codex-app-server") {
       const audit = codexTopologyAudit(p as any, join(nodesDir(), id), process.cwd());
       const verified = audit.lastRecoveryVerification as any;
@@ -16221,6 +16234,16 @@ async function doctorCommand() {
       info("→ run", `anet doctor --fix  to auto-migrate ${needsMigration.length} node(s)`);
     }
   }
+
+  // #1259 —— 🔴 **空集也要出声。**
+  //   上面那条飞书盘点只在命中时打印。0 命中和「这台机器没有节点目录」「跑在另一棵
+  //   .anet 树里」输出一模一样，而 doctor 全绿会被读成「全网没问题」。
+  //   #1259 的作者为此专门写了一句：一台机器的盘点**不能推广成「全网没有」**，
+  //   并附了他因「局部样本 + 全称措辞」栽过两次的记录。
+  //   ⇒ 无论命中与否，都把**这次扫的是哪一棵树**说出来（口径与 `anet daemon list`
+  //     的 `scanned:` 一致，#1725）。
+  info("Feishu × runtime 盘点", `扫了 ${nodesDir()} 下 ${ids.length} 个节点配置`
+    + `；这只是**这一棵 .anet 树**，同一台机器上可能还有别的（见 #1259）`);
 
   // #125 — scan all nodes for plain-secret env values still persisted in
   // config.json. Migration is per-node (`anet node migrate-token-to-envref


### PR DESCRIPTION
#1259 的结论：飞书桥经 parent IPC 交给 `think()`，而 `think()` 是所有 runtime 共用
的入口 —— **没有任何东西阻止** codex / opencode 节点开飞书通道，**也没有任何东西
验证过它能工作**。该 issue 评论里还有更要紧的一格：**飞书的工具拒绝层在其余
runtime 上根本不会触发**；#1575 是预防性的（挡新配），**已经配好的组合仍在裸奔**。

它列的「还缺的两件」里，第一件是一条**只读盘点**：

> 现存哪些节点同时满足「runtime ≠ claude-agent-sdk」且「配了 feishu 通道」。
> 这是本地 `.anet/nodes/*/config.json` + `channels/feishu/` 的存在性检查，
> **不需要连 hub、不需要发任何消息**，可以做成 `anet doctor` 的一格。

这个提交就是它。**第二件（把 Layer B 提到 runtime 无关的位置）没做** —— 该 issue
明写「在那之前本 issue 不应关闭」。

## 做在哪

`doctorCommand` 已有的节点循环里加一个 `if`，复用现成的 `p` / `runtime` / `id`，
不新建遍历。判据用**目录存在性**：

```ts
runtime !== "claude-agent-sdk" && existsSync(join(nodesDir(), id, "channels", "feishu"))
```

`channels/feishu` 这个路径与 `cli.ts` 里 `channelDir` 的算法同源，不另拼。

🔴 用 `warning`（⚠）不用 `error`（❌）：这是「没验过 + 拦截层不生效」，**不是「一定坏」**。

## 🔴 空集也出声

盘点只在命中时打印的话，**0 命中**和「这棵树里没有节点」「飞书节点在另一棵 `.anet`
树里」输出一模一样，而 doctor 全绿会被读成「全网没问题」。#1259 的作者专门写了
一句：一台机器的盘点**不能推广成「全网没有」**，并附了他因「局部样本 + 全称措辞」
栽过两次的记录。

所以无论命中与否都打印一行，把**这次扫的是哪一棵树**说出来（口径与
`anet daemon list` 的 `scanned:` 一致，#1725）：

```
Feishu × runtime 盘点: 扫了 <nodesDir()> 下 N 个节点配置；
                       这只是**这一棵 .anet 树**，同一台机器上可能还有别的（见 #1259）
```

这不是客套：实测这台开发机上有 **95 棵 `.anet` 树**（71 棵真实工作树）。
`~/.anet` 下**没有**任何配飞书的节点，而 #1259 量到的「157 个配置里命中 1 个」
就在别的树里。

## 验证

判据抽出来单独喂一棵 `/tmp` 假树（**不碰任何真节点配置**），1 阳 3 阴：

```
⚠ 告警  配了 feishu + runtime=codex-app-server      ← 该响
· 静默  配了 feishu + runtime=claude-agent-sdk      ← 不该响
· 静默  没配 feishu + runtime=codex-app-server      ← 不该响
· 静默  配的是 channels/telegram（不是 feishu）      ← 不该响，挡「有 channels/ 就算命中」
```

其余：

```
bun build --target node --external '*'   rc=0
check-doc-symbol-anchors / docs-integrity / no-escaped-comments / home-path-baseline  全 rc=0
```

🔴 **行号 pin 影响 = 0（查过的）**：本仓有 161 处按行号引用 `cli.ts`，我最靠前的
插入点是 16137，**之后 0 处**。（顺带复证上次那条：往 `cli.ts` 尾部附近插入最安全。）

🔴 **两处插入都验过落在 `doctorCommand`（16034..16422）范围内且全文唯一** ——
`cli.ts` 里 `const ids = listProfileIds();` 有 **4 处**，`grep | head -1` 给的是
7387 那个。挡住这件事的不是我的警觉，是 `assert count == 1`。

Refs #1259

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)