### PR TITLE
docs(getting-started): latest 戳 .47 → .76 —— promote 之后戳漂了,拦下了 .46 发布

### DIFF
--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -6,7 +6,7 @@
      version being published against these stamps and blocks the release, listing every line to update.
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
-<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
+<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
 <!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.76 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
@@ -25,7 +25,7 @@ Skip this page and go to the [Upgrade Guide](/en/guide/upgrade) (usually `anet u
 
 - **Node.js ≥ 22.13.0**
 - **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun that step always fails**, but how depends on the channel:
-  · **builds that carry the preflight** (measured 2026-08-30: `latest` = `2.3.0-preview.47`, and `preview`): refused before launch with `❌ anet hub start requires the Bun runtime` (exit code 1);
+  · **builds that carry the preflight** (measured 2026-08-30 on `2.3.0-preview.47`; since 2026-09-02 both `latest` and `preview` are `2.3.0-preview.76`, and the preflight has been present since `.47`): refused before launch with `❌ anet hub start requires the Bun runtime` (exit code 1);
   · **older builds without it** (measured on `2.2.21`): a bare `Error: spawn bunx ENOENT` plus a Node stack trace.
   After installing, `bun --version` should print a version.
 
@@ -101,7 +101,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.76` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.76` (current `latest` and `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -5,7 +5,7 @@
      同时变假。release gate 会拿正在发的版本和这两条戳比对,不一致就拦下发布并列出
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
-<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.47 -->
+<!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
 <!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.76 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
@@ -24,7 +24,7 @@
 
 - **Node.js ≥ 22.13.0**
 - **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 时第 2 步一定失败**，但表现分两条线:
-  · **含 preflight 的构建**（2026-08-30 实测:`latest` = `2.3.0-preview.47`、以及 `preview`）:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`（退出码 1）；
+  · **含 preflight 的构建**（2026-08-30 在 `2.3.0-preview.47` 上实测；2026-09-02 起 `latest` 与 `preview` 都是 `2.3.0-preview.76`，preflight 自 `.47` 起一直在）:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`（退出码 1）；
   · **更早、不含 preflight 的构建**（实测 `2.2.21`）:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈。
   装完 `bun --version` 应有输出。
 
@@ -99,7 +99,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.76`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.76`(当前 `latest` 与 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 


### PR DESCRIPTION
release run 33701933272(commhub-server .46)闸 4 红:`latest 戳说 agent-network=2.3.0-preview.47,而 npm 上 dist-tags.latest 是 2.3.0-preview.76`。09-02 14:17 我把 .76 promote 到 latest 时没更新上手指南的戳。

改两份 getting-started 的 latest 戳 + 正文两处「latest = .47」的时态(.47 上实测的事实保留,补一句 latest/preview 现在都是 .76,preflight 自 .47 起一直在)。本地用 CI 同款参数跑 gate 4 两个包都 rc=0;docs-integrity / locale-parity / release-channel-assertions rc=0。

合并后重触发 .46 的 release-gate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD