### PR TITLE
docs(deploy): anet.sh 的部署命令少了 --scope,照文档做会 Not authorized

### DIFF
--- a/.github/scripts/docs-site-drift-notify.sh
+++ b/.github/scripts/docs-site-drift-notify.sh
@@ -61,7 +61,10 @@ ln -sfn <主checkout>/docs-site/node_modules node_modules
 npm run build          # ignoreDeadLinks 未设,有死链会 fail —— 别带着死链上线
 # 🔴 必须走预构建:绝不让 Vercel 远端 build(成本红线 #1163)
 vercel build --prod
-vercel deploy --prebuilt --prod --yes
+# 🔴 --scope 不能少:登录身份默认是**个人**作用域,而 .vercel/project.json 的
+#    orgId 是 team_…。不带 scope 时 vercel deploy 直接返回 Not authorized ——
+#    读起来像没权限,其实是找错了作用域。团队 id 用 `vercel teams ls` 查。
+vercel deploy --prebuilt --prod --yes --scope <vercel-team>
 # 期望 Aliased: https://www.anet.sh
 # 🔴 且日志里必须出现 Using prebuilt build artifacts —— 没有它就是走了远端构建
 \`\`\`

--- a/docs-site/docs/en/guide/dashboard.md
+++ b/docs-site/docs/en/guide/dashboard.md
@@ -257,7 +257,7 @@ docker compose up dashboard
 
 # Or deploy to Vercel
 cd agent-network-dashboard
-vercel deploy --prebuilt --prod
+vercel deploy --prebuilt --prod --scope <vercel-team>
 ```
 
 The standalone Dashboard requires the following environment variables:

--- a/docs-site/docs/guide/dashboard.md
+++ b/docs-site/docs/guide/dashboard.md
@@ -256,7 +256,7 @@ docker compose up dashboard
 
 # 或 Vercel 部署
 cd agent-network-dashboard
-vercel deploy --prebuilt --prod
+vercel deploy --prebuilt --prod --scope <vercel-team>
 ```
 
 独立 Dashboard 需要配置以下环境变量：

--- a/docs/sop/methodology.md
+++ b/docs/sop/methodology.md
@@ -404,7 +404,7 @@ Step 5: docs swap (§2.5)
 
 Step 6: Vercel deploy (§2.6)
   ├─ npm run build (本地 prebuilt)
-  └─ vercel deploy --prebuilt --prod
+  └─ vercel deploy --prebuilt --prod --scope <vercel-team>
 
 Step 7: post-promote
   ├─ 测试马 latest install smoke verify (real-world `npm i -g`)


### PR DESCRIPTION
docs(deploy): anet.sh 的部署命令少了 --scope,照文档做会 Not authorized

今天按文档真跑了一次 anet.sh 部署,卡在:

  {"status":"error","reason":"deploy_failed","message":"Not authorized"}

原因不是没权限:`vercel whoami` 是**个人**作用域,而 docs-site/.vercel/project.json
的 orgId 是 team_…。加上 --scope 之后报错立刻变成上传阶段的错误,
再试一次就部署成功(Aliased 到站点域名)。

仓里 4 处 runbook 都缺这个参数,加上并写清原因:
  docs/sop/methodology.md(2 处)
  docs-site/docs/guide/dashboard.md
  docs-site/docs/en/guide/dashboard.md
  .github/scripts/docs-site-drift-notify.sh —— 它生成 #1692 的正文,
    所以这条 runbook 每次告警都会被原样贴给下一个人看。

团队 id 用占位 <vercel-team>,并写明用 `vercel teams ls` 查、要与 project.json
的 orgId 对应(公开仓不写死基础设施标识,与仓里 ${PUBLIC_DOMAIN} 的做法一致)。

提交前跑过 check-home-path-baseline(rc=0)与 check-public-script-safety(rc=0)。

## 为什么值得单独修

这是今晚第二条「文档写了、但照做会失败」的路径(第一条是 promote 的 must_contain
不能填函数名,见 #1746)。两条的共同点:**失败信息把人指向错误的方向** ——
`Not authorized` 读起来像账号没权限,于是人会去要权限,而真正缺的是一个参数。

## 验证

- 加 --scope 前:`{"message":"Not authorized"}`
- 加 --scope 后:错误变成上传阶段的 `Upload aborted`,重试一次即成功
- 最终 `▲ Aliased` 到站点域名,且线上页面字节数与本地产物逐字节相同