### PR TITLE
docs(#1522): 修掉 #1751 留下的两处过期注释(仍写着「SIGTERM → 5s → SIGKILL」)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -10297,8 +10297,13 @@ Stop a running agent node.
   // 在 /proc/net/unix 里**一行都没有**,listeners=0 —— 它是个孤儿路径名,
   // 不是"还在拆卸"。成因:删它的 removeUnchangedStaleSocket 住在 agent-node
   // 进程里(grok-copresence/leader-lifecycle.ts:501),而 stop 的
-  // reapOwnedGeneration 是 SIGTERM → 5s → SIGKILL;负载下 agent-node 侧那条
-  // 拆卸链(每段默认 2000ms,最坏 8s)跑不完 5 秒就被 SIGKILL,清理永不执行。
+  // reapOwnedGeneration 是 SIGTERM → 宽限 → SIGKILL。**#1522 之前那个宽限是 5s**,
+  // 而负载下 agent-node 侧那条拆卸链(每段默认 2000ms,最坏 8s)跑不完 5 秒就被
+  // SIGKILL,清理永不执行。
+  // 🔴 #1751 已从另一端修掉:宽限 5s → 10s(10 > 8),并加了
+  //    agent-network/src/stop-grace-covers-teardown.test.ts 钉住
+  //    「CLI 宽限 > timeoutMs × 4」。下面这段窗口的历史成因保留在这里,
+  //    因为它解释了 #1385 当年为什么放大窗口也没用。
   // 于是这里的窗口在等一个五秒前被自己杀掉的清扫者 —— 窗口放到多大都等不到,
   // #1385 把 3s 放到 10s 只压低了命中率。
   //

--- a/agent-network/src/stale-socket.ts
+++ b/agent-network/src/stale-socket.ts
@@ -10,11 +10,14 @@
 // 也就是说残留的是一个**没有任何监听者的孤儿路径名**,不是"还在拆卸"。
 // 成因:删这个 socket 的 `removeUnchangedStaleSocket` 住在 agent-node 进程里
 // (grok-copresence/leader-lifecycle.ts:501),而 CLI 的 stop 走
-// `reapOwnedGeneration`:SIGTERM → 5s → SIGKILL。负载下 agent-node 侧那条
+// `reapOwnedGeneration`:SIGTERM → 宽限 → SIGKILL。**#1522 之前那个宽限是 5s**,
+// 而负载下 agent-node 侧那条
 // 拆卸链(每段默认 2000ms,最坏 2+2+2+2=8s)跑不完 5 秒就被 SIGKILL,
 // **清理代码永远不会执行**。于是 CLI 回到自己那 10 秒窗口,
 // 等一个五秒前被自己杀掉的清扫者 —— 窗口放到多大都等不到。
 // (#1385 把窗口 3s→10s 只压低了命中率,原理上修不掉。)
+// 🔴 #1751 从另一端修掉了它:宽限 5s → 10s(10 > 8),并用
+//    agent-network/src/stop-grace-covers-teardown.test.ts 钉住这条不等式。
 //
 // 🔴 判据取**最保守**的一版:只有 `/proc/net/unix` 里**完全找不到**这个路径
 //    才允许 unlink。仓里现有两个谓词各自更松一点 ——


### PR DESCRIPTION
docs(#1522): 修掉 #1751 留下的两处过期注释(仍写着「SIGTERM → 5s → SIGKILL」)

#1751 把 termDeadline 从 5_000 抬到 10_000,但仓里还有两处注释把 5s
当成**当前值**在描述:

  agent-network/bin/cli.ts      「reapOwnedGeneration 是 SIGTERM → 5s → SIGKILL」
  agent-network/src/stale-socket.ts  同一句话的另一份

这类同义副本最麻烦的地方是:改代码的人通常只改自己那一处,而**别人读到的
往往是另一处**。两处都改成「宽限」并标明 5s 是 #1522 之前的值,同时补上
「#1751 已从另一端修掉、并有 stop-grace-covers-teardown.test.ts 钉住」。

历史成因段落**保留** —— 它解释了 #1385 当年为什么把窗口 3s→10s 也没用,
删掉会让后来人重走一遍。

校验:两个文件里「SIGTERM → 5s → SIGKILL」命中数各为 0;
守卫测试 2 pass。

## 怎么发现的

改完 `#1751` 之后我去查「**有没有调用方带一个比新的最坏耗时(10+3=13s)更短的超时**」——
那是反方向的完整性检查。grep `reapOwnedGeneration` 时命中了两条**注释**：

```
agent-network/bin/cli.ts:10286        // reapOwnedGeneration 是 SIGTERM → 5s → SIGKILL；…
agent-network/src/stale-socket.ts:13  // `reapOwnedGeneration`：SIGTERM → 5s → SIGKILL。…
```

**我改了常量，没改描述它的两句话。** 而 `#1751` 的检查全绿 ——
**没有任何门会报这个**。

## 为什么这类副本值得单独修

改代码的人通常只改自己动到的那一处；而**别人读到的往往是另一处**。
这两句都是在解释「为什么 stale socket 的窗口放到多大都没用」——
一个来这里排查的人，读到的是**已经不成立的前提**。

## 保留了什么

历史成因那一段**没有删**：它解释了 `#1385` 当年把窗口 3s→10s 为什么也没用。
删掉会让后来人重走一遍。改的只是「5s 是**当前值**」这个断言 ——
现在写成「`#1522` 之前那个宽限是 5s」，并指向 `#1751` 与守卫测试。

## 验证

```
grep -c 'SIGTERM → 5s → SIGKILL'  两个文件各 **0**
bun test ./agent-network/src/stop-grace-covers-teardown.test.ts  →  **2 pass / 0 fail**
```

🔴 顺带：这个分支的基底我核过三条 —— HEAD=`302d729e`、守卫测试文件在、
`termDeadline` 是 `10_000`。第一次建 worktree 时用的是**本地陈旧的 `origin/main`**
(`acfaa5f7`)，若在那上面提交，这个 PR 会**静默回退 `#1751`**，而 diff 只显示注释改动。