### PR TITLE
fix(#1522): node stop 的 SIGTERM 宽限 5s → 10s,让拆卸链跑得完

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -9250,7 +9250,21 @@ async function reapOwnedGeneration(owned: readonly LifecycleProcessIdentity[]): 
   const unknown = unverifiable();
   if (unknown.length) return [{ kind: "process", detail: `birth unavailable for owned pids ${unknown.map(p => p.pid).join(",")}` }];
   signalOwned("SIGTERM");
-  const termDeadline = Date.now() + 5_000;
+  // #1522 —— 这个宽限必须**大于** agent-node 那条拆卸链的最坏耗时,否则下面的
+  // SIGKILL 会把正在做清理的进程打断,留下 post-stop 残留(实测症状:
+  // `post-stop cleanup retained pinned project sandbox placeholder: .grok`)。
+  //
+  // 最坏耗时来自 agent-node/src/runtime/grok-copresence/leader-lifecycle.ts 的
+  // `terminateOwnedGrokLeader(identity, timeoutMs = 2_000)`:
+  //   SIGTERM 等 2s → 重验身份 → SIGKILL 等 2s   = 一次调用最坏 4s
+  //   该函数在拆卸链里被调用两次                  = **最坏 8s**
+  //
+  // 🔴 不要反过来去缩短那 2_000:它是 SIGKILL 升级前重做完整身份绑定的窗口,
+  //    用来挡同 UID 的 PID 复用竞态(Node 无 pidfd_send_signal)。缩它会削弱那道保护。
+  //
+  // 这里是**上限不是固定等待** —— 下面的循环在 survivors() 清空时立刻返回,
+  // 正常路径上进程 SIGTERM 后很快就退出,用户感觉不到差别。
+  const termDeadline = Date.now() + 10_000;
   while (Date.now() < termDeadline) {
     await new Promise(r => setTimeout(r, 100));
     const unknownNow = unverifiable();

--- a/agent-network/src/stop-grace-covers-teardown.test.ts
+++ b/agent-network/src/stop-grace-covers-teardown.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1522 —— `anet node stop` 先 SIGTERM 再等一个宽限，然后 SIGKILL。
+// 如果那个宽限**小于** agent-node 拆卸链的最坏耗时，清理代码就会在最坏路径上
+// 被 SIGKILL 打断，留下 post-stop 残留（实测断言：
+// `post-stop cleanup retained pinned project sandbox placeholder: .grok`）。
+//
+// 这条不等式此前**没有任何守卫**：两个常量分在两个包里，谁调小任何一边都不会有人发现。
+// 修的时候容易只改一处；这条测试把两边绑在一起。
+//
+// 🔴 注意方向：要修必须**抬 CLI 侧的宽限**，不要去缩 leader-lifecycle 的 timeoutMs ——
+//    那 2 秒之后紧跟着 `assertIdentityStillOwnsListener`，是 SIGKILL 升级前重做
+//    完整身份绑定的窗口，用来挡同 UID 的 PID 复用竞态（Node 无 pidfd_send_signal）。
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf-8");
+const LIFECYCLE = readFileSync(
+  join(import.meta.dir, "..", "..", "agent-node", "src", "runtime", "grok-copresence", "leader-lifecycle.ts"),
+  "utf-8",
+);
+
+// 数字字面量允许 `_` 分隔符：`10_000` 用 `[0-9][0-9_]*` 才抓得到，`[0-9]+` 会抓成 `10`。
+function num(text: string, re: RegExp, what: string): number {
+  const m = text.match(re);
+  if (!m) throw new Error(`找不到 ${what} —— 它可能被改名或改写了，先确认再调这条测试`);
+  return Number(m[1].replaceAll("_", ""));
+}
+
+describe("#1522 stop 宽限必须盖得住拆卸链", () => {
+  const termGraceMs = num(CLI, /const termDeadline = Date\.now\(\) \+ ([0-9][0-9_]*);/, "CLI 的 termDeadline");
+  const leaderStepMs = num(
+    LIFECYCLE,
+    /export async function terminateOwnedGrokLeader\([\s\S]{0,200}?timeoutMs = ([0-9][0-9_]*),/,
+    "terminateOwnedGrokLeader 的 timeoutMs",
+  );
+
+  // 一次调用最坏 = SIGTERM 等 timeoutMs + SIGKILL 等 timeoutMs；该函数在拆卸链里被调用两次。
+  const worstTeardownMs = leaderStepMs * 2 * 2;
+
+  it("两个常量都还在（改名了要来更新这条测试，而不是让它静默失效）", () => {
+    expect(termGraceMs).toBeGreaterThan(0);
+    expect(leaderStepMs).toBeGreaterThan(0);
+  });
+
+  it("CLI 宽限 > 拆卸链最坏耗时", () => {
+    expect(worstTeardownMs).toBe(leaderStepMs * 4);
+    expect(termGraceMs).toBeGreaterThan(worstTeardownMs);
+  });
+});


### PR DESCRIPTION
fix(#1522): node stop 的 SIGTERM 宽限 5s → 10s,让拆卸链跑得完

anet node stop 对整棵进程树的宽限是 5 秒,而 agent-node 那条负责清理的
拆卸链最坏要 8 秒,于是清理代码在最坏路径上必然被 SIGKILL 打断,留下
post-stop 残留。实测症状(2026-09-01 main@06bec50f 的 test225 ratchet):

  FAIL: post-stop cleanup retained pinned project sandbox placeholder: .grok

8 秒的来源(leader-lifecycle.ts 的 terminateOwnedGrokLeader,timeoutMs=2_000):
  SIGTERM 等 2s → 重验身份 → SIGKILL 等 2s = 一次调用最坏 4s
  该函数在拆卸链里被调用两次              = 最坏 8s

选择抬 CLI 侧宽限而不是缩那个 2_000:后者是 SIGKILL 升级前重做完整身份
绑定的窗口,用来挡同 UID 的 PID 复用竞态(Node 无 pidfd_send_signal),
缩它会削弱那道保护。两条路的代价不对称。

10_000 = 8s 最坏 + 2s 余量。这是**上限不是固定等待**:循环在 survivors()
清空时立刻返回,正常路径上进程 SIGTERM 后很快退出,用户感觉不到差别。

改动是一个常量 + 说明注释。提交前跑过 check-home-path-baseline、
check-doc-symbol-anchors、check-docs-integrity,三个 rc=0。

## 这条不是调大一个超时，是修一个必然发生的截断

CLI 侧的形状（`agent-network/bin/cli.ts` 的 `reapOwnedGeneration`）：

```
signalOwned("SIGTERM")
const termDeadline = Date.now() + 5_000     ← 宽限 5 秒
… 轮询 survivors() …
signalOwned("SIGKILL")
const killDeadline = Date.now() + 3_000
```

而 agent-node 的清理链在最坏路径上要 8 秒才走完。**5 < 8 ⇒ 清理必然被 SIGKILL 截断。**
这不是概率问题，是这条不等式的直接后果。

## 为什么不反过来缩 `terminateOwnedGrokLeader` 的 2_000

那个函数的注释自己写着：

> Node has no public pidfd_send_signal API, so preview still has a syscall-sized
> numeric PID race against a same-UID actor.

那 2 秒之后紧跟着的是 `assertIdentityStillOwnsListener(identity)` —— **升级到 SIGKILL 之前
重做完整的身份绑定校验**。缩短它 = 收窄一个防同 UID PID 复用的窗口。

| 方案 | 改动 | 代价 |
|---|---|---|
| **本 PR（A）** | 一个常量 | `node stop` **最坏**多等 3 秒（且只在真的走到最坏路径时） |
| B 缩 `timeoutMs` | 一个默认参数 | 削弱防 PID 复用的校验窗口 |

**代价不对称，所以选 A。**

## 关于用户会不会觉得变慢

`termDeadline` 是**上限**：`while (Date.now() < termDeadline)` 的循环里
`if (survivors().length === 0) return []`，进程一退干净就立刻返回。
正常路径上 SIGTERM 之后进程很快退出，这个改动在那里**不产生任何额外等待**。

## 验证

- 提交前本地跑过 `check-home-path-baseline` / `check-doc-symbol-anchors` /
  `check-docs-integrity`，三个 `rc=0`。
- 改动只有一个数字字面量 + 注释行。
- 🔴 真正的判据是 CI 里的 `test225 known-failure ratchet`：它的
  `baseline_entries=0`，任何新失败都会硬红并打印断言原文。
  本 PR 若引入回归，那道门会直接说出来。