### PR TITLE
fix(test1212): Windows 真机门失败时写脱敏后的定位证据 (#1749)

### DIFF
--- a/tests/test1212-windows-real-codex-gate/README.md
+++ b/tests/test1212-windows-real-codex-gate/README.md
@@ -38,3 +38,11 @@ Linux host evidence. Neither is relabelled as Windows real-Codex evidence.
 Only `result.json` and `report.txt` are uploaded. They contain no credential,
 raw terminal/app-server/bridge log, absolute private path, or raw thread/turn
 ID. The entire private root is ACL-restricted and deleted after the run.
+
+## Failure evidence (#1749)
+
+When the journey fails, `result.json` is still written — with `phase` (which of the 9 steps),
+`error.message`, and for ConPTY failures `conpty.{exitCode, elapsedMs, timedOut, outputTail}`.
+Everything passes through `failure-evidence.mjs` first: this run's token, `COMMHUB_AUTH_TOKEN`,
+the private root, `HOME` and `CODEX_HOME` are replaced, and token-shaped strings are masked.
+`report.txt` carries the same in prose. `static-contract.mjs` checks the redaction both ways.

--- a/tests/test1212-windows-real-codex-gate/failure-evidence.mjs
+++ b/tests/test1212-windows-real-codex-gate/failure-evidence.mjs
@@ -1,0 +1,58 @@
+// #1749 — Windows 真机门失败时的证据形状。
+//
+// 之前 run.ps1 的 catch 只写 `result: FAIL` + 自己抛的那句 "real Windows journey failed",
+// artifact 里 331 字节,没有任何能定位的信息(ConPTY exit 1 发生在 10.5s,与 180s 超时
+// 无关 —— 这个事实当时只能从 job 时长反推)。
+//
+// 这里给 journey 一个统一的失败证据:阶段名、错误、ConPTY 退出码/耗时/输出尾巴,
+// 全部先脱敏再落盘。脱敏不复用 agent-node 的 credential-redaction.ts(那是 TS,
+// journey 用 node 直接跑 .mjs),规则照它的形状:token 前缀、Bearer、sk- 密钥、
+// 以及本次 run 的私有路径与已知秘密字面量。
+const TOKEN_SHAPES = [
+  /\b[aun]tok_[A-Za-z0-9._-]{6,}/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\bsk-[A-Za-z0-9_-]{8,}/g,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{10,}/g,
+  /\bxox[abp]-[A-Za-z0-9-]{10,}/g,
+];
+
+export function redactForArtifact(text, { secrets = [], paths = [] } = {}) {
+  let s = String(text ?? "");
+  for (const secret of secrets.filter(x => typeof x === "string" && x.length >= 6)) s = s.split(secret).join("<redacted-secret>");
+  for (const p of paths.filter(x => typeof x === "string" && x.length >= 4)) {
+    s = s.split(p).join("<private-path>");
+    s = s.split(p.replaceAll("\\", "/")).join("<private-path>");
+  }
+  for (const re of TOKEN_SHAPES) s = s.replace(re, "<redacted-token>");
+  return s;
+}
+
+/** 输出尾巴:去掉 ANSI/控制序列后取最后 maxChars 个字符。ConPTY 重绘不算证据,但
+ *  最后几行往往就是报错本身。 */
+export function outputTail(out, maxChars = 2000) {
+  const plain = String(out ?? "").replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "").replace(/\x1b\][^\x07]*\x07/g, "").replace(/\r/g, "");
+  return plain.length > maxChars ? plain.slice(plain.length - maxChars) : plain;
+}
+
+/** 把 terminal() 的失败塞进 Error,journey 的 catch 直接读。 */
+export function attachConptyDiag(error, { exitCode, elapsedMs, out, timedOut }) {
+  error.conpty = { exitCode: exitCode ?? null, elapsedMs, timedOut: Boolean(timedOut), outputTail: outputTail(out) };
+  return error;
+}
+
+export function failureEvidence({ error, phase, base = {}, redact = { secrets: [], paths: [] } }) {
+  const r = text => redactForArtifact(text, redact);
+  return {
+    ...base,
+    result: "FAIL",
+    phase: phase ?? "unknown",
+    error: { name: error?.name ?? "Error", message: r(error?.message ?? String(error)), stack: r(error?.stack ?? "").split("\n").slice(0, 8).join("\n") },
+    conpty: error?.conpty ? { ...error.conpty, outputTail: r(error.conpty.outputTail) } : null,
+    failedAt: new Date().toISOString(),
+  };
+}
+
+export function failureReport(ev) {
+  const c = ev.conpty ? `conpty: exit=${ev.conpty.exitCode} elapsedMs=${ev.conpty.elapsedMs} timedOut=${ev.conpty.timedOut}\n--- output tail ---\n${ev.conpty.outputTail}\n` : "";
+  return `test1212 Windows real Codex protected manual gate\nresult: FAIL\nphase: ${ev.phase}\nsource: ${ev.sourceSha}\nerror: ${ev.error.message}\n${c}NOT-IN-CI: credential-bearing manual gate; evidence scrubbed.\n`;
+}

--- a/tests/test1212-windows-real-codex-gate/static-contract.mjs
+++ b/tests/test1212-windows-real-codex-gate/static-contract.mjs
@@ -52,3 +52,34 @@ let reads = 0;
 const late = await pollCompletedAssistant(async () => ({ turns: [reads++ < 2 ? promptOnly : { ...promptOnly, items: [...promptOnly.items, { id: "a1", type: "agentMessage", text: `${nonce} HUMAN_DONE` }] }] }), "t", before, nonce, { timeoutMs: 1000, intervalMs: 1 });
 requireContract(late.item.id === "a1" && reads === 3, "bounded poll did not wait for late assistant");
 console.log(`PASS test1212 LF+CRLF + prompt-only red + late-assistant green + ${mutations.length} mutations red`);
+
+// ── #1749 失败证据:journey 失败时 result.json 必须带脱敏后的定位信息 ─────────
+import { attachConptyDiag, failureEvidence, failureReport, outputTail, redactForArtifact } from "./failure-evidence.mjs";
+{
+  const j = journey;
+  requireContract(/attachConptyDiag\(new Error\(`ConPTY exit \$\{exitCode\}`\)/.test(j) && /attachConptyDiag\(new Error\("ConPTY timeout"\)/.test(j), "ConPTY failures do not carry exit/elapsed/tail diag");
+  requireContract(/\} catch \(error\) \{[\s\S]*failureEvidence\(\{ error, phase/.test(j) && /failureReport\(ev\)/.test(j), "journey catch does not write failure evidence");
+  requireContract((j.match(/^\s*phase = "/gm) || []).length >= 8, "fewer than 8 phase markers — a FAIL would not say where");
+  requireContract(/redact: \{ secrets: \[token, process\.env\.COMMHUB_AUTH_TOKEN\], paths: \[privateRoot, home, codexHome\] \}/.test(j), "failure evidence not redacted against this run's token and private paths");
+
+  // 功能:脱敏两向。正例每种形状都要变成占位;负控:普通文本逐字不变。
+  const priv = "C:\\Users\\x\\AppData\\Local\\Temp\\t1212";
+  const red = redactForArtifact(`ntok_abcdef123456 utok_zzzzzz9999 Bearer QWxhZGRpbjpvcGVu sk-abcdefghijkl ghp_abcdefghijklmnop path=${priv}\\work also ${priv.replaceAll("\\", "/")}/hub.db secret=super-secret-value`, { secrets: ["super-secret-value"], paths: [priv] });
+  for (const bad of ["ntok_abcdef123456", "utok_zzzzzz9999", "QWxhZGRpbjpvcGVu", "sk-abcdefghijkl", "ghp_abcdefghijklmnop", priv, "super-secret-value", "Temp/t1212"]) requireContract(!red.includes(bad), `leak survived redaction: ${bad}`);
+  requireContract(red.includes("<redacted-token>") && red.includes("<private-path>") && red.includes("<redacted-secret>"), "redaction placeholders missing");
+  const plain = "ConPTY exit 1 after opening Codex TUI; node start windows-real --no-inherit-codex-home";
+  requireContract(redactForArtifact(plain, { secrets: [], paths: [] }) === plain, "negative control: plain diagnostic text was altered");
+
+  // 输出尾巴:去 ANSI、有界。
+  const tail = outputTail("\x1b[2J\x1b[1;1H" + "x".repeat(5000) + "\r\nlast line", 100);
+  requireContract(!tail.includes("\x1b") && tail.length === 100 && tail.endsWith("last line"), "outputTail must strip ANSI and keep the last N chars");
+
+  // 证据形状:conpty 尾巴也走脱敏;phase/error 齐全;report 可读。
+  const err = attachConptyDiag(new Error("ConPTY exit 1"), { exitCode: 1, elapsedMs: 10500, out: "boot\nToken ntok_leakleakleak here\nerror: spawn EPERM", timedOut: false });
+  const ev = failureEvidence({ error: err, phase: "first-node-start-conpty", base: { schema: "anet/windows-real-codex-gate/v1", sourceSha: "deadbeef", notInCi: true }, redact: { secrets: [], paths: [] } });
+  requireContract(ev.result === "FAIL" && ev.phase === "first-node-start-conpty" && ev.conpty.exitCode === 1 && ev.conpty.elapsedMs === 10500 && ev.conpty.timedOut === false, "failure evidence shape wrong");
+  requireContract(!JSON.stringify(ev).includes("ntok_leakleakleak") && ev.conpty.outputTail.includes("spawn EPERM"), "conpty tail must be redacted but keep the error line");
+  const rep = failureReport(ev);
+  requireContract(/result: FAIL/.test(rep) && /phase: first-node-start-conpty/.test(rep) && /exit=1 elapsedMs=10500/.test(rep) && !rep.includes("ntok_leakleakleak"), "report.txt shape wrong");
+  console.log("#1749 failure-evidence contracts: ok");
+}

--- a/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
+++ b/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 import pty from "../../agent-network/node_modules/node-pty/lib/index.js";
 import { assistantItems, assistantSnapshot, pollCompletedAssistant } from "./thread-evidence.mjs";
+import { attachConptyDiag, failureEvidence, failureReport } from "./failure-evidence.mjs";
 
 if (process.platform !== "win32") throw new Error("real gate requires native Windows ConPTY");
 const repo = resolve(import.meta.dirname, "../..");
@@ -31,9 +32,10 @@ const marker = `WINDOWS_REAL_${randomUUID().replaceAll("-", "")}`;
 const sleepSeconds = 70;
 const evidence = { schema: "anet/windows-real-codex-gate/v1", result: "FAIL", notInCi: true, sourceSha: expectedSha, codexVersion: "0.148.0", platform: process.platform, conpty: true };
 const delay = ms => new Promise(r => setTimeout(r, ms));
+let phase = "setup";
 async function wait(label, fn, ms = 30000) { const end = Date.now() + ms; while (Date.now() < end) { if (await fn()) return; await delay(200); } throw new Error(`timeout: ${label}`); }
 function run(args, input = "") { const r = spawnSync(bun, [cli, ...args], { cwd: project, env, input, encoding: "utf8", timeout: 60000 }); if (r.status) throw new Error(`anet ${args.join(" ")} failed`); return `${r.stdout}${r.stderr}`; }
-function terminal(args, drive, ms = 180000) { return new Promise((ok, bad) => { const child = pty.spawn(bun, [cli, ...args], { cwd: project, env, cols: 140, rows: 45 }); let out = ""; const timer = setTimeout(() => { child.kill(); bad(new Error("ConPTY timeout")); }, ms); child.onData(d => { out += d; drive?.(child, out); }); child.onExit(({ exitCode }) => { clearTimeout(timer); exitCode === 0 ? ok(out) : bad(new Error(`ConPTY exit ${exitCode}`)); }); }); }
+function terminal(args, drive, ms = 180000) { return new Promise((ok, bad) => { const startedAt = Date.now(); const child = pty.spawn(bun, [cli, ...args], { cwd: project, env, cols: 140, rows: 45 }); let out = ""; const timer = setTimeout(() => { child.kill(); bad(attachConptyDiag(new Error("ConPTY timeout"), { exitCode: null, elapsedMs: Date.now() - startedAt, out, timedOut: true })); }, ms); child.onData(d => { out += d; drive?.(child, out); }); child.onExit(({ exitCode }) => { clearTimeout(timer); exitCode === 0 ? ok(out) : bad(attachConptyDiag(new Error(`ConPTY exit ${exitCode}`), { exitCode, elapsedMs: Date.now() - startedAt, out, timedOut: false })); }); }); }
 async function task(auth, network, priority) { const r = await fetch(`http://127.0.0.1:${port}/api/task`, { method: "POST", headers: { Authorization: `Bearer ${auth}`, "Content-Type": "application/json" }, body: JSON.stringify({ alias: "windows-real", from: "test1212", network_id: network, priority, task: `${priority} gate message; reply with ${priority.toUpperCase()}_OK`, meta: { source: "dashboard-chat", client_request_id: randomUUID() } }) }); const b = await r.json(); if (!r.ok || !b.task_id) throw new Error("task post failed"); return b.task_id; }
 async function readThread(remote, threadId) {
   const ws = new WebSocket(remote);
@@ -46,12 +48,15 @@ async function readThread(remote, threadId) {
   } finally { ws.close(); }
 }
 try {
+  phase = "hub-boot";
   await wait("temporary Hub", async () => { try { return (await fetch(`http://127.0.0.1:${port}/health`)).ok; } catch { return false; } });
+  phase = "register-login-create";
   run(["register", "--username", "test1212", "--password", "pass123456", "--hub", `http://127.0.0.1:${port}`]);
   run(["login", "--username", "test1212", "--password", "pass123456", "--hub", `http://127.0.0.1:${port}`]);
   run(["node", "create", "windows-real", "--runtime", "codex-app-server", "--copresence", "true", "--hub", `http://127.0.0.1:${port}`]);
   mkdirSync(nodeHome, { recursive: true });
   writeFileSync(join(nodeHome, "auth.json"), readFileSync(join(codexHome, "auth.json")), { mode: 0o600 });
+  phase = "pin-agent-node";
   const exactRoot = join(privateRoot, "exact", "node_modules", "@sleep2agi", "agent-node"), exactDist = join(exactRoot, "dist");
   mkdirSync(exactDist, { recursive: true });
   writeFileSync(join(exactRoot, "package.json"), JSON.stringify({ name: "@sleep2agi/agent-node", version: pairedVersion, publishConfig: { tag: "preview" }, bin: { "agent-node": "dist/cli.js" } }));
@@ -63,6 +68,7 @@ try {
   env.PATH = `${bin};${env.PATH}`;
   const cfgPath = join(project, ".anet", "nodes", "windows-real", "config.json");
   let injected = false, injectionAt = 0, activeTurnId, preAssistantSnapshot, taskIds = [], drivePromise, driveError;
+  phase = "first-node-start-conpty";
   await terminal(["node", "start", "windows-real", "--no-inherit-codex-home"], (child, output) => {
     if (!injected && output.includes("opening Codex TUI")) {
       injected = true;
@@ -91,17 +97,21 @@ try {
       }, 7000);
     }
   });
+  phase = "active-turn-witness";
   if (drivePromise) await drivePromise;
   if (driveError) throw driveError;
   if (!injected || !injectionAt || !activeTurnId || !preAssistantSnapshot || !taskIds.length) throw new Error("active human turn was not driven");
+  phase = "bridge-and-steer-checks";
   const cfg1 = JSON.parse(readFileSync(cfgPath, "utf8"));
   const bridgeLog = readFileSync(join(project, ".anet", "nodes", "windows-real", "windows-bridge.log"), "utf8");
   const steered = (bridgeLog.match(/\(steered\)/g) || []).length;
   if (steered !== 2 || /\(queued|FIFO|new turn/i.test(bridgeLog)) throw new Error("normal/high did not both steer the active turn");
   const managed = JSON.parse(readFileSync(join(project, ".anet", "nodes", "windows-real", "windows-copresence.json"), "utf8"));
   if (managed.processes.filter(x => x.role === "bridge").length !== 1) throw new Error("not exactly one bridge");
+  phase = "stop";
   run(["node", "stop", "windows-real"]);
   if (existsSync(join(project, ".anet", "nodes", "windows-real", "windows-copresence.json"))) throw new Error("stop left managed processes");
+  phase = "restart-preserves-thread";
   let exited = false;
   await terminal(["node", "start", "windows-real", "--no-inherit-codex-home"], (child, output) => { if (!exited && output.includes(marker)) { exited = true; child.write("/exit\r"); } }, 90000);
   const cfg2 = JSON.parse(readFileSync(cfgPath, "utf8"));
@@ -110,4 +120,10 @@ try {
   Object.assign(evidence, { result: "PASS", sourceBound: true, codexLauncherSha256: process.env.ANET_TEST1212_LAUNCHER_SHA256, codexVendorSha256: process.env.ANET_TEST1212_VENDOR_SHA256, realBuiltAgentNode: true, sameHomeRemoteThread: true, activeHumanTurnSecondsMinimum: 60, humanTurnBoundary: "authoritative thread/read: inProgress before task posts; same turn completed with HUMAN_DONE assistant item after task terminals", priorities: ["normal", "high"], taskCount: 2, steeredCount: 2, turnStartOutcomeDelta: 0, turnStartEvidenceBoundary: "derived from two production bridge '(steered)' outcomes and absence of queued/new-turn outcome; not a raw RPC wire count", bridgeCount: 1, stopRestartHistory: true, rawLogsUploaded: false });
   writeFileSync(join(artifacts, "result.json"), JSON.stringify(evidence, null, 2));
   writeFileSync(join(artifacts, "report.txt"), `test1212 Windows real Codex protected manual gate\nresult: PASS\nsource: ${expectedSha}\nNOT-IN-CI: credentialed GitHub-hosted windows-latest/ConPTY gate\nCodex: 0.148.0; real built agent-node: yes\nnormal+high: authoritative thread/read active before posts, same turn completed with HUMAN_DONE after terminals and >=60s\nturn/start outcome delta: 0 (derived bridge outcome, NOT raw-wire evidence)\nsame HOME/remote/thread; one bridge; stop/restart history: PASS\ncredentials, raw logs, paths and thread IDs: not uploaded\n`);
+} catch (error) {
+  // #1749 —— 失败也要留下能定位的证据(脱敏后)。之前只有 run.ps1 的 catch 写一个
+  // 没有信息量的 FAIL。私有路径与本次 token 一律打码;真凭据(auth.json)从不进 artifact。
+  const ev = failureEvidence({ error, phase, base: evidence, redact: { secrets: [token, process.env.COMMHUB_AUTH_TOKEN], paths: [privateRoot, home, codexHome] } });
+  try { writeFileSync(join(artifacts, "result.json"), JSON.stringify(ev, null, 2)); writeFileSync(join(artifacts, "report.txt"), failureReport(ev)); } catch {}
+  throw error;
 } finally { try { run(["node", "stop", "windows-real"]); } catch {} hub.kill(); }


### PR DESCRIPTION
Closes #1749。

**问题**:失败时 artifact 只有 run.ps1 catch 自己抛的那句话(331 字节),定位不了。

**改法**(全在 `tests/test1212-windows-real-codex-gate/`):
- `failure-evidence.mjs`:`redactForArtifact`(本次 token / `COMMHUB_AUTH_TOKEN` / 私有路径两种斜杠 / ntok|utok|atok、Bearer、sk-、ghp_、xox 形状)、`outputTail`(去 ANSI、有界 2000 字符)、`attachConptyDiag`、`failureEvidence`、`failureReport`。
- `windows-real-e2e.mjs`:`terminal()` 失败时带 `exitCode / elapsedMs / timedOut / outputTail`;9 个 `phase` 标记;`catch` 先脱敏再写 `result.json` + `report.txt`,然后 rethrow(run.ps1 的 catch 仍在,但 journey 先写的文件更有信息)。真凭据 `auth.json` 从不进 artifact。
- `static-contract.mjs`(qa.yml 里 ubuntu 跑):4 条源码契约 + 功能检查(脱敏 8 种形状正例、负控逐字不变、尾巴去 ANSI 且有界、证据形状、report);**witnessed-red**:把 catch 的脱敏参数改成空 → `failure evidence not redacted against this run's token and private paths`。

本地 `node tests/test1212-windows-real-codex-gate/static-contract.mjs` rc=0(原 11 个变异仍红 + 新契约 ok)。真机 Windows 走 `windows-real-codex-gate` 手动触发,不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD