### PR TITLE
fix(grok-build-cli-home): #1770 稳定化重建 commhubMcp 时丢了 activeTaskFile —— 真机 config.toml 没有标记 env

### DIFF
--- a/agent-node/src/runtime/grok-build-cli-home.test.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.test.ts
@@ -870,6 +870,22 @@ describe("prepareGrokCliHome", () => {
     expect(config).toContain(`ANET_COMMHUB_ENV_FILE = ${JSON.stringify(stagedEnv)}`);
     expect(config).toContain('ANET_COMMHUB_MODE = "outbound-only"');
     expect(readFileSync(stagedServer, "utf8")).toBe("// reviewed commhub MCP server\n");
+    // #1770 —— 运行时把当前网络任务标记的路径交给 node-server;这个字段曾在
+    // 「稳定化」那一步被重建成五个字段而丢掉(真机 config.toml 里没有它,
+    // 三重出站因此没被改写)。断言它逐字进 env。
+    const markerPath = join(root, "project", ".anet", ".active-network-task.json");
+    const withMarker = prepareGrokCliHome({
+      sourceHome,
+      stateRoot: dirname(stateHome),
+      stateHome,
+      denyPaths: [secretDir],
+      projectCwd: join(root, "project"),
+      useLeader: true,
+      commhubMcp: { ...commhubMcp, activeTaskFile: markerPath },
+    });
+    expect(withMarker).toBeDefined();
+    const configWithMarker = readFileSync(join(stateHome, "config.toml"), "utf8");
+    expect(configWithMarker).toContain(`ANET_ACTIVE_NETWORK_TASK_FILE = ${JSON.stringify(markerPath)}`);
     expect(readFileSync(stagedEnv, "utf8")).toBe("COMMHUB_TOKEN=ntok_test\n");
     expect(statSync(stagedServer).mode & 0o777).toBe(0o600);
     expect(statSync(stagedEnv).mode & 0o777).toBe(0o600);

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -1162,7 +1162,8 @@ function validateCommhubMcpConfig(
       throw new Error(`grok-build-cli commhub MCP ${label} is invalid`);
     }
   }
-  return { command, serverPath, envFile, alias: config.alias, resumeId: config.resumeId };
+  // #1770 —— 这里是显式重建,不是 spread:新字段不写进来就会在此静默消失。
+  return { command, serverPath, envFile, alias: config.alias, resumeId: config.resumeId, activeTaskFile: config.activeTaskFile };
 }
 
 /**


### PR DESCRIPTION
真机复现 #1770 的第一步就撞上了:把 DEV 上自己的 grok-v1 换到 anet .77 + agent-node .60(隔离前缀,不动全局),重启后 `~/.anet-grok/node-*/config.toml` 的 `[mcp_servers.commhub].env` 里**没有** `ANET_ACTIVE_NETWORK_TASK_FILE`,node-server 于是没有标记路径,改写从未武装;探针任务的出站仍是 2 条(模型自己的 send_task + 运行时 reply)。

根因:`grok-build-cli-home.ts` 里稳定化 commhubMcp 的那一步返回值是**显式五字段重建**(`{ command, serverPath, envFile, alias, resumeId }`),不是 spread,#1778 新增的 `activeTaskFile` 在这里静默消失;dist 里模板与调用点都在(bundle 里能 grep 到),所以单看源码/产物都像是对的。

## 改法

一行:返回值补 `activeTaskFile: config.activeTaskFile`,并留一句注释说明这里是显式重建。

## 证据

- `grok-build-cli-home.test.ts` 新断言:传 `activeTaskFile` 后 config.toml 含 `ANET_ACTIVE_NETWORK_TASK_FILE = "<路径>"`。**修前 1 fail,修后全绿**(同一条测试)。
- typecheck 棘轮 81/81 不变。

## 之后

需要再发 agent-node `.61` 才能到真机;发了以后在 grok-v1 上重复探针,期望出站 = 1(只剩运行时 reply)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD