### PR TITLE
chore(release): agent-node 2.5.0-preview.61 —— #1770 补漏(activeTaskFile 被稳定化重建丢掉)

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.77";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.60";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.61";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.60",
+  "version": "2.5.0-preview.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.60",
+      "version": "2.5.0-preview.61",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.60",
+  "version": "2.5.0-preview.61",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.61.md
+++ b/docs/tests/release-v2.5.0-preview.61.md
@@ -1,0 +1,31 @@
+# agent-node 2.5.0-preview.61
+
+`.60` 之后只有一个提交,但没有它 `.60` 里的 #1770 那一半**根本不生效**:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `483501e2` | #1781 | **#1770 补漏** —— `grok-build-cli-home.ts` 稳定化 commhubMcp 时是显式五字段重建,`.60` 新加的 `activeTaskFile` 在那里被丢掉,真机 `config.toml` 的 mcp env 里没有 `ANET_ACTIVE_NETWORK_TASK_FILE`,node-server 拿不到标记路径,改写从未武装(DEV grok-v1 实测:探针出站仍 2 条) |
+
+## 这一版带给用户什么
+
+装了 `.60` + anet `.77` 的共存节点,发起方仍会收到模型自己发的那条重复 send_task;`.61` 之后 node-server 才真的拿到标记路径。**要重启共存节点**(config.toml 是启动时生成的)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.61
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.61
+npm i -g @sleep2agi/agent-network@2.3.0-preview.77   # node-server 那一半
+anet node stop <name> && anet node start <name> --copresence   # config.toml 启动时重生成
+```
+
+## 证据
+
+- `grok-build-cli-home.test.ts` 新断言(传 `activeTaskFile` 后 config.toml 含 `ANET_ACTIVE_NETWORK_TASK_FILE = "<路径>"`):修前 1 fail,修后 43/43。
+- typecheck 棘轮 81/81 不变。
+- 发布后在 DEV grok-v1 重做探针,目标出站 = 1(只剩运行时 reply),结果回填到 #1770。


### PR DESCRIPTION
`.60` 里 #1770 的运行时半边不生效(真机 config.toml 缺 `ANET_ACTIVE_NETWORK_TASK_FILE`,见 #1770 评论),#1781 一行修好;单独发 `.61` 让它到真机。

- 四处戳 .60 → .61(package.json / lock ×2 / `PAIRED_AGENT_NODE_VERSION`)
- `docs/tests/release-v2.5.0-preview.61.md` 含 Install/Upgrade;`check-doc-version-claims.py --package agent-node --version 2.5.0-preview.61 --verify-latest-from-npm` rc=0;pair 测试 6/6

合并后 release-gate 发 preview,然后在 DEV grok-v1 重做探针(目标出站 = 1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD