### PR TITLE
chore(release): agent-node 2.5.0-preview.59 —— #1615 钉版 + #870/#880 共存状态机出口

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.76";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.58";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.59";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.58",
+  "version": "2.5.0-preview.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.58",
+      "version": "2.5.0-preview.59",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.58",
+  "version": "2.5.0-preview.59",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.59.md
+++ b/docs/tests/release-v2.5.0-preview.59.md
@@ -1,0 +1,42 @@
+# agent-node 2.5.0-preview.59
+
+`.58` 之后改到 `agent-node/` 的提交（`files: ["dist","README.md"]`，除测试外都进包）：
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `42951f12` | #1774 | **#1615 钉版** —— 启动通过校验的 grok 可执行文件写回 config，下次优先用它（GROK_BINARY 仍最优先）；daemon 自动拉起也钉得住 |
+| `af645a91` | #1775 | **#870** —— 网络回合超时后「有上限的等待 + PTY 安静 ≥60 s」才放弃那一轮（显式事件 `network_turn_abandoned`），队列继续 |
+| `67fff18c` | #1776 | **#880** —— human_editing 里 10 分钟无按键且有任务在等，替人按 Ctrl-C，队列继续 |
+
+## 这一版带给用户什么
+
+三条都是 grok 共存节点「看起来健康、任务却一条条 300 s 超时」这一族的出口：
+- 人在 TUI 里敲了半截走开（09-02 晚 TMWork苹果打包狗 卡 69 分钟那种）→ 10 分钟后自动让路；
+- grok 那一轮的 `turn_ended` 没来 → 超时后再等一个超时且 PTY 安静 60 s 才放弃；
+- grok 自我更新到验证清单外的版本 → 下次重启仍用上次钉住的那个文件。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.59
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.59
+# 三条都在长驻进程内,必须重启节点:
+anet daemon restart <daemon>        # 需要 anet ≥ 2.3.0-preview.74
+# 早于 .74 的 anet 用两步:
+anet node stop <name> && anet node start <name>
+```
+
+重启一次之后 config 里会多出 `grokBinary` / `grokBinaryVersion`（#1615 的钉），此后 PATH 上的 grok 再变也不影响下次启动。
+
+## 证据
+
+- `grok-binary-pin.test.ts` 7 条、`stalled-network-turn.test.ts` 5 条、`abandoned-human-editing.test.ts` 4 条、`state.test.ts` +1；test725 自动收；typecheck 棘轮基线不变；test631 私有 config 写点 5 → 6 已登记。
+
+## promote 时的 must_contain
+
+`network_turn_abandoned`（无正则元字符；`.58` 产物用闸 4 原样命令 0 命中，`.59` 的 state.ts/runtime.ts 都含）。


### PR DESCRIPTION
.58 之后 `agent-node/` 的三个提交(#1774 / #1775 / #1776)都是 grok 共存「看着健康、任务一条条 300 s 超时」这一族的修复,值得单独出一版给舰队。

- 四处戳 .58 → .59(package.json / package-lock ×2 / `PAIRED_AGENT_NODE_VERSION`)
- `docs/tests/release-v2.5.0-preview.59.md`:含闸 3 要的 Install/Upgrade;promote 判据 `network_turn_abandoned`(闸 4 原样命令在 .58 产物 0 命中)

`check-doc-version-claims.py --package agent-node --version 2.5.0-preview.59 --verify-latest-from-npm` rc=0(带 CI 参数)。合并后 release-gate 发 preview。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD