### PR TITLE
fix(grok-copresence): #870 网络回合超时后「有上限的等待 + PTY 安静观测」的出口

### DIFF
--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -31,6 +31,7 @@ import { StringDecoder } from "string_decoder";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
 import { resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
 import { describeStuckPhase } from "./stuck-phase-alarm";
+import { describeStalledNetworkTurn } from "./stalled-network-turn";
 import { describeBlockedKey } from "./blocked-key-name";
 import {
   newGrokJsonlState,
@@ -1036,6 +1037,9 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   // moved on an actual phase change, so receiving a task while busy cannot
   // reset the clock that is supposed to reveal being stuck.
   private phaseSince = Date.now();
+  // #870 —— 超时后放弃回合要用的两个观测量。
+  private lastPtyOutputAt = Date.now();
+  private timedOutNetworkTask: { taskId: string; at: number; timeoutMs: number } | null = null;
   private logState: GrokJsonlState = newGrokJsonlState();
   private pty: GrokPtyLike | null = null;
   private activeTui: GrokTuiGeneration | null = null;
@@ -1557,6 +1561,12 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     return new Promise<GrokCopresenceThinkResult>((resolveTask, rejectTask) => {
       const timer = setTimeout(() => {
         this.pending.delete(opts.taskId);
+        // #870 —— 记下「这条正在网络回合里的任务超时了」;后面 reapStalledNetworkTurn 用它
+        //    决定要不要放弃那一轮。只记当前活动回合的那条,排队中的超时与此无关。
+        if (this.arbitration.phase === "network_turn" && this.arbitration.activeTurn?.owner === "network"
+          && this.arbitration.activeTurn.task.taskId === opts.taskId) {
+          this.timedOutNetworkTask = { taskId: opts.taskId, at: Date.now(), timeoutMs };
+        }
         // A queued timeout must never execute later. An already-active turn
         // cannot be cancelled safely: it may have side effects, so retain the
         // active boundary until its real turn_ended event arrives.
@@ -1724,6 +1734,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     this.activeTui = tui;
     pty.onData((data) => {
       if (this.activeTui !== tui || generation !== this.ptyGeneration || this.closing) return;
+      this.lastPtyOutputAt = Date.now();
       this.observeTuiReadiness(generation, data);
       this.attach?.broadcastOutput(data);
     });
@@ -2575,8 +2586,30 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     }
   }
 
+  /** #870 —— 有上限的等待 + PTY 安静观测,两者都满足才把卡住的网络回合拉回 idle。 */
+  private reapStalledNetworkTurn(): void {
+    const active = this.arbitration.phase === "network_turn" && this.arbitration.activeTurn?.owner === "network"
+      ? this.arbitration.activeTurn.task.taskId : null;
+    const stalled = describeStalledNetworkTurn({
+      phase: this.arbitration.phase,
+      activeTaskId: active,
+      timedOutTaskId: this.timedOutNetworkTask?.taskId ?? null,
+      timedOutAt: this.timedOutNetworkTask?.at ?? null,
+      now: Date.now(),
+      taskTimeoutMs: this.timedOutNetworkTask?.timeoutMs ?? 0,
+      lastPtyOutputAt: this.lastPtyOutputAt,
+    });
+    if (!stalled || !active) return;
+    this.warn(`[grok-copresence] ${stalled}`);
+    unregisterOwnedNetworkTask(this.logState, active);
+    this.timedOutNetworkTask = null;
+    const result = this.transition({ type: "network_turn_abandoned", taskId: active });
+    if (result.accepted) setImmediate(() => this.replayDeferredHumanOrSchedule());
+  }
+
   private pollLogs(): void {
     if (this.closing) return;
+    this.reapStalledNetworkTurn();
     try {
       // Always consume chat first. If events wins a filesystem flush race,
       // the reducer retains pending completion until the next assistant line.
@@ -3098,7 +3131,10 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     } else if (result.accepted && event.type === "human_input_submitted") {
       this.activeTurnTerminalEventSeen = false;
     }
-    if (result.accepted && event.type === "turn_completed") this.clearApprovalCorrelation(true);
+    if (result.accepted && (event.type === "turn_completed" || event.type === "network_turn_abandoned")) {
+      this.clearApprovalCorrelation(true);
+      if (event.type === "turn_completed") this.timedOutNetworkTask = null;
+    }
     if (result.accepted) this.broadcastState();
     return result;
   }

--- a/agent-node/src/runtime/grok-copresence/stalled-network-turn.test.ts
+++ b/agent-node/src/runtime/grok-copresence/stalled-network-turn.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { describeStalledNetworkTurn } from "./stalled-network-turn";
+const base = { phase: "network_turn", activeTaskId: "t1", timedOutTaskId: "t1", timedOutAt: 1_000_000, now: 1_000_000 + 300_000, taskTimeoutMs: 300_000, lastPtyOutputAt: 1_000_000 };
+describe("#870 stalled network turn", () => {
+  test("超时后又满一个 timeout 且 PTY 安静 ≥60s → 放弃,并说清两个数字", () => {
+    const m = describeStalledNetworkTurn(base);
+    expect(m).toMatch(/timed out 300s ago/); expect(m).toMatch(/silent for 300s/);
+  });
+  test("超时后还没满一个 timeout → 不放弃(有上限的等待)", () => {
+    expect(describeStalledNetworkTurn({ ...base, now: base.timedOutAt + 299_000 })).toBeNull();
+  });
+  test("PTY 最近还在输出 → 不放弃(那一轮可能真在跑)", () => {
+    expect(describeStalledNetworkTurn({ ...base, lastPtyOutputAt: base.now - 10_000 })).toBeNull();
+  });
+  test("phase 不是 network_turn → 不管", () => {
+    expect(describeStalledNetworkTurn({ ...base, phase: "idle" })).toBeNull();
+    expect(describeStalledNetworkTurn({ ...base, phase: "human_turn" })).toBeNull();
+  });
+  test("超时的不是当前活动任务(已经换了一轮)→ 不放弃", () => {
+    expect(describeStalledNetworkTurn({ ...base, activeTaskId: "t2" })).toBeNull();
+    expect(describeStalledNetworkTurn({ ...base, timedOutTaskId: null, timedOutAt: null })).toBeNull();
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/stalled-network-turn.ts
+++ b/agent-node/src/runtime/grok-copresence/stalled-network-turn.ts
@@ -1,0 +1,41 @@
+// #870 —— 网络回合超时后,状态机故意不回 idle(共享 TUI 里那一轮可能还在跑,强行标 idle 会
+// 并发注入)。但它把「回 idle」完全押在 turn_ended 一定会到上;不到时 phase 永远停在
+// network_turn,后面每条任务只 queued 不 injected,各自等满超时失败,且没有自愈路径。
+//
+// 这里给出「有上限的等待 + 观测」的出口,两个条件都要满足才放弃那一轮:
+//   1. 有上限:那条任务已经超时,而且从超时算起又过了一个 taskTimeout(总共 ≥ 2× timeout)
+//      仍没等到 turn_ended;
+//   2. 有观测:PTY 已经连续 quietMs 没有任何输出 —— 真在跑的 grok 回合会持续刷屏
+//      (流式输出/进度),安静这么久说明那一轮不在产出。
+// 放弃 = 把状态机从 network_turn 拉回 idle(显式事件 network_turn_abandoned,只对同一个
+// taskId 生效),后面排队的任务才能注入;日志里写明两个数字。
+export interface StalledNetworkTurnInput {
+  readonly phase: string;
+  /** 当前 network_turn 里的任务 id(没有则 null)。 */
+  readonly activeTaskId: string | null;
+  /** 超时时记下的那条任务 id(没有超时过则 null)。 */
+  readonly timedOutTaskId: string | null;
+  /** 超时发生的时刻(ms epoch)。 */
+  readonly timedOutAt: number | null;
+  readonly now: number;
+  readonly taskTimeoutMs: number;
+  /** PTY 最后一次有输出的时刻。 */
+  readonly lastPtyOutputAt: number;
+  readonly quietMs?: number;
+}
+
+export const STALLED_TURN_QUIET_MS = 60_000;
+
+export function describeStalledNetworkTurn(input: StalledNetworkTurnInput): string | null {
+  if (input.phase !== "network_turn") return null;
+  if (!input.activeTaskId || !input.timedOutTaskId || input.activeTaskId !== input.timedOutTaskId) return null;
+  if (input.timedOutAt === null) return null;
+  const sinceTimeout = input.now - input.timedOutAt;
+  if (sinceTimeout < input.taskTimeoutMs) return null;
+  const quietMs = input.quietMs ?? STALLED_TURN_QUIET_MS;
+  const quietFor = input.now - input.lastPtyOutputAt;
+  if (quietFor < quietMs) return null;
+  return `network turn ${input.activeTaskId} timed out ${Math.round(sinceTimeout / 1000)}s ago and no turn_ended arrived; `
+    + `PTY has been silent for ${Math.round(quietFor / 1000)}s — abandoning the turn so queued tasks can run (#870). `
+    + `If the shared TUI was in fact still working, the next injection will be queued behind it by grok itself.`;
+}

--- a/agent-node/src/runtime/grok-copresence/state.test.ts
+++ b/agent-node/src/runtime/grok-copresence/state.test.ts
@@ -65,6 +65,27 @@ describe("Grok co-presence arbitration", () => {
     expect(h.state.phase).toBe("network_turn");
   });
 
+  it("#870: network_turn_abandoned only releases the exact stuck turn, then the FIFO continues", () => {
+    const h = harness();
+    h.send({ type: "network_task_received", task: task("n1") });
+    h.send({ type: "network_task_received", task: task("n2") });
+    expect(h.send({ type: "schedule_network" }).effects).toEqual([{ type: "inject_network_task", task: task("n1") }]);
+    expect(h.state.phase).toBe("network_turn");
+    // 超时把 n1 的 promise 取消掉了,但状态机故意不回 idle(共享 TUI 可能还在跑)。
+    // 错的 taskId / 不在 network_turn 时都不能放行 —— 放弃的必须正是卡住的那一轮。
+    expect(h.send({ type: "network_turn_abandoned", taskId: "n2" })).toMatchObject({ accepted: false, effects: [] });
+    expect(h.state.phase).toBe("network_turn");
+    const abandoned = h.send({ type: "network_turn_abandoned", taskId: "n1" });
+    expect(abandoned.accepted).toBe(true);
+    expect(abandoned.effects).toEqual([{ type: "network_turn_abandoned", task: task("n1") }]);
+    expect(h.state).toMatchObject({ phase: "idle", activeTurn: null });
+    // 排在后面的 n2 现在能注入了 —— 这正是 #870 缺的那条出路。
+    expect(h.send({ type: "schedule_network" }).effects).toEqual([{ type: "inject_network_task", task: task("n2") }]);
+    // idle 时再来一次放弃是空操作。
+    h.send({ type: "turn_completed", owner: "network" });
+    expect(h.send({ type: "network_turn_abandoned", taskId: "n2" })).toMatchObject({ accepted: false, effects: [] });
+  });
+
   it("gives a newly active human composer priority over an existing FIFO", () => {
     const h = harness();
     h.send({ type: "network_task_received", task: task("n1") });

--- a/agent-node/src/runtime/grok-copresence/state.ts
+++ b/agent-node/src/runtime/grok-copresence/state.ts
@@ -56,6 +56,8 @@ export type GrokCopresenceEvent =
   | { type: "human_input_cancelled" }
   | { type: "schedule_network" }
   | { type: "turn_completed"; owner: GrokCopresenceTurnOwner }
+  /** #870 —— 超时后 turn_ended 迟迟不来且 PTY 安静:显式放弃那一轮(只对同一个 taskId 生效)。 */
+  | { type: "network_turn_abandoned"; taskId: string }
   | { type: "disconnected" }
   | { type: "reconnected" }
   | { type: "approval_requested" }
@@ -65,6 +67,7 @@ export type GrokCopresenceEvent =
 export type GrokCopresenceEffect =
   | { type: "inject_network_task"; task: GrokCopresenceNetworkTask }
   | { type: "network_turn_completed"; task: GrokCopresenceNetworkTask }
+  | { type: "network_turn_abandoned"; task: GrokCopresenceNetworkTask }
   | { type: "human_turn_completed" };
 
 export interface GrokCopresenceTransition {
@@ -165,6 +168,18 @@ export function reduceGrokCopresenceState(
         state,
         { phase: "idle", activeTurn: null, waitingHuman: false },
         [{ type: "network_turn_completed", task }],
+      );
+    }
+
+    case "network_turn_abandoned": {
+      // 只在「网络回合仍是这条任务」时放行:换了一轮、或已经 idle,都不动。
+      if (state.phase !== "network_turn" || state.activeTurn?.owner !== "network") return ignored(state);
+      if (state.activeTurn.task.taskId !== event.taskId) return ignored(state);
+      const task = copyTask(state.activeTurn.task);
+      return changed(
+        state,
+        { phase: "idle", activeTurn: null, waitingHuman: false },
+        [{ type: "network_turn_abandoned", task }],
       );
     }
 


### PR DESCRIPTION
Closes #870。

**设计**(按 issue 里的两条建议合起来做,不是「超时就强制 idle」):
- 超时时记下「当前网络回合的这条任务超时了」(排队中的超时与此无关);
- `pollLogs` 每轮 `reapStalledNetworkTurn`:仍停在**同一**回合、从超时算起又满一个 taskTimeout(总 ≥ 2×)、且 **PTY 已连续 ≥ 60 s 无任何输出**(真在跑的 grok 回合会持续刷屏)—— 三条都成立才发 `network_turn_abandoned`;
- 状态机只对同一 `taskId` 且 phase=network_turn 放行 → idle → 队列继续;`turn_completed` 正常到达则清记录,不会误放弃;日志写明「超时多久 / 安静多久」。

**测试**:`stalled-network-turn.test.ts` 5 条(满/不满上限、PTY 活跃、phase 不对、换了一轮);`state.test.ts` +1(错 taskId 不放行 → 正确 taskId 放行 → 后续任务注入 → idle 时空操作)。typecheck 棘轮基线不变。

没做真 grok 复现(同 issue 作者当时的处境);这条改动对「turn_ended 正常到达」的路径是 no-op。#880(human_editing 无超时)是同一状态机的另一格,不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD