### PR TITLE
fix(hub): tools/list 不再抛 schema._zod —— 四处单参 z.record 改双参 (#1756)

### DIFF
--- a/server/src/tools-list-json-schema.test.ts
+++ b/server/src/tools-list-json-schema.test.ts
@@ -1,0 +1,66 @@
+// #1756 — 标准 MCP 客户端的 tools/list 必须能成功。
+//
+// 2026-09-02 量到:main 上 client.listTools() 直接抛
+//   McpError -32603: undefined is not an object (evaluating 'schema._zod')
+// 逐字段二分,肇事者是四处 `z.record(z.unknown())`(report_status.config_snapshot /
+// send_desktop_message.meta / update_node_config.patch.flags / create_node.node_spec.*):
+// zod v4 的 z.record 要两个参数(key, value),单参数时 value schema 是 undefined,
+// SDK 生成 JSON Schema 时对它取 `_zod` 就炸。修法:z.record(z.string(), z.unknown())。
+//
+// 这条测试守两件事:① listTools 整体成功且条数 == 登记表条数;② 每个工具单独都能
+// toJSONSchema —— 第 ② 条让下一次谁再写单参 record 时,红的是「哪个工具哪个字段」。
+// 跑法:cd server && COMMHUB_DB=/tmp/lt.db bun test src/tools-list-json-schema.test.ts
+import { describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import { registerTools } from "./tools.js";
+
+async function connect() {
+  const server = new McpServer({ name: "list-tools-test", version: "1" });
+  registerTools(server, undefined, "net_list_tools", "u_list_tools", "u_list_tools", false, "tok_list_tools");
+  const client = new Client({ name: "list-tools-client", version: "1" });
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await server.connect(st);
+  await client.connect(ct);
+  return { server, client, close: async () => { await client.close(); await server.close(); } };
+}
+
+describe("#1756 tools/list", () => {
+  test("every registered tool converts to JSON Schema on its own (names the offender)", async () => {
+    const { server, close } = await connect();
+    try {
+      const reg: Record<string, any> = (server as any)._registeredTools;
+      const names = Object.keys(reg);
+      expect(names.length).toBeGreaterThan(40);
+      const bad: string[] = [];
+      for (const n of names) {
+        const schema = reg[n]?.inputSchema;
+        const shape = schema?.shape ?? schema ?? {};
+        for (const [k, v] of Object.entries(shape)) {
+          try { z.toJSONSchema(z.object({ [k]: v as any })); } catch (e: any) { bad.push(`${n}.${k}: ${String(e?.message).slice(0, 60)}`); }
+        }
+      }
+      expect(bad).toEqual([]);
+    } finally { await close(); }
+  }, 20_000);
+
+  test("client.listTools() succeeds and returns every registered tool", async () => {
+    const { server, client, close } = await connect();
+    try {
+      const reg: Record<string, any> = (server as any)._registeredTools;
+      const listed = (await client.listTools()).tools;
+      expect(listed.length).toBe(Object.keys(reg).length);
+      const byName = new Set(listed.map(t => t.name));
+      for (const n of ["report_status", "send_desktop_message", "update_node_config", "create_node", "read_node_rules_file"]) {
+        expect(byName.has(n), n).toBe(true);
+      }
+      // 修过的四个字段在 JSON Schema 里必须是 object(不是 undefined / 空)
+      const schemaOf = (n: string) => listed.find(t => t.name === n)!.inputSchema as any;
+      expect(schemaOf("report_status").properties.config_snapshot).toBeDefined();
+      expect(schemaOf("send_desktop_message").properties.meta.type).toBe("object");
+      expect(schemaOf("update_node_config").properties.patch.properties.flags.type).toBe("object");
+    } finally { await close(); }
+  }, 20_000);
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -598,7 +598,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // can grey out remote-restart for them.
       config_snapshot: z.object({
         model: z.string().max(200).optional().nullable(),
-        flags: z.record(z.unknown()).optional(),
+        flags: z.record(z.string(), z.unknown()).optional(),
         config_revision: z.number().int().min(0).optional(),
         config_update_capable: z.boolean().optional(),
         peer_reply_inbox_capable: z.literal(true).optional(),
@@ -2377,7 +2377,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       message: z.string().min(1).max(10000),
       severity: z.enum(["info", "success", "warning", "error"]).optional().default("info"),
       kind: z.string().min(1).max(80).optional().default("agent_message"),
-      meta: z.record(z.unknown()).optional(),
+      meta: z.record(z.string(), z.unknown()).optional(),
       from_session: z.string().max(200).optional(),
       network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens; ntok stays bound to its network)."),
     },
@@ -2674,7 +2674,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       base_revision: z.number().int().min(0).describe("Current revision per the dashboard's last GET — 409 if hub's current revision differs."),
       patch: z.object({
         model: z.string().max(200).optional(),
-        flags: z.record(z.unknown()).optional(),
+        flags: z.record(z.string(), z.unknown()).optional(),
         // #260 P5 — channel enable/disable. Restart-tier field (agent-node
         // reads config.channels once at boot to fork per-channel workers,
         // so the swap takes effect via process restart). Not
@@ -2682,7 +2682,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         // (network scope) only.
         //
         // Deliberately `z.array(z.unknown()).max(16)` (mirrors flags's
-        // `z.record(z.unknown())`): trust nothing at the wire boundary,
+        // `z.record(z.string(), z.unknown())`): trust nothing at the wire boundary,
         // narrow the same way `narrowChannelsPatch` narrows raw untrusted
         // JSON (typeof + allowlist + dedup + case-fold). A strict
         // `z.array(z.string())` would fail-fast on a single non-string
@@ -3477,7 +3477,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         name: z.string().min(1).max(64),
         runtime: z.string().min(1).max(64),
         model: z.string().min(1).max(100).optional().nullable(),
-        flags: z.record(z.unknown()).optional(),
+        flags: z.record(z.string(), z.unknown()).optional(),
         env_refs: z.array(z.string().max(64)).optional(),
         channels: z.array(z.unknown()).optional(),
       }),


### PR DESCRIPTION
Closes #1756。

**根因**:zod v4 的 `z.record` 要 (key, value) 两个参数;`z.record(z.unknown())` 单参时 value schema 是 `undefined`,SDK 生成 JSON Schema 对它取 `_zod` 就炸,`client.listTools()` 整个 -32603。逐字段二分出四处(tools.ts 601 / 2380 / 2677 / 3480),正是 tsc 一直报 `Expected 2-3 arguments, but got 1` 的那四行。

**修法**:`z.record(z.string(), z.unknown())`。运行时语义不变(仍是任意字符串键 + 任意值);`create-node-tool-schema` / `config-apply-sec1` / `desktop-message-seam` / `ack-create-request-transport` / `rules-file-transport` 69/69 仍绿,test629(unknown-field policy)10/10。

**守卫** `server/src/tools-list-json-schema.test.ts`:① 每个登记工具单独 `toJSONSchema`,红时点名「哪个工具哪个字段」;② `listTools` 成功且条数 == 登记表。**witnessed-red**:stash 掉修复跑一次 2/2 红,修复后 2/2 绿。

影响面:生产 hub 从 .45 起对标准 MCP 客户端(Claude Code 的 MCP 接入、Inspector)的 `tools/list` 才能用;之前只有走直调 `tools/call` 的客户端不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD