### PR TITLE
chore(release): agent-network 2.3.0-preview.77 + agent-node 2.5.0-preview.60 —— #1770 两半 + #1768 平台门

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.76",
+  "version": "2.3.0-preview.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.76",
+      "version": "2.3.0-preview.77",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.76",
+  "version": "2.3.0-preview.77",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.76";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.59";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.77";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.60";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.59",
+  "version": "2.5.0-preview.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.59",
+      "version": "2.5.0-preview.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.59",
+  "version": "2.5.0-preview.60",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.76 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.77 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -101,7 +101,8 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.76` (current `latest` and `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.77` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.76 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.77 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -99,7 +99,8 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.76`(当前 `latest` 与 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.77`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.77.md
+++ b/docs/tests/release-v2.3.0-preview.77.md
@@ -1,0 +1,43 @@
+# `@sleep2agi/agent-network@2.3.0-preview.77`
+
+## 为什么发这一版:**共存节点的两条修复要靠它落地,顺带把 .76 之后攒的 26 个 CLI/daemon 提交带出去**
+
+| 用户看到的 | `.76` | `.77` |
+|---|---|---|
+| Mac / Windows 上 `anet node start <grok 节点> --copresence` | `❌ grok co-presence does not run on darwin … agent-node refuses this at startup`(**归错了人**,agent-node 早就按 darwin/win32 能力表在跑) | 放行,打一条「无内核层强制隔离,只用于受信任任务/网络」提示,agent-node 启动时逐条打 reducedGuarantees(#1768) |
+| 共存节点回一条任务,发起方收到几次 | 3 次:模型自己的 send_message + **high** send_task + 运行时的终态 reply(#1770) | 1 次:node-server(outbound-only)把前两条改写成不推送的进度上报(需 agent-node ≥ `2.5.0-preview.60` 写标记) |
+| `anet node stop` 拆卸链 | SIGTERM 5 s 就 SIGKILL,grok 共存节点拆不完(#1522) | 宽限 10 s |
+| agent 发文件 | 只能粘 file_id | `attachments` 直接带文件(#1186) |
+| `anet doctor` | — | 多两项:「非 claude-agent-sdk 的 runtime 配了飞书通道」盘点、#1615「下次重启会挂」现在就能看见 |
+| `anet daemon start` / `daemon init` / `daemon list` | 不说 workdir;存量 daemon 的 runtime 清单不自愈;「locally」其实是当前目录 | 启动打出 workdir 和管得到的节点目录;清单自愈;扫的目录说清楚 |
+| `--force` / `--yes` | 会吃掉下一个参数 | 登记成布尔标志(#1737) |
+| `anet node edit` | — | 放开 `--runtime` / `--model`(#1698) |
+| PINNED_SERVER_VERSION | `.44`/`.45` | `.46`(需要生产 hub 同步升级,见 deploy/hub/README.md) |
+
+完整清单:`git log 7d3b0fad..b4964102 -- agent-network/bin agent-network/src`(26 个非 release 提交)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.77
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.77
+npm i -g @sleep2agi/agent-node@2.5.0-preview.60   # #1770 的另一半;不升也不坏,只是三条出站照旧
+# daemon 是长驻进程,换包要重启才生效:
+anet daemon restart <daemon>
+# 共存节点要重启一次才会重新生成 .anet/node-server.js(node-server 改动在这里面):
+anet node stop <name> && anet node start <name> --copresence
+```
+
+## 边界
+
+- `.anet/node-server.js` 是节点启动时由 anet 写入项目目录的,**不重启节点不会换**;`anet doctor` 不会报这一项。
+- PINNED_SERVER_VERSION 指到 `.46`,`anet hub start` 会拉 `.46`;生产 hub 仍在 `.45`,升级另走六步流程。
+
+## promote 时的 must_contain
+
+`progress_of_active_task`(无正则元字符;`.76` 产物用闸 4 原样命令 0 命中)。

--- a/docs/tests/release-v2.5.0-preview.60.md
+++ b/docs/tests/release-v2.5.0-preview.60.md
@@ -1,0 +1,33 @@
+# agent-node 2.5.0-preview.60
+
+`.59` 之后改到 `agent-node/` 的只有一个提交,但它是 #1770 的一半,另一半在 agent-network 2.3.0-preview.77 的 node-server 里;**两边都升到位这条修复才生效**。
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `093c0d06` | #1778 | **#1770** —— 共存运行时注入网络任务时写 `<cwd>/.anet/.active-network-task.json`(`{taskId, from, startedAt}`,0600),网络回合完成/放弃时删;路径经 mcp env `ANET_ACTIVE_NETWORK_TASK_FILE` 交给 node-server |
+
+## 这一版带给用户什么
+
+共存节点(grok TUI)里模型自己对任务发起方再发一遍 send_message / high send_task,发起方同一句话收三次(09-02 晚 TMWork苹果打包狗 实测)。这一版让运行时把「当前替谁跑哪条任务」写成标记;配合 agent-network `.77` 的 node-server,那两条重复出站会被改写成不推送的进度上报。只升 agent-node 不升 anet:标记会写,但没人读,行为与 `.59` 相同(无害)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.60
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.60
+npm i -g @sleep2agi/agent-network@2.3.0-preview.77   # #1770 的另一半
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `active-network-task-marker.test.ts` 4 条、`runtime.test.ts` +1(注入时标记存在且字段正确,turn_ended 后消失;变异去掉清除 → 红)。
+
+## promote 时的 must_contain
+
+`ANET_ACTIVE_NETWORK_TASK_FILE`(无正则元字符;`.59` 产物 0 命中——发布前用闸 4 原样命令再验一次)。


### PR DESCRIPTION
两个包各出一版 preview,让今天合进 main 的 #1770(共存节点三重出站)与 #1768(darwin/win32 平台门)到真机。#1770 是两半:agent-node 写标记、agent-network 的 node-server 读标记改写出站,**两包都升到位才生效**;只升一边不坏。

- agent-network `.77`:.76 之后 `agent-network/bin|src` 有 26 个非 release 提交(#1768、#1770 node-server、#1522 SIGTERM 10 s、#1186 附件、doctor/daemon 一批、PINNED_SERVER_VERSION .46)。说明文件按「用户看到的 | .76 | .77」列。
- agent-node `.60`:只有 #1770 那一个提交。

戳:两包 package.json / lock×2 / `opencode-agent-node-pair.ts` 两个 PAIRED 常量;getting-started zh+en 的 `channel=preview` 戳 → .77(`latest` 戳留 .76,表格拆成两行)。

门(本地,CI 参数):`check-doc-version-claims.py --package agent-network --version 2.3.0-preview.77 --verify-latest-from-npm` rc=0;同命令 agent-node .60 rc=0;`check-doc-symbol-pins.py .` 与 `. --doc-root docs-site` 都 rc=0;pair 测试 6/6。两个说明都含 `## Install` / `## Upgrade`。

合并后:release-gate 各 dispatch 一次(agent-network .77、agent-node .60);promote 的 must_contain 分别是 `progress_of_active_task` / `ANET_ACTIVE_NETWORK_TASK_FILE`(都已用闸 4 原样命令在上一版产物验过 0 命中)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD