### PR TITLE
chore(anet): PINNED_SERVER_VERSION .44 → .45(.45 已在 npm preview 上)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1811,7 +1811,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.44";
+const PINNED_SERVER_VERSION = "0.9.0-preview.45";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/src/hub-version-skew.test.ts
+++ b/agent-network/src/hub-version-skew.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { formatHubVersionDetail } from "./hub-version-skew";
 
 const HUB = "http://127.0.0.1:9200";
-const PIN = "0.9.0-preview.44";
+const PIN = "0.9.0-preview.45";
 
 describe("formatHubVersionDetail (#1595)", () => {
   test("一致时不多说一句", () => {

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -51,11 +51,6 @@ set -uo pipefail
 #   回滚目标 = runtime-v32-run-terminal-d5199bc9，目录仍在；hub-daemon 备份见 rollback-693-*
 # 2026-08-13 00:5x: runtime-v33 → runtime-v34-preview29(0.9.0-preview.29;含 #698 peer-reply 终结原任务、#697 model 注入)
 #   回滚目标 = runtime-v33-upload-bridge-17b8223f(0.9.0-preview.27),目录仍在
-# 2026-09-02: preview44 → preview45（跟随 PINNED_SERVER_VERSION；app#225 节点规则文件）
-#   内容 = #1755 五个规则文件工具(read/write_node_rules_file、get_rules_file_result、
-#          get/ack_rules_file_request) + 表 node_rules_requests(启动时 CREATE TABLE IF NOT EXISTS,
-#          无迁移) + 门铃 rules_file；另 #1687/#1651 UTC 时间解析、#1632 daemon 报错文案
-#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 # 2026-08-28: preview29 → preview34（对齐 PINNED_SERVER_VERSION）
 #   🔴 这一条不是一次真实的机器升级记录,是**把仓库这份对齐到仓库自己声明的版本**。
 #      在此之前仓库启动器写 preview29、PINNED_SERVER_VERSION 写 preview.34,
@@ -91,6 +86,11 @@ set -uo pipefail
 #   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
 #      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
 #      在这里标出来，免得下一个人把这份历史当完整的读。
+# 2026-09-02: preview44 → preview45（跟随 PINNED_SERVER_VERSION；app#225 节点规则文件）
+#   内容 = #1755 五个规则文件工具(read/write_node_rules_file、get_rules_file_result、
+#          get/ack_rules_file_request) + 表 node_rules_requests(启动时 CREATE TABLE IF NOT EXISTS,
+#          无迁移) + 门铃 rules_file；另 #1687/#1651 UTC 时间解析、#1632 daemon 报错文案
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview45"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -51,6 +51,11 @@ set -uo pipefail
 #   回滚目标 = runtime-v32-run-terminal-d5199bc9，目录仍在；hub-daemon 备份见 rollback-693-*
 # 2026-08-13 00:5x: runtime-v33 → runtime-v34-preview29(0.9.0-preview.29;含 #698 peer-reply 终结原任务、#697 model 注入)
 #   回滚目标 = runtime-v33-upload-bridge-17b8223f(0.9.0-preview.27),目录仍在
+# 2026-09-02: preview44 → preview45（跟随 PINNED_SERVER_VERSION；app#225 节点规则文件）
+#   内容 = #1755 五个规则文件工具(read/write_node_rules_file、get_rules_file_result、
+#          get/ack_rules_file_request) + 表 node_rules_requests(启动时 CREATE TABLE IF NOT EXISTS,
+#          无迁移) + 门铃 rules_file；另 #1687/#1651 UTC 时间解析、#1632 daemon 报错文案
+#   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 # 2026-08-28: preview29 → preview34（对齐 PINNED_SERVER_VERSION）
 #   🔴 这一条不是一次真实的机器升级记录,是**把仓库这份对齐到仓库自己声明的版本**。
 #      在此之前仓库启动器写 preview29、PINNED_SERVER_VERSION 写 preview.34,
@@ -86,7 +91,7 @@ set -uo pipefail
 #   🔴 注意：上面的历史行只记到 preview37，而这一行改动前的值是 preview39 —— 
 #      preview37→39 那两跳没有留下记录。我不补写别人的历史（内容我不知道），
 #      在这里标出来，免得下一个人把这份历史当完整的读。
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview44"
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview45"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.44' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.45' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
`docs/tests/release-v0.9.0-preview.45.md` 里写的两步中的第 2 步:`0.9.0-preview.45` 已由 release-gate run 33586157333 发到 npm preview(`npm view` 可见),现在把三处字面量一起换:

- `agent-network/bin/cli.ts` `PINNED_SERVER_VERSION`
- `agent-network/src/hub-version-skew.test.ts` `PIN`
- `tests/test766-bunx-preflight/run.sh` 的 `grep -Fxq` 字面量

效果:`anet hub` 用 bunx 起本地 hub 时装 `.45`(带 app#225 的规则文件工具)。生产 hub(pm2 托管那台)不受此 PR 影响,升级仍是 owner 的动作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD