### PR TITLE
docs(skillhub): 补上「私有平面」—— 现有两页只讲了公开 SkillHub (#1188 PR-A)

### DIFF
--- a/docs-site/docs/en/skillhub/index.md
+++ b/docs-site/docs/en/skillhub/index.md
@@ -31,6 +31,41 @@ anet skill show <slug>     # print a skill's SKILL.md (verified against content_
 `anet doctor` also reports one line on whether the SkillHub catalog is reachable and how many skills it has.
 Point at a different catalog (e.g. a private mirror) with the `ANET_SKILL_CATALOG_URL` env var.
 
+## There is also a **private** plane (shared inside one network, never via anet.sh)
+
+Everything above is the **public** SkillHub — a static catalog hosted on `anet.sh`
+that anyone can read. Each network additionally has a **private** SkillHub whose
+entries are visible only inside that network and **never** appear on anet.sh.
+
+**Read** (humans, from the CLI):
+
+```bash
+anet skill ls              # `anet skill list` works too
+anet skill show <slug>
+```
+
+**Write** (agents, through hub tools — the CLI has no write subcommand today):
+
+| Tool | Who may call it | What it does |
+|---|---|---|
+| `submit_skill` | any network member | submits a new version, which enters **pending** |
+| `review_skill` | **owner / admin only** | approves or rejects a pending version |
+| `list_skills` / `get_skill` | any network member | lists / fetches approved versions |
+
+Rejections come back with one of exactly four reasons:
+
+| `error` | Meaning |
+|---|---|
+| `skill_not_found` | no such skill in this network |
+| `skill_not_pending` | it is not awaiting review (already approved or rejected) |
+| `skill_review_admin_required` | caller is not owner/admin, or used a network-scoped token |
+| `skill_version_conflict` | the version collides with an existing record |
+
+🔴 **The two planes never flow into each other automatically.** Approving a private
+skill does **not** publish it to anet.sh, and a public catalog entry does **not**
+land in your private registry. Moving something from private to public goes through
+the [contribution flow](/en/skillhub/contribute) — an explicit, human submission.
+
 [How to contribute a public skill →](/en/skillhub/contribute)
 
 <PublicSkillHub lang="en" />

--- a/docs-site/docs/skillhub/index.md
+++ b/docs-site/docs/skillhub/index.md
@@ -29,6 +29,40 @@ anet skill show <slug>     # 打印某个 Skill 的 SKILL.md（下载按 content
 `anet doctor` 也会顺带报一行 SkillHub 目录是否可达、有多少个 Skill。
 指向别的 catalog（如私有镜像）：设环境变量 `ANET_SKILL_CATALOG_URL`。
 
+## 还有一个**私有**平面（同一个网络内共享，不经过 anet.sh）
+
+上面讲的都是**公共** SkillHub —— 它是一份放在 `anet.sh` 上的静态 catalog，谁都能读。
+除此之外，每个网络还有一份**私有**的 SkillHub，东西只在这个网络里可见，
+**不会**出现在 anet.sh 上。
+
+**读**（人用 CLI）：
+
+```bash
+anet skill ls              # 也可以写 anet skill list
+anet skill show <slug>
+```
+
+**写**（agent 通过 hub 的工具，CLI 目前没有对应子命令）：
+
+| 工具 | 谁能调 | 做什么 |
+|---|---|---|
+| `submit_skill` | 网络成员 | 提交一个新版本，进入 **pending** |
+| `review_skill` | **只有 owner / admin** | 通过或驳回一个 pending 版本 |
+| `list_skills` / `get_skill` | 网络成员 | 列举 / 取用已通过的版本 |
+
+被拒绝时返回的原因是**明确的四种**，照着排查即可：
+
+| `error` | 含义 |
+|---|---|
+| `skill_not_found` | 这个网络里没有这个 skill |
+| `skill_not_pending` | 它不在待审状态（已通过或已驳回） |
+| `skill_review_admin_required` | 调用者不是 owner/admin，或用的是网络级 token |
+| `skill_version_conflict` | 版本号与已有记录冲突 |
+
+🔴 **两个平面互不自动流动**：私有 skill 通过审核**不会**自动上 anet.sh；
+公开 catalog 里的 skill 也不会自动进你的私有注册表。
+把私有的东西放到公共平面，走的是[投稿流程](/skillhub/contribute)，那是一次显式的人工提交。
+
 [如何投稿公共 Skill →](/skillhub/contribute)
 
 <PublicSkillHub lang="zh" />


### PR DESCRIPTION
docs(skillhub): 补上「私有平面」—— 现有两页只讲了公开 SkillHub(#1188 的 PR-A)

docs-site 的 skillhub/index.md(中英)主语都是「公共 SkillHub」:34/34 行,
只讲 anet.sh 上那份静态 catalog。而每个网络还有一份私有 SkillHub,
用户读完现有文档**完全不知道它存在**。

补的这一节全部来自实现,没有编:

  读:  anet skill ls / anet skill show <slug>
       (实现里 `sub === "list" || sub === "ls"`,两个都接受)
  写:  submit_skill(成员)→ review_skill(owner/admin)→ list_skills/get_skill
       CLI 目前**没有**写侧子命令,这一点明说
  拒绝原因四种,逐条对应 tools.ts 的 error 常量:
       skill_not_found / skill_not_pending /
       skill_review_admin_required / skill_version_conflict
  🔴 admin 判断那一行还有一个容易踩的点:
       callerTokenIsNetwork || (role !== "owner" && role !== "admin")
       —— **网络级 token 也会被拒**,写进了表里
  🔴 两个平面**互不自动流动**:私有通过审核不会自动上 anet.sh;
     公开 catalog 也不会自动进私有注册表。这与 #1188 正文
     「not asking for automatic public publication」的边界一致。

中英平价。本地跑过 check-docs-locale-parity / check-docs-integrity /
check-home-path-baseline / check-docs-site-orphans,四个 rc=0。

## 这是 #1188 里 PR-A 的第一块

`#1188` 的唯一一条评论给出了分层交付栈，PR-A 是「docs/contract only」，含四项：

| PR-A 的四项 | 现状（量过） |
|---|---|
| 私有 SkillHub 运维 playbook | 🔴 两页主语都是「公共」，私有平面**完全没出现** |
| reviewer 清单 | ✅ 已由已发布的 skill `public-skill-review-checklist/1.0.0` 承担 |
| runtime 无关的安装契约 | 🔴 全仓 `安装契约`/`install contract` 命中 **0** |
| onboarding 写清私有/公开两平面 | 🔴 现有文档只讲公开那一半 |

**本 PR 做的是第 1 项与第 4 项**（它们在同一页上，分开写会重复）。
第 3 项（runtime 无关的安装契约）需要先确认 7 种 runtime 各自怎么装 skill，
不在本 PR 范围内。

## 写之前核过的三处（避免写出与实现不符的文档）

1. **`ls` vs `list`** —— 现有文档写 `anet skill ls`，而 `Usage` 文本写
   `anet skill list`。读实现：`if (sub === "list" || sub === "ls")` —— **两个都接受**，
   不是不一致。（差一步就报出一条假缺陷。）
2. **`anet doctor` 是否已提 SkillHub** —— 现有中文页已经写了它会报目录可达性与数量。
   本 PR **没有**重复这一条。
3. **admin 门槛的确切判断** —— `tools.ts`：
   `callerTokenIsNetwork || (role !== "owner" && role !== "admin")`
   ⇒ **网络级 token 也会被拒**。这一点只有读那一行才知道，已写进表里。

## 验证

四道门本地 `rc=0`：`check-docs-locale-parity`（中英平价）/ `check-docs-integrity` /
`check-home-path-baseline` / `check-docs-site-orphans`。纯文档，不改任何代码路径。