### PR TITLE
fix(grok-copresence): #1770 共存节点对发起方的重复出站改写成进度上报

### DIFF
--- a/agent-network/src/active-network-task.test.ts
+++ b/agent-network/src/active-network-task.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACTIVE_NETWORK_TASK_MAX_AGE_MS,
+  clampOutboundPriority,
+  decideOutboundRewrite,
+  parseActiveNetworkTask,
+} from "./active-network-task.js";
+
+const NOW = 1_800_000_000_000;
+const marker = JSON.stringify({ taskId: "5844f347", from: "通信龙", startedAt: NOW - 5_000 });
+
+describe("parseActiveNetworkTask", () => {
+  test("reads a fresh marker", () => {
+    expect(parseActiveNetworkTask(marker, NOW)).toEqual({ taskId: "5844f347", from: "通信龙", startedAt: NOW - 5_000 });
+  });
+  test("missing, empty, malformed and shape-less inputs all mean no active task", () => {
+    expect(parseActiveNetworkTask(undefined, NOW)).toBeNull();
+    expect(parseActiveNetworkTask("", NOW)).toBeNull();
+    expect(parseActiveNetworkTask("{not json", NOW)).toBeNull();
+    expect(parseActiveNetworkTask("[]", NOW)).toBeNull();
+    expect(parseActiveNetworkTask(JSON.stringify({ taskId: "x" }), NOW)).toBeNull();
+    expect(parseActiveNetworkTask(JSON.stringify({ taskId: "x", from: " ", startedAt: NOW }), NOW)).toBeNull();
+  });
+  test("a stale marker (runtime died before clearing it) is ignored", () => {
+    const old = JSON.stringify({ taskId: "t", from: "a", startedAt: NOW - ACTIVE_NETWORK_TASK_MAX_AGE_MS - 1 });
+    expect(parseActiveNetworkTask(old, NOW)).toBeNull();
+    const edge = JSON.stringify({ taskId: "t", from: "a", startedAt: NOW - ACTIVE_NETWORK_TASK_MAX_AGE_MS });
+    expect(parseActiveNetworkTask(edge, NOW)).not.toBeNull();
+  });
+});
+
+describe("decideOutboundRewrite", () => {
+  const active = { taskId: "5844f347", from: "通信龙", startedAt: NOW };
+  test("send_task / send_message aimed at the originator become progress of the active task", () => {
+    expect(decideOutboundRewrite("commhub_send_task", { alias: "通信龙", task: "PING-c2e1 已收到" }, active))
+      .toEqual({ kind: "progress_of_active_task", taskId: "5844f347", from: "通信龙", text: "PING-c2e1 已收到" });
+    expect(decideOutboundRewrite("commhub_send_message", { alias: " 通信龙 ", message: "收到" }, active))
+      .toEqual({ kind: "progress_of_active_task", taskId: "5844f347", from: "通信龙", text: "收到" });
+  });
+  test("dispatching to anyone else passes through untouched", () => {
+    expect(decideOutboundRewrite("commhub_send_task", { alias: "Mac打包牛", task: "帮我打包" }, active)).toEqual({ kind: "pass" });
+  });
+  test("no active task means no rewrite even for the same alias", () => {
+    expect(decideOutboundRewrite("commhub_send_message", { alias: "通信龙", message: "x" }, null)).toEqual({ kind: "pass" });
+  });
+  test("a missing alias never matches", () => {
+    expect(decideOutboundRewrite("commhub_send_message", { message: "x" }, active)).toEqual({ kind: "pass" });
+    expect(decideOutboundRewrite("commhub_send_message", null, active)).toEqual({ kind: "pass" });
+  });
+});
+
+describe("clampOutboundPriority", () => {
+  test("outbound-only demotes a model-chosen high to normal and leaves the rest", () => {
+    expect(clampOutboundPriority("high", true)).toBe("normal");
+    expect(clampOutboundPriority("low", true)).toBe("low");
+    expect(clampOutboundPriority("normal", true)).toBe("normal");
+    expect(clampOutboundPriority("urgent", true)).toBeUndefined();
+  });
+  test("full mode keeps high", () => {
+    expect(clampOutboundPriority("high", false)).toBe("high");
+  });
+});

--- a/agent-network/src/active-network-task.ts
+++ b/agent-network/src/active-network-task.ts
@@ -1,0 +1,73 @@
+// #1770 —— outbound-only 模式下,模型对「当前网络任务的发起方」自己再发一遍
+// send_task / send_message,会让发起方收到同一句话三次(其中一条还是 high)。
+//
+// node-server 进程本来不知道运行时正替谁跑哪条任务(任务是运行时注入 PTY 的文本)。
+// 运行时把当前网络任务写进一个标记文件(agent-node 的 active-network-task-marker.ts),
+// 这里只做两件纯函数的事:读懂那个文件、决定要不要把出站改写成对该任务的进度上报。
+//
+// 改写成的是 **report_status(非终态、不推送)**,和模型显式调 commhub_reply(status=in_progress)
+// 走的是同一条路;运行时随后发的终态 reply 仍是唯一推到发起方的那条。
+
+export interface ActiveNetworkTask {
+  taskId: string;
+  from: string;
+  startedAt: number;
+}
+
+/** 运行时崩溃没来得及删标记时的兜底:超过这个年龄的标记当不存在。 */
+export const ACTIVE_NETWORK_TASK_MAX_AGE_MS = 30 * 60_000;
+
+export function parseActiveNetworkTask(
+  raw: string | null | undefined,
+  now: number,
+  maxAgeMs: number = ACTIVE_NETWORK_TASK_MAX_AGE_MS,
+): ActiveNetworkTask | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  const taskId = typeof record.taskId === "string" ? record.taskId.trim() : "";
+  const from = typeof record.from === "string" ? record.from.trim() : "";
+  const startedAt = typeof record.startedAt === "number" && Number.isFinite(record.startedAt) ? record.startedAt : NaN;
+  if (!taskId || !from || !Number.isFinite(startedAt)) return null;
+  if (now - startedAt > maxAgeMs || startedAt - now > 60_000) return null;
+  return { taskId, from, startedAt };
+}
+
+export type OutboundTool = "commhub_send_task" | "commhub_send_message";
+
+export type OutboundRewrite =
+  | { kind: "pass" }
+  | { kind: "progress_of_active_task"; taskId: string; from: string; text: string };
+
+/**
+ * 只在「目标 alias 恰好是当前网络任务的发起方」时改写;发给别人的照常放行——
+ * 模型替任务派活给第三方是合法的协作,不能一刀切。
+ */
+export function decideOutboundRewrite(
+  tool: OutboundTool,
+  args: { alias?: unknown; task?: unknown; message?: unknown } | null | undefined,
+  active: ActiveNetworkTask | null,
+): OutboundRewrite {
+  if (!active) return { kind: "pass" };
+  const alias = typeof args?.alias === "string" ? args.alias.trim() : "";
+  if (!alias || alias !== active.from) return { kind: "pass" };
+  const body = tool === "commhub_send_task" ? args?.task : args?.message;
+  const text = typeof body === "string" ? body : String(body ?? "");
+  return { kind: "progress_of_active_task", taskId: active.taskId, from: active.from, text };
+}
+
+/** outbound-only 模式下模型不能自选 high(#1770 第三条):降为 normal,其余原样。 */
+export function clampOutboundPriority(
+  priority: unknown,
+  outboundOnly: boolean,
+): "high" | "normal" | "low" | undefined {
+  if (priority !== "high" && priority !== "normal" && priority !== "low") return undefined;
+  if (outboundOnly && priority === "high") return "normal";
+  return priority;
+}

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -103,6 +103,7 @@ import {
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { decideReplyAlias, replyAliasArgs } from "./reply-originator.js";
+import { clampOutboundPriority, decideOutboundRewrite, parseActiveNetworkTask } from "./active-network-task.js";
 
 // ── Load ~/.anet/config.json for token fallback ──────
 function loadAnetConfig(): Record<string, string> {
@@ -149,6 +150,36 @@ const AUTH_TOKEN = process.env.COMMHUB_TOKEN || ANET_CONFIG.token || "";
 // registration/heartbeat/offline report. Keep the legacy full channel mode as
 // the default for Claude Code installations that launch this same artifact.
 const OUTBOUND_ONLY = process.env.ANET_COMMHUB_MODE === "outbound-only";
+// #1770 —— 运行时写的「当前网络任务」标记(仅共存/outbound-only 布局会给这个路径)。
+const ACTIVE_NETWORK_TASK_FILE = process.env.ANET_ACTIVE_NETWORK_TASK_FILE || "";
+function readActiveNetworkTask() {
+  if (!OUTBOUND_ONLY || !ACTIVE_NETWORK_TASK_FILE) return null;
+  let raw: string | null = null;
+  try {
+    raw = readFileSync(ACTIVE_NETWORK_TASK_FILE, "utf-8");
+  } catch {
+    return null;
+  }
+  return parseActiveNetworkTask(raw, Date.now());
+}
+// 改写成的是非终态进度(report_status),与 commhub_reply(status=in_progress) 同一条路:
+// 不推送、只入库;运行时随后的终态 reply 仍是唯一推到发起方的那条。
+async function reportProgressOfActiveTask(taskId: string, text: string) {
+  const result = await callCommHub("report_status", {
+    resume_id: RESUME_ID,
+    alias: ALIAS,
+    status: "working",
+    task: text.slice(0, 200),
+    output: text,
+  });
+  return {
+    ok: true,
+    rewritten: "progress_of_active_task",
+    task_id: taskId,
+    note: "recorded as progress of the task you are currently handling; the runtime sends the final reply — do not send it again",
+    upstream: result,
+  };
+}
 
 // #1345 — claude-code-cli nodes have no agent-node process, so this proxy is
 // the only place a per-alias node log can come from. Mirror every log line
@@ -442,7 +473,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
   }
 
   if (name === "commhub_send_task") {
-    const { alias, task, priority, attachments } = args as any;
+    const { alias, task, priority: rawPriority, attachments } = args as any;
+    const rewrite = decideOutboundRewrite("commhub_send_task", args as any, readActiveNetworkTask());
+    if (rewrite.kind === "progress_of_active_task") {
+      return { content: [{ type: "text", text: JSON.stringify(await reportProgressOfActiveTask(rewrite.taskId, rewrite.text)) }] };
+    }
+    const priority = clampOutboundPriority(rawPriority, OUTBOUND_ONLY);
     const parsedTaskAttachments = normalizeOutboundAttachments(attachments);
     if (!parsedTaskAttachments.ok) {
       return { content: [{ type: "text", text: JSON.stringify({ ok: false, error: parsedTaskAttachments.error }) }] };
@@ -463,6 +499,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
 
   if (name === "commhub_send_message") {
     const { alias, message } = args as any;
+    const rewrite = decideOutboundRewrite("commhub_send_message", args as any, readActiveNetworkTask());
+    if (rewrite.kind === "progress_of_active_task") {
+      return { content: [{ type: "text", text: JSON.stringify(await reportProgressOfActiveTask(rewrite.taskId, rewrite.text)) }] };
+    }
     const result = await callCommHub("send_message", {
       alias,
       message,

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -17,6 +17,7 @@ import {
   assertCopresenceSupported as assertGrokCopresenceSupported,
   copresenceDowngradeNotice as grokCopresenceDowngradeNotice,
 } from "./runtime/grok-copresence/platform";
+import { activeNetworkTaskMarkerPath } from "./runtime/grok-copresence/active-network-task-marker.js";
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
@@ -4059,6 +4060,7 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
           envFile: commhubMcpEnv,
           alias: currentAlias(),
           resumeId: `grok-cli-${NODE_ID || grokHomeKey}`,
+          activeTaskFile: activeNetworkTaskMarkerPath(grokCwd),
         },
         denyPaths: grokCliDenyPaths({
           projectCwd: grokCwd,

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -52,6 +52,8 @@ export interface GrokCommhubMcpConfig {
   envFile: string;
   alias: string;
   resumeId: string;
+  /** #1770 —— 运行时写的当前网络任务标记;交给 node-server 做出站去重。 */
+  activeTaskFile?: string;
 }
 
 /**
@@ -1589,7 +1591,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
       "[mcp_servers.commhub]",
       `command = ${JSON.stringify(commhubMcp.command)}`,
       `args = [${JSON.stringify(commhubMcp.serverPath)}]`,
-      `env = { ANET_COMMHUB_ENV_FILE = ${JSON.stringify(commhubMcp.envFile)}, ANET_COMMHUB_MODE = "outbound-only", COMMHUB_ALIAS = ${JSON.stringify(commhubMcp.alias)}, COMMHUB_RESUME_ID = ${JSON.stringify(commhubMcp.resumeId)} }`,
+      `env = { ANET_COMMHUB_ENV_FILE = ${JSON.stringify(commhubMcp.envFile)}, ANET_COMMHUB_MODE = "outbound-only", ${commhubMcp.activeTaskFile ? `ANET_ACTIVE_NETWORK_TASK_FILE = ${JSON.stringify(commhubMcp.activeTaskFile)}, ` : ""}COMMHUB_ALIAS = ${JSON.stringify(commhubMcp.alias)}, COMMHUB_RESUME_ID = ${JSON.stringify(commhubMcp.resumeId)} }`,
       "enabled = true",
       "",
     ] : []),

--- a/agent-node/src/runtime/grok-copresence/active-network-task-marker.test.ts
+++ b/agent-node/src/runtime/grok-copresence/active-network-task-marker.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ACTIVE_NETWORK_TASK_FILE,
+  activeNetworkTaskMarkerPath,
+  clearActiveNetworkTaskMarker,
+  writeActiveNetworkTaskMarker,
+} from "./active-network-task-marker.js";
+
+let dir = "";
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "anet-marker-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("active network task marker", () => {
+  test("path lives next to node-server's .env under <cwd>/.anet", () => {
+    expect(activeNetworkTaskMarkerPath("/work/p")).toBe(join("/work/p", ".anet", ACTIVE_NETWORK_TASK_FILE));
+  });
+  test("write creates the directory, is 0600 and round-trips the three fields", () => {
+    const path = activeNetworkTaskMarkerPath(dir);
+    writeActiveNetworkTaskMarker(path, { taskId: "5844f347", from: "通信龙", startedAt: 123 });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ taskId: "5844f347", from: "通信龙", startedAt: 123 });
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(existsSync(`${path}.${process.pid}.tmp`)).toBe(false);
+  });
+  test("a second write replaces the first (one active task at a time)", () => {
+    const path = activeNetworkTaskMarkerPath(dir);
+    writeActiveNetworkTaskMarker(path, { taskId: "a", from: "x", startedAt: 1 });
+    writeActiveNetworkTaskMarker(path, { taskId: "b", from: "y", startedAt: 2 });
+    expect(JSON.parse(readFileSync(path, "utf8")).taskId).toBe("b");
+  });
+  test("clear is idempotent", () => {
+    const path = activeNetworkTaskMarkerPath(dir);
+    clearActiveNetworkTaskMarker(path);
+    writeActiveNetworkTaskMarker(path, { taskId: "a", from: "x", startedAt: 1 });
+    clearActiveNetworkTaskMarker(path);
+    clearActiveNetworkTaskMarker(path);
+    expect(existsSync(path)).toBe(false);
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/active-network-task-marker.ts
+++ b/agent-node/src/runtime/grok-copresence/active-network-task-marker.ts
@@ -1,0 +1,35 @@
+// #1770 —— 共存 TUI 里模型能调的 CommHub 工具来自 `.anet/node-server.js`(outbound-only),
+// 那个进程不知道运行时正替谁跑哪条任务。运行时在注入网络任务时写下这个标记,
+// 回合结束(完成 / 放弃)时删掉;node-server 据此把模型对发起方的 send_task/send_message
+// 改写成该任务的进度上报,发起方就不会收到同一句话三遍。
+//
+// 文件放在 `<projectCwd>/.anet/` —— 和 node-server 的 `.env` 同目录、同 0600 权限;
+// 路径通过 mcp 配置的 env `ANET_ACTIVE_NETWORK_TASK_FILE` 显式交给 node-server,
+// 不让它按 cwd 猜(credentialDir 布局下 .env 不在项目目录里)。
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export const ACTIVE_NETWORK_TASK_FILE = ".active-network-task.json";
+
+export interface ActiveNetworkTaskMarker {
+  taskId: string;
+  from: string;
+  startedAt: number;
+}
+
+export function activeNetworkTaskMarkerPath(projectCwd: string): string {
+  return join(projectCwd, ".anet", ACTIVE_NETWORK_TASK_FILE);
+}
+
+/** 原子写(tmp + rename),0600;目录不存在就建(0700)。 */
+export function writeActiveNetworkTaskMarker(path: string, marker: ActiveNetworkTaskMarker): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ taskId: marker.taskId, from: marker.from, startedAt: marker.startedAt }), { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+/** 不存在也算成功——清理必须幂等,回合结束会从多条路径各清一次。 */
+export function clearActiveNetworkTaskMarker(path: string): void {
+  rmSync(path, { force: true });
+}

--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -17,7 +17,7 @@ import {
 } from "fs";
 import { PassThrough } from "stream";
 import { createConnection, type Socket } from "net";
-import { mkdtempSync, readFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join, resolve } from "path";
 import { describe, expect, test } from "bun:test";
@@ -1657,6 +1657,42 @@ describe("Grok copresence runtime integration", () => {
       expect(internals.ownedAnyTuiGeneration).toBe(true);
       expect(internals.pendingTuiProcessIds.size).toBe(0);
       for (const path of footprint.removedPaths) expect(existsSync(path), path).toBe(false);
+    } finally {
+      await runtime?.close();
+      await fixture.close();
+    }
+  }, 10_000);
+
+  test("#1770 writes the active network task marker on injection and clears it when the turn ends", async () => {
+    const fixture = new RuntimeFixture();
+    const markerPath = join(fixture.cwd, ".anet", ".active-network-task.json");
+    let runtime: GrokCopresenceRuntimeSession | undefined;
+    try {
+      runtime = await openGrokCopresenceRuntime({
+        ...fixture.options(),
+        activeNetworkTaskMarkerPath: markerPath,
+      });
+      expect(existsSync(markerPath)).toBe(false);
+      const consumed: string[] = [];
+      const pending = runtime.submit({
+        taskId: "marker-1",
+        from: "通信龙",
+        text: "HOLD_OPEN",
+        timeoutMs: 4_000,
+        onConsumed: () => consumed.push("consumed"),
+      });
+      await waitFor(() => consumed.length === 1);
+      // 回合进行中:node-server 据此把模型对「通信龙」的 send_task/send_message 改写成进度上报。
+      const marker = JSON.parse(readFileSync(markerPath, "utf8")) as { taskId: string; from: string; startedAt: number };
+      expect(marker.taskId).toBe("marker-1");
+      expect(marker.from).toBe("通信龙");
+      expect(typeof marker.startedAt).toBe("number");
+
+      const sessionDir = grokSessionDirectory(fixture.grokHome, fixture.cwd, SESSION);
+      appendJson(join(sessionDir, "chat_history.jsonl"), { type: "assistant", content: "FINAL marker-1" });
+      appendJson(join(sessionDir, "events.jsonl"), { type: "turn_ended", outcome: "completed" });
+      expect((await pending).replyText).toBe("FINAL marker-1");
+      await waitFor(() => !existsSync(markerPath));
     } finally {
       await runtime?.close();
       await fixture.close();

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -28,6 +28,7 @@ import {
 import { createServer as createNetServer } from "node:net";
 import { setTimeout as delay } from "timers/promises";
 import { StringDecoder } from "string_decoder";
+import { clearActiveNetworkTaskMarker, writeActiveNetworkTaskMarker } from "./active-network-task-marker.js";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
 import { resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
 import { describeStuckPhase } from "./stuck-phase-alarm";
@@ -242,6 +243,9 @@ export type GrokPtySpawn = (
 ) => GrokPtyLike | Promise<GrokPtyLike>;
 
 export interface GrokCopresenceOpenOptions {
+  /** #1770 —— 有值时,注入网络任务写 `{taskId, from, startedAt}` 到这里,回合结束删掉;
+   *  node-server(outbound-only)据此把模型对发起方的重复出站改写成进度上报。 */
+  activeNetworkTaskMarkerPath?: string;
   /** 观测到的 `grok --version` 原文，用于按 build 决定 argv 里的旧开关。 */
   grokVersion?: string;
   binary?: string;
@@ -2567,6 +2571,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
           from: effect.task.from,
           taskId: effect.task.taskId,
         });
+        this.writeActiveNetworkTaskMarker(effect.task);
         this.pty.write(formatNetworkTuiInput(effect.task));
         const pending = this.pending.get(effect.task.taskId);
         if (pending && !pending.submitted) {
@@ -3156,9 +3161,31 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     if (result.accepted && (event.type === "turn_completed" || event.type === "network_turn_abandoned")) {
       this.clearApprovalCorrelation(true);
       if (event.type === "turn_completed") this.timedOutNetworkTask = null;
+      if (event.type === "network_turn_abandoned" || event.owner === "network") this.clearActiveNetworkTaskMarker();
     }
     if (result.accepted) this.broadcastState();
     return result;
+  }
+
+  // #1770 —— 标记文件的读写失败不能影响回合本身:写不下去只少了一层去重,回合照跑。
+  private writeActiveNetworkTaskMarker(task: { taskId: string; from: string }): void {
+    const path = this.opts.activeNetworkTaskMarkerPath;
+    if (!path) return;
+    try {
+      writeActiveNetworkTaskMarker(path, { taskId: task.taskId, from: task.from, startedAt: Date.now() });
+    } catch (error) {
+      this.warn(`[grok-copresence] could not write active network task marker: ${errorMessage(error)}`);
+    }
+  }
+
+  private clearActiveNetworkTaskMarker(): void {
+    const path = this.opts.activeNetworkTaskMarkerPath;
+    if (!path) return;
+    try {
+      clearActiveNetworkTaskMarker(path);
+    } catch (error) {
+      this.warn(`[grok-copresence] could not clear active network task marker: ${errorMessage(error)}`);
+    }
   }
 
   private clearApprovalCorrelation(_clearSettled = false): void {


### PR DESCRIPTION
Closes #1770。定位见 issue 评论:三条出站里前两条是模型自己调 `.anet/node-server.js`(outbound-only)的 `commhub_send_message` / `commhub_send_task`(还自选了 high),它不知道运行时正替谁跑哪条任务;第三条才是运行时的终态 reply。

## 改法(两个包各一小步,同一个 PR)

- **agent-node**:`active-network-task-marker.ts` —— 注入网络任务时写 `<cwd>/.anet/.active-network-task.json`(`{taskId, from, startedAt}`,tmp+rename,0600),`turn_completed(owner=network)` / `network_turn_abandoned` 时删;路径经 mcp 配置的 env `ANET_ACTIVE_NETWORK_TASK_FILE` 显式交给 node-server(不让它按 cwd 猜,credentialDir 布局下 `.env` 不在项目目录)。运行时 opts 新增可选 `activeNetworkTaskMarkerPath`,cli.ts 传 `activeNetworkTaskMarkerPath(grokCwd)`;读写失败只 warn,不影响回合。
- **agent-network node-server(仅 outbound-only)**:`active-network-task.ts` —— 目标 alias == 当前任务发起方 → 改写成 `report_status`(非终态、不推送、与 `commhub_reply(status=in_progress)` 同一条路),返回 `{ok:true, rewritten:"progress_of_active_task", task_id, note}` 告诉模型别再发;发给第三方照常放行;模型自选 `priority=high` 降为 normal。标记超过 30 分钟视为不存在(运行时崩溃没来得及删的兜底)。

## 证据

- `active-network-task.test.ts` 9 条、`active-network-task-marker.test.ts` 4 条、`runtime.test.ts` +1(注入时标记存在且字段正确,turn_ended 后消失)。
- 变异见证:去掉回合结束的清除 → 新用例 1 fail;还原 → 1 pass。
- `check-agent-node-typecheck-ratchet.py` 81/81(基线不变);`check-doc-symbol-pins.py . --doc-root docs-site` rc=0;grok-build-cli-home / runtime / node-server-payload 既有用例全绿。

## 没做的

真机复现(TMWork苹果打包狗)要等两个包都发版后再发一条探针任务看出站条数;这版 PR 只到单测+变异。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD