### PR TITLE
feat(agent-node): #1615 钉版 —— 启动通过校验的 grok 可执行文件写回 config,下次优先用它

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -22,6 +22,7 @@ import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
 import { packageRootFrom } from "./runtime/package-root";
 import { processRulesFileRequests } from "./runtime/rules-file";
+import { chooseGrokBinary, grokBinaryPinToRecord } from "./runtime/grok-binary-pin";
 
 // 🔴 这三处原先都喂 `__dirname`,而打包器把它内联成构建期常量 —— 见 #1433。
 // `resolveAgentNodeDir` 的注释里写着「运行时 thisModuleDir 是 .../agent-node/dist」,
@@ -928,6 +929,26 @@ function writebackSession(sessionId: string) {
     debug(`session 写回: ${configFilePath} → ${sessionId.slice(0, 8)}...`);
   } catch (e: any) {
     warn(`writebackSession failed: ${e.message}`);
+  }
+}
+
+// #1615 —— 把启动时真正通过校验的 grok 可执行文件(绝对路径 + 版本横幅)写回 config,
+// 下次 chooseGrokBinary 优先用它。裸名先按当时的 PATH 解析;解析不出就不记(不猜)。
+function writebackGrokBinaryPin(binary: string, versionLine: string, pathEnv: string | undefined) {
+  if (!configFilePath) return;
+  try {
+    const { resolveGrokCommhubMcpCommand } = require("./runtime/grok-build-cli-home");
+    const absolute = isAbsolute(binary) ? binary : resolveGrokCommhubMcpCommand(binary, String(pathEnv ?? process.env.PATH ?? ""));
+    const record = grokBinaryPinToRecord(absolute, versionLine);
+    if (!record) return;
+    const cfg = JSON.parse(readFileSync(configFilePath, "utf-8"));
+    if (cfg.grokBinary === record.grokBinary && cfg.grokBinaryVersion === record.grokBinaryVersion) return;
+    cfg.grokBinary = record.grokBinary;
+    cfg.grokBinaryVersion = record.grokBinaryVersion;
+    atomicWriteJson(configFilePath, cfg);
+    log(`[grok] pinned binary written back: ${record.grokBinary} (${record.grokBinaryVersion})`);
+  } catch (e: any) {
+    warn(`writebackGrokBinaryPin failed: ${e?.message || e}`);
   }
 }
 
@@ -3929,7 +3950,12 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       );
     }
 
-    const grokBinary = process.env.GROK_BINARY || "grok";
+    // #1615 —— 优先用 config 里上次启动钉住的绝对路径(GROK_BINARY 仍然最优先),
+    //    daemon 自动拉起 / anet daemon restart 这些没法带环境变量的路径上也能钉住版本。
+    const grokChoice = chooseGrokBinary({ env: process.env as { GROK_BINARY?: string }, config: fileConfig as any, existsSync });
+    if (grokChoice.warning) warn(`[grok-copresence] ${grokChoice.warning}`);
+    const grokBinary = grokChoice.binary;
+    log(`[grok-copresence] grok binary: ${grokBinary} (from ${grokChoice.source})`);
     // 🔴 2026-08-20：共存把 process.cwd() 整个交给 grok 的 folder trust，而那道闸
     //    拒绝 $HOME 与文件系统根；而 `anet node create` 的注册表是 cwd 相对的
     //    （agent-network/bin/cli.ts:145 nodesDir() = <cwd>/.anet/nodes）。
@@ -4076,6 +4102,8 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       assertGrokCliVersion(version);
       assertGrokCopresenceVersion(version);
       assertGrokCopresenceFeatures(help);
+      // #1615 —— 校验通过的这个文件就是下次要钉的:裸名先解析成绝对路径再记。
+      writebackGrokBinaryPin(grokBinary, version, initialRuntime.env.PATH);
     } catch (error: any) {
       throw new Error(
         `Grok CLI is missing or too old for co-presence (${error?.message || error}). `
@@ -4381,7 +4409,11 @@ async function processWithGrokCli(
     warn(`[grok-cli] image attachments are not wired into --prompt-json yet; sending text-only prompt`);
   }
 
-  const grokBinary = process.env.GROK_BINARY || "grok";
+  // #1615 —— 同共存路径:config 钉的绝对路径优先于 PATH 裸名(GROK_BINARY 最优先)。
+  const grokChoice = chooseGrokBinary({ env: process.env as { GROK_BINARY?: string }, config: fileConfig as any, existsSync });
+  if (grokChoice.warning) warn(`[grok-cli] ${grokChoice.warning}`);
+  const grokBinary = grokChoice.binary;
+  log(`[grok-cli] grok binary: ${grokBinary} (from ${grokChoice.source})`);
   // Unlike ACP, the CLI lane is a coding runtime: it must operate in the real
   // worktree so git metadata and atomic writes retain normal semantics.
   const grokCwd = process.cwd();
@@ -4484,6 +4516,8 @@ async function processWithGrokCli(
       });
       assertGrokCliVersion(version);
       assertGrokCliFeatures(help);
+      // #1615 —— 同共存路径:校验通过的这个文件写回 config 作为下次的钉。
+      writebackGrokBinaryPin(grokBinary, version, initialRuntime.env.PATH);
       validatedGrokCliBinary = grokBinary;
       debug(`[grok-cli] ${version}`);
     } catch (error: any) {

--- a/agent-node/src/runtime/grok-binary-pin.test.ts
+++ b/agent-node/src/runtime/grok-binary-pin.test.ts
@@ -1,0 +1,39 @@
+// #1615 钉版:三级优先 + 钉的路径失效时的退回与说明。
+// 跑法:cd agent-node && bun test src/runtime/grok-binary-pin.test.ts
+import { describe, expect, test } from "bun:test";
+import { chooseGrokBinary, grokBinaryPinToRecord } from "./grok-binary-pin";
+
+const exists = (set: string[]) => (p: string) => set.includes(p);
+
+describe("chooseGrokBinary", () => {
+  test("GROK_BINARY 环境变量永远优先(既有语义不变)", () => {
+    expect(chooseGrokBinary({ env: { GROK_BINARY: "/opt/grok-1.0.5" }, config: { grokBinary: "/home/u/.grok/downloads/grok-1.0.5" }, existsSync: exists(["/home/u/.grok/downloads/grok-1.0.5"]) }))
+      .toEqual({ binary: "/opt/grok-1.0.5", source: "env" });
+  });
+  test("无 env、config 钉了且文件还在 → 用钉的", () => {
+    expect(chooseGrokBinary({ env: {}, config: { grokBinary: "/home/u/.grok/downloads/grok-1.0.5" }, existsSync: exists(["/home/u/.grok/downloads/grok-1.0.5"]) }))
+      .toEqual({ binary: "/home/u/.grok/downloads/grok-1.0.5", source: "config" });
+  });
+  test("钉的文件没了 → 退回 PATH,并说清为什么", () => {
+    const c = chooseGrokBinary({ env: {}, config: { grokBinary: "/home/u/.grok/downloads/grok-1.0.5" }, existsSync: exists([]) });
+    expect(c.binary).toBe("grok"); expect(c.source).toBe("path"); expect(c.warning).toMatch(/no longer exists/);
+  });
+  test("钉的不是绝对路径 → 无视并说明(防止 config 里塞个 PATH 相对名当钉)", () => {
+    const c = chooseGrokBinary({ env: {}, config: { grokBinary: "grok" }, existsSync: exists(["grok"]) });
+    expect(c.binary).toBe("grok"); expect(c.warning).toMatch(/not an absolute path/);
+  });
+  test("什么都没有 → 老行为:PATH 上的 grok", () => {
+    expect(chooseGrokBinary({ env: {}, config: null, existsSync: exists([]) })).toEqual({ binary: "grok", source: "path" });
+  });
+  test("空串 env 不算指定", () => {
+    expect(chooseGrokBinary({ env: { GROK_BINARY: "  " }, config: null, existsSync: exists([]) }).source).toBe("path");
+  });
+});
+
+describe("grokBinaryPinToRecord", () => {
+  test("只记绝对路径", () => {
+    expect(grokBinaryPinToRecord("grok", "grok 1.0.5 (5115b46bc9)")).toBeNull();
+    expect(grokBinaryPinToRecord("/home/u/.grok/downloads/grok-1.0.5", "grok 1.0.5 (5115b46bc9) [stable]\n"))
+      .toEqual({ grokBinary: "/home/u/.grok/downloads/grok-1.0.5", grokBinaryVersion: "grok 1.0.5 (5115b46bc9) [stable]" });
+  });
+});

--- a/agent-node/src/runtime/grok-binary-pin.ts
+++ b/agent-node/src/runtime/grok-binary-pin.ts
@@ -1,0 +1,57 @@
+// #1615 —— grok CLI 会自我更新;更新到验证清单之外的版本后,**正在跑的节点表面正常,
+// 下一次重启才起不来**,而 daemon 自动拉起 / anet daemon restart 这些自动化路径上没有
+// 地方带 GROK_BINARY。
+//
+// 这里做的是「钉版」:节点启动并通过版本校验之后,把它**实际用的那个可执行文件的
+// 绝对路径**和版本横幅写回自己的 config;之后再起时:
+//   1. GROK_BINARY 环境变量(人显式指定)永远优先 —— 不改既有语义;
+//   2. 否则用 config 里钉的绝对路径,前提是它还存在;
+//   3. 否则退回 PATH 上的裸名 `grok`(老行为)。
+// 钉的路径照样要过验证清单(调用方原有的 assertGrok*Version 不动),所以 fail-closed 没放松:
+// 钉住的是「同一台机上次能起的那个文件」,不是「任何文件」。
+import { isAbsolute } from "node:path";
+
+export interface GrokBinaryPin {
+  /** 上次启动实际用的绝对路径。 */
+  grokBinary?: string;
+  /** 上次启动看到的 `grok --version` 横幅,只用于显示/诊断。 */
+  grokBinaryVersion?: string;
+}
+
+export type GrokBinarySource = "env" | "config" | "path";
+
+export interface GrokBinaryChoice {
+  binary: string;
+  source: GrokBinarySource;
+  /** 钉的路径不能用时的说明(退回 PATH 之前告诉人为什么)。 */
+  warning?: string;
+}
+
+export function chooseGrokBinary(input: {
+  env: { GROK_BINARY?: string };
+  config: GrokBinaryPin | null | undefined;
+  existsSync: (p: string) => boolean;
+}): GrokBinaryChoice {
+  const fromEnv = (input.env.GROK_BINARY || "").trim();
+  if (fromEnv) return { binary: fromEnv, source: "env" };
+  const pinned = (input.config?.grokBinary || "").trim();
+  if (pinned) {
+    if (!isAbsolute(pinned)) {
+      return { binary: "grok", source: "path", warning: `config grokBinary "${pinned}" is not an absolute path; ignoring it` };
+    }
+    if (!input.existsSync(pinned)) {
+      return {
+        binary: "grok", source: "path",
+        warning: `config grokBinary ${pinned} no longer exists (grok updated or moved?); falling back to PATH — the PATH grok must still be a verified build`,
+      };
+    }
+    return { binary: pinned, source: "config" };
+  }
+  return { binary: "grok", source: "path" };
+}
+
+/** 启动通过校验后要写回的字段。裸名解析成绝对路径由调用方完成(它有 PATH 解析器)。 */
+export function grokBinaryPinToRecord(resolvedAbsolute: string, versionLine: string): GrokBinaryPin | null {
+  if (!isAbsolute(resolvedAbsolute)) return null;
+  return { grokBinary: resolvedAbsolute, grokBinaryVersion: versionLine.trim() };
+}

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -29,7 +29,12 @@ grep -q 'atomicWritePrivateFile(dotenvPath, body)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateFile(anetEnvPath, envContent)' agent-network/bin/cli.ts
 grep -q 'repairPrivateFilePermissions(p);' agent-network/bin/cli.ts
 grep -q 'repairPrivateFilePermissions(path);' agent-network/bin/cli.ts
-test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 5
+test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 6
+# #1615 grok binary pin adds one config write (grokBinary + grokBinaryVersion). Same
+# private atomic choke point; the count alone would not prove the sixth write is the
+# pin, so bind it to the function the same way the Codex pending record is bound below.
+grep -A12 'function writebackGrokBinaryPin' agent-node/src/cli.ts \
+  | grep -q 'atomicWriteJson(configFilePath, cfg)'
 # Deferred Codex co-presence adds one token-preserving config write before the
 # exact thread is resumable. It must use the same private atomic choke point;
 # counting five alone would not prove that the new write is the pending record.


### PR DESCRIPTION
Ref #1615(不 close:doctor 的漂移检查已在,这条补「自动化路径也能钉版」那一格;剩「预检在 stop 之前拒绝」可另做)。

**改法**(agent-node):
- `runtime/grok-binary-pin.ts`:`chooseGrokBinary` 三级优先 —— `GROK_BINARY` > `config.grokBinary`(绝对路径且文件还在)> PATH 裸名;钉的失效时退回并说明。
- 校验通过后 `writebackGrokBinaryPin`:裸名按当时 PATH 解析成绝对路径,写 `config.grokBinary` + `grokBinaryVersion`;共存与 headless 两条 lane 都接。
- 钉的路径照样过既有的 `assertGrokCliVersion` / `assertGrokCopresenceVersion`:**fail-closed 不放松**。

7 条单测(test725 自动收);typecheck 棘轮基线不变;pin 门 rc=0。

真机行为:Mac 上 `~/.grok/downloads/grok-1.0.5-macos-aarch64` 这类路径会被钉住,PATH 上的 grok 再自动升到 1.0.13 也不影响下次重启。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD