### PR TITLE
fix(grok-copresence): #1770 标记路径真正接到 runtime 并搬到凭据目录 —— .61 真机仍 2 条出站

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -17,7 +17,7 @@ import {
   assertCopresenceSupported as assertGrokCopresenceSupported,
   copresenceDowngradeNotice as grokCopresenceDowngradeNotice,
 } from "./runtime/grok-copresence/platform";
-import { activeNetworkTaskMarkerPath } from "./runtime/grok-copresence/active-network-task-marker.js";
+import { activeNetworkTaskMarkerPathInCredentialDir } from "./runtime/grok-copresence/active-network-task-marker.js";
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
@@ -4022,6 +4022,11 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
     const grokHomeKey = grokCliStateKey(NODE_ID || ALIAS || "default");
     const stateGrokRoot = join(home, ".anet-grok");
     const stateGrokHome = join(stateGrokRoot, grokHomeKey);
+    // #1770 —— 当前网络任务标记。放在 node-server 已经在读 .env 的那个凭据目录里
+    // (prepareGrokCliHome 的 credentialDir = <home>/.anet-grok-credentials/<key>),
+    // 而不是项目 .anet/:后者对沙箱里的 grok(及其子进程 node-server)是 deny 的。
+    // 同一个路径同时交给 mcp env(读方)和 runtime(写方);两边不一致就等于没接。
+    const activeNetworkTaskMarker = activeNetworkTaskMarkerPathInCredentialDir(home, grokHomeKey);
     const commhubMcpServer = resolve(grokCwd, ".anet", "node-server.js");
     const commhubMcpEnv = resolve(grokCwd, ".anet", ".env");
     const runtimeDir = join(stateGrokHome, "run");
@@ -4060,7 +4065,7 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
           envFile: commhubMcpEnv,
           alias: currentAlias(),
           resumeId: `grok-cli-${NODE_ID || grokHomeKey}`,
-          activeTaskFile: activeNetworkTaskMarkerPath(grokCwd),
+          activeTaskFile: activeNetworkTaskMarker,
         },
         denyPaths: grokCliDenyPaths({
           projectCwd: grokCwd,
@@ -4196,6 +4201,7 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
     }
     const session = await openGrokCopresenceRuntime({
       binary: grokBinary,
+      activeNetworkTaskMarkerPath: activeNetworkTaskMarker,
       cwd: grokCwd,
       grokHome: grokCliHome.home,
       // 1.0.5 移除了 --no-memory / --no-auto-update 且硬拒未知 flag，

--- a/agent-node/src/runtime/grok-copresence/active-network-task-marker.test.ts
+++ b/agent-node/src/runtime/grok-copresence/active-network-task-marker.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   ACTIVE_NETWORK_TASK_FILE,
   activeNetworkTaskMarkerPath,
+  activeNetworkTaskMarkerPathInCredentialDir,
   clearActiveNetworkTaskMarker,
   writeActiveNetworkTaskMarker,
 } from "./active-network-task-marker.js";
@@ -16,6 +17,16 @@ afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 describe("active network task marker", () => {
   test("path lives next to node-server's .env under <cwd>/.anet", () => {
     expect(activeNetworkTaskMarkerPath("/work/p")).toBe(join("/work/p", ".anet", ACTIVE_NETWORK_TASK_FILE));
+  });
+  test("#1770 the credential-dir path matches prepareGrokCliHome's credentialDir layout", () => {
+    expect(activeNetworkTaskMarkerPathInCredentialDir("/home/u", "node-abc")).toBe(join("/home/u", ".anet-grok-credentials", "node-abc", ACTIVE_NETWORK_TASK_FILE));
+  });
+  test("#1770 cli.ts hands the SAME path to the mcp env (reader) and the runtime (writer)", () => {
+    // 真机第二次探针:mcp env 有路径、runtime 没拿到 activeNetworkTaskMarkerPath,标记从未写出。
+    const cli = readFileSync(join(import.meta.dir, "..", "..", "cli.ts"), "utf8");
+    expect(cli).toContain("activeTaskFile: activeNetworkTaskMarker,");
+    expect(cli).toContain("activeNetworkTaskMarkerPath: activeNetworkTaskMarker,");
+    expect(cli).not.toContain("activeNetworkTaskMarkerPath(grokCwd)");
   });
   test("write creates the directory, is 0600 and round-trips the three fields", () => {
     const path = activeNetworkTaskMarkerPath(dir);

--- a/agent-node/src/runtime/grok-copresence/active-network-task-marker.ts
+++ b/agent-node/src/runtime/grok-copresence/active-network-task-marker.ts
@@ -21,6 +21,15 @@ export function activeNetworkTaskMarkerPath(projectCwd: string): string {
   return join(projectCwd, ".anet", ACTIVE_NETWORK_TASK_FILE);
 }
 
+/**
+ * 真机(#1770 评论)证明项目 .anet/ 不是好位置:它对沙箱里的 grok 及其子进程 node-server 是 deny 的,
+ * 读方永远读不到。node-server 已经在读 `<home>/.anet-grok-credentials/<key>/.env`,标记放同一目录。
+ * 这里的拼法必须与 grok-build-cli-home.ts 里 credentialDir 的拼法一致(dirname(stateRoot) + basename(stateHome))。
+ */
+export function activeNetworkTaskMarkerPathInCredentialDir(home: string, grokHomeKey: string): string {
+  return join(home, ".anet-grok-credentials", grokHomeKey, ACTIVE_NETWORK_TASK_FILE);
+}
+
 /** 原子写(tmp + rename),0600;目录不存在就建(0700)。 */
 export function writeActiveNetworkTaskMarker(path: string, marker: ActiveNetworkTaskMarker): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });


### PR DESCRIPTION
agent-node `.61` 在 DEV grok-v1 上第二次探针(`PING-b9d4`):config.toml 的 mcp env 已经有 `ANET_ACTIVE_NETWORK_TASK_FILE`,出站仍是 2 条(模型 send_task + 运行时 reply)。两个原因,这个 PR 一起修:

1. **写方没接上**:cli.ts 把路径放进了 `commhubMcp.activeTaskFile`(读方),但从没把 `activeNetworkTaskMarkerPath` 传给 `openGrokCopresenceRuntime`(写方),标记从未写出。#1778 的 runtime 测试是直接给 runtime 传路径,所以绿;cli.ts 这一跳没人测。
2. **原路径读不到**:`<cwd>/.anet/` 对沙箱里的 grok 及其子进程 node-server 是 deny 的(凭据正因此被 prepare 搬到 `<home>/.anet-grok-credentials/<key>/`)。标记现在也放那个目录,node-server 已经在那里读 `.env`。

## 改法

- `active-network-task-marker.ts`:新增 `activeNetworkTaskMarkerPathInCredentialDir(home, grokHomeKey)`,拼法与 `prepareGrokCliHome` 的 credentialDir 一致。
- `cli.ts` 共存分支:算一次 `activeNetworkTaskMarker`,同一个变量同时给 `commhubMcp.activeTaskFile` 和 `openGrokCopresenceRuntime({ activeNetworkTaskMarkerPath })`。
- 测试:路径拼法;以及 cli.ts 源码两处都用同一变量、旧的 `activeNetworkTaskMarkerPath(grokCwd)` 不再出现(这一跳只能这样钉,真机再验)。

## 证据

- marker + grok-build-cli-home 测试 49/49;typecheck 棘轮 81/81;doc-symbol-pins 两种参数 rc=0。
- 合并后发 agent-node `.62`,grok-v1 第三次探针,目标出站 = 1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD