### PR TITLE
fix(grok-copresence): #880 human_editing 的空闲出口 —— 10 分钟无按键且有任务在等时替人按 Ctrl-C

### DIFF
--- a/agent-node/src/runtime/grok-copresence/abandoned-human-editing.test.ts
+++ b/agent-node/src/runtime/grok-copresence/abandoned-human-editing.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { HUMAN_EDITING_IDLE_MS, describeAbandonedHumanEditing } from "./abandoned-human-editing";
+describe("#880 abandoned human editing", () => {
+  test("human_editing + 10 分钟无按键 + 有任务在等 → 取消草稿,并说清两个数字", () => {
+    const m = describeAbandonedHumanEditing({ phase: "human_editing", sinceLastHumanInputMs: HUMAN_EDITING_IDLE_MS, queued: 2 });
+    expect(m).toMatch(/no keystrokes for 10m/); expect(m).toMatch(/2 network task/);
+  });
+  test("没有任务在等 → 不打扰(草稿放多久都不动)", () => {
+    expect(describeAbandonedHumanEditing({ phase: "human_editing", sinceLastHumanInputMs: 3 * HUMAN_EDITING_IDLE_MS, queued: 0 })).toBeNull();
+  });
+  test("最近还在打字 → 不动", () => {
+    expect(describeAbandonedHumanEditing({ phase: "human_editing", sinceLastHumanInputMs: HUMAN_EDITING_IDLE_MS - 1, queued: 1 })).toBeNull();
+  });
+  test("不是 human_editing → 不管", () => {
+    expect(describeAbandonedHumanEditing({ phase: "network_turn", sinceLastHumanInputMs: 1e9, queued: 1 })).toBeNull();
+    expect(describeAbandonedHumanEditing({ phase: "idle", sinceLastHumanInputMs: 1e9, queued: 1 })).toBeNull();
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/abandoned-human-editing.ts
+++ b/agent-node/src/runtime/grok-copresence/abandoned-human-editing.ts
@@ -1,0 +1,26 @@
+// #880 —— human_editing 没有超时出口:人在 attach 的 TUI 里敲了字、没提交也没取消就走开,
+// 仲裁永远停在 human_editing,网络任务只排队不注入,每条 300 s 后超时失败。
+//
+// 出口只在三条同时成立时才走,而且只做「人本来就能做的那一下」(Ctrl-C 取消编辑):
+//   1. phase 是 human_editing;
+//   2. 从最后一次人类按键算起已经 ≥ idleMs(默认 10 分钟)—— 人真在打字不会安静这么久;
+//   3. 队列里有网络任务在等 —— 没人等就不打扰人的草稿(哪怕它已经放了一小时)。
+// 代价是那半截草稿被清掉;日志写明「安静了多久、几条任务在等」,让人知道为什么。
+export interface AbandonedHumanEditingInput {
+  readonly phase: string;
+  readonly sinceLastHumanInputMs: number;
+  readonly queued: number;
+  readonly idleMs?: number;
+}
+
+export const HUMAN_EDITING_IDLE_MS = 10 * 60_000;
+
+export function describeAbandonedHumanEditing(input: AbandonedHumanEditingInput): string | null {
+  if (input.phase !== "human_editing") return null;
+  if (input.queued <= 0) return null;
+  const idleMs = input.idleMs ?? HUMAN_EDITING_IDLE_MS;
+  if (!Number.isFinite(input.sinceLastHumanInputMs) || input.sinceLastHumanInputMs < idleMs) return null;
+  return `human composer has had no keystrokes for ${Math.round(input.sinceLastHumanInputMs / 60_000)}m while `
+    + `${input.queued} network task(s) wait behind it — cancelling the abandoned draft (Ctrl-C) so they can run (#880). `
+    + `Type again to take the TUI back.`;
+}

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -32,6 +32,7 @@ import { startGrokAttachServer, type GrokAttachServer } from "./attach";
 import { resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
 import { describeStuckPhase } from "./stuck-phase-alarm";
 import { describeStalledNetworkTurn } from "./stalled-network-turn";
+import { describeAbandonedHumanEditing } from "./abandoned-human-editing";
 import { describeBlockedKey } from "./blocked-key-name";
 import {
   newGrokJsonlState,
@@ -1039,6 +1040,8 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   private phaseSince = Date.now();
   // #870 —— 超时后放弃回合要用的两个观测量。
   private lastPtyOutputAt = Date.now();
+  // #880 —— 人最后一次按键的时刻;human_editing 里 10 分钟没按键且有任务在等就取消草稿。
+  private lastHumanInputAt = Date.now();
   private timedOutNetworkTask: { taskId: string; at: number; timeoutMs: number } | null = null;
   private logState: GrokJsonlState = newGrokJsonlState();
   private pty: GrokPtyLike | null = null;
@@ -2123,6 +2126,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
 
   private onHumanInput(data: Buffer): void {
     if (!data.length || this.closing) return;
+    this.lastHumanInputAt = Date.now();
     if (!this.pty) {
       this.deferHumanInput(data);
       return;
@@ -2607,9 +2611,27 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     if (result.accepted) setImmediate(() => this.replayDeferredHumanOrSchedule());
   }
 
+  /** #880 —— 人敲了字走开:安静 ≥10 分钟且有任务在等,替人按一下 Ctrl-C(和被拦截的斜杠输入同一条路)。 */
+  private reapAbandonedHumanEditing(): void {
+    if (!this.pty || this.recovering || this.closing) return;
+    const stale = describeAbandonedHumanEditing({
+      phase: this.arbitration.phase,
+      sinceLastHumanInputMs: Date.now() - this.lastHumanInputAt,
+      queued: this.arbitration.queue.length,
+    });
+    if (!stale) return;
+    this.warn(`[grok-copresence] ${stale}`);
+    this.writeHumanBytes(Buffer.from("\x03", "binary"));
+    this.resetHumanComposerAudit();
+    const result = this.transition({ type: "human_input_cancelled" });
+    this.lastHumanInputAt = Date.now();
+    if (result.accepted) setImmediate(() => this.replayDeferredHumanOrSchedule());
+  }
+
   private pollLogs(): void {
     if (this.closing) return;
     this.reapStalledNetworkTurn();
+    this.reapAbandonedHumanEditing();
     try {
       // Always consume chat first. If events wins a filesystem flush race,
       // the reducer retains pending completion until the next assistant line.


### PR DESCRIPTION
Closes #880。与 #1775(#870)是同一状态机的两格,形状对称:有上限的等待 + 观测。

**规则**(三条同时成立才动):phase=`human_editing`;从最后一次人类按键起 ≥ 10 分钟;队列里有网络任务在等。动作 = 和「被拦截的斜杠输入」完全同一条路:写 `\\x03`、重置 composer 审计、`human_input_cancelled` → idle → 注入。**没人等就不碰人的草稿**(放一小时也不动)。日志写明「安静了多久、几条在等」。

真实案例:09-02 晚 TMWork苹果打包狗 输入框里一串 `/////////` 让仲裁停在 human_editing 69 分钟,Vincent 两条任务各 300 s 超时;我手工发了一个 Ctrl-C 才恢复。这条把那一下自动化,但只在有任务等的时候。

`abandoned-human-editing.test.ts` 4 条;typecheck 棘轮基线不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD