### PR TITLE
fix(grok-build-cli): #1767 被打断的 stop 留下的精确占位不再让下一次启动被拒 —— 拿到项目锁后回收

### DIFF
--- a/agent-node/src/runtime/grok-build-cli-home.test.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.test.ts
@@ -29,6 +29,7 @@ import {
   resolveGrokCommhubMcpCommand,
   canTrustGrokProjectCwd,
   isOverBroadGrokTrustTarget,
+  reclaimStaleProjectSandboxPlaceholders,
 } from "./grok-build-cli-home";
 import { assertGrokCopresenceAgentProfile } from "./grok-copresence/policy";
 
@@ -342,6 +343,54 @@ describe("prepareGrokCliHome", () => {
       denyPaths: [secretDir],
     })).toThrow("project executable configuration");
     expect(existsSync(resumedStateHome)).toBe(false);
+  });
+
+  it("#1767 a start after an interrupted stop admits the exact stale placeholders instead of refusing", () => {
+    // SIGTERM (or a tmux kill) before post-stop cleanup leaves the five 0-byte
+    // 0444 placeholders in the project; the next start used to refuse with
+    // "expected a real directory" and needed a human to delete them.
+    const root = mkdtempSync(join(tmpdir(), "grok-cli-stale-placeholders-"));
+    roots.push(root);
+    const sourceHome = join(root, "source");
+    const stateHome = join(root, "state");
+    const project = join(root, "project");
+    const secretDir = join(project, ".anet");
+    for (const directory of [sourceHome, stateHome, secretDir]) mkdirSync(directory, { recursive: true, mode: 0o700 });
+    for (const name of [".grok", ".claude", ".cursor", ".mcp.json", ".envrc"]) {
+      writeFileSync(join(project, name), "", { mode: 0o444 });
+      chmodSync(join(project, name), 0o444);
+    }
+    expect(() => prepareGrokCliHome({
+      sourceHome,
+      stateRoot: dirname(stateHome),
+      stateHome,
+      projectCwd: project,
+      useLeader: true,
+      denyPaths: [secretDir],
+    })).not.toThrow();
+
+    // Reclaim (the runtime does this right after it holds the project turn lock):
+    // exactly the five pinned names go, an unknown 0444 file and a real dir stay.
+    const unknown = join(project, ".grok-future-placeholder");
+    writeFileSync(unknown, "", { mode: 0o444 });
+    chmodSync(unknown, 0o444);
+    expect(reclaimStaleProjectSandboxPlaceholders(project).sort()).toEqual([".claude", ".cursor", ".envrc", ".grok", ".mcp.json"]);
+    for (const name of [".grok", ".claude", ".cursor", ".mcp.json", ".envrc"]) {
+      expect(existsSync(join(project, name)), name).toBe(false);
+    }
+    expect(existsSync(unknown)).toBe(true);
+    expect(reclaimStaleProjectSandboxPlaceholders(project)).toEqual([]);
+
+    // A real regular file at one of those names is not a placeholder: still refused.
+    writeFileSync(join(project, ".envrc"), "export X=1\n", { mode: 0o644 });
+    expect(() => prepareGrokCliHome({
+      sourceHome,
+      stateRoot: dirname(stateHome),
+      stateHome,
+      projectCwd: project,
+      useLeader: true,
+      denyPaths: [secretDir],
+    })).toThrow("project executable configuration");
   });
 
   it("validates every exact project placeholder before unlinking any sibling", () => {

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -533,6 +533,35 @@ function openOwnedProjectDirectoryForPostStop(path: string): {
   }
 }
 
+/** #1767 —— 「本人留下的 0 字节 0444 单链接普通文件」这个精确形状,不抛异常的判断。 */
+function isExactProjectSandboxPlaceholderStat(stat: ReturnType<typeof lstatSync>, uid: number | undefined): boolean {
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1 || stat.size !== 0) return false;
+  if (posixFileModes() && (stat.mode & 0o7777) !== 0o444) return false;
+  if (uid !== undefined && stat.uid !== uid) return false;
+  return true;
+}
+
+function isStaleProjectSandboxPlaceholder(path: string): boolean {
+  const stat = lstatIfPresent(path);
+  if (!stat) return false;
+  return isExactProjectSandboxPlaceholderStat(stat, process.getuid?.());
+}
+
+/**
+ * #1767 —— 上一次进程被 SIGTERM / tmux kill 打断在 post-stop 清理之前,项目里会留下
+ * 五个占位;下一次启动曾被它们拒绝(expected a real directory),要人手删。
+ * 这里只回收**精确占位形状**的那五个名字,走与 post-stop 同一条校验链
+ * (任一候选不是占位就整批拒绝,不做部分清理);其余文件一律不碰。
+ * 调用方必须已持有项目 turn lock(同一项目不可能有另一个活着的 TUI)。
+ */
+export function reclaimStaleProjectSandboxPlaceholders(projectCwd: string): string[] {
+  const present = GROK_POST_STOP_CLEANUP_POLICY.projectSandboxPlaceholders.basenames
+    .filter((name) => isStaleProjectSandboxPlaceholder(join(projectCwd, name)));
+  if (present.length === 0) return [];
+  removeExactProjectSandboxPlaceholders(resolve(projectCwd));
+  return [...present];
+}
+
 function assertExactProjectSandboxPlaceholder(
   path: string,
   stat: ReturnType<typeof lstatSync>,
@@ -1059,7 +1088,8 @@ export function assertNoProjectGrokExecutableSources(cwd: string, strictFolderTr
     // Grok process so they cannot be planted after this admission check.
     const grokDir = join(directory, ".grok");
     const grokStat = lstatIfPresent(grokDir);
-    if (grokStat && (grokStat.isSymbolicLink() || !grokStat.isDirectory())) {
+    // #1767 —— 上次没清掉的精确占位不是可执行来源;runtime 拿到 turn lock 后会回收它。
+    if (grokStat && (grokStat.isSymbolicLink() || !grokStat.isDirectory()) && !isStaleProjectSandboxPlaceholder(grokDir)) {
       throw new Error(
         `grok-build-cli refuses project policy state at ${grokDir}: expected a real directory`,
       );
@@ -1068,6 +1098,8 @@ export function assertNoProjectGrokExecutableSources(cwd: string, strictFolderTr
     // plugins are always refused, but other project compatibility state stays
     // governed by Grok's normal untrusted-folder behavior.
     for (const executableSource of [".grok/hooks", ".grok/plugins"]) {
+      // #1767 —— .grok 是上次留下的 0 字节占位时,它底下不可能有 hooks/plugins(lstat 会 ENOTDIR)。
+      if (grokStat && !grokStat.isDirectory() && isStaleProjectSandboxPlaceholder(grokDir)) break;
       const candidate = join(directory, executableSource);
       if (!lstatIfPresent(candidate)) continue;
       throw new Error(
@@ -1084,12 +1116,12 @@ export function assertNoProjectGrokExecutableSources(cwd: string, strictFolderTr
     for (const policyDirectory of [".grok", ".claude", ".cursor"]) {
       const candidate = join(directory, policyDirectory);
       const stat = lstatIfPresent(candidate);
-      if (stat && (stat.isSymbolicLink() || !stat.isDirectory())) {
+      if (stat && (stat.isSymbolicLink() || !stat.isDirectory()) && !isStaleProjectSandboxPlaceholder(candidate)) {
         throw new Error(
           `grok-build-cli refuses project policy state at ${candidate}: expected a real directory`,
         );
       }
-      if (stat && readdirSync(candidate).length !== 0) {
+      if (stat && stat.isDirectory() && readdirSync(candidate).length !== 0) {
         throw new Error(
           `grok-build-cli refuses project executable configuration at ${candidate}: `
           + "shared-TUI folder trust requires an empty project extension directory",
@@ -1099,6 +1131,7 @@ export function assertNoProjectGrokExecutableSources(cwd: string, strictFolderTr
     for (const source of [".mcp.json", ".envrc"]) {
       const candidate = join(directory, source);
       if (!lstatIfPresent(candidate)) continue;
+      if (isStaleProjectSandboxPlaceholder(candidate)) continue; // #1767
       throw new Error(
         `grok-build-cli refuses project executable configuration at ${candidate}: `
         + "folder trust would activate code outside the model tool sandbox",

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { createHash, randomBytes } from "crypto";
 import { spawn } from "child_process";
 import {
@@ -534,7 +535,7 @@ function openOwnedProjectDirectoryForPostStop(path: string): {
 }
 
 /** #1767 —— 「本人留下的 0 字节 0444 单链接普通文件」这个精确形状,不抛异常的判断。 */
-function isExactProjectSandboxPlaceholderStat(stat: ReturnType<typeof lstatSync>, uid: number | undefined): boolean {
+function isExactProjectSandboxPlaceholderStat(stat: Stats, uid: number | undefined): boolean {
   if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1 || stat.size !== 0) return false;
   if (posixFileModes() && (stat.mode & 0o7777) !== 0o444) return false;
   if (uid !== undefined && stat.uid !== uid) return false;
@@ -544,7 +545,7 @@ function isExactProjectSandboxPlaceholderStat(stat: ReturnType<typeof lstatSync>
 function isStaleProjectSandboxPlaceholder(path: string): boolean {
   const stat = lstatIfPresent(path);
   if (!stat) return false;
-  return isExactProjectSandboxPlaceholderStat(stat, process.getuid?.());
+  return isExactProjectSandboxPlaceholderStat(stat as Stats, process.getuid?.());
 }
 
 /**

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -30,7 +30,7 @@ import { setTimeout as delay } from "timers/promises";
 import { StringDecoder } from "string_decoder";
 import { clearActiveNetworkTaskMarker, writeActiveNetworkTaskMarker } from "./active-network-task-marker.js";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
-import { resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
+import { reclaimStaleProjectSandboxPlaceholders, resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
 import { describeStuckPhase } from "./stuck-phase-alarm";
 import { describeStalledNetworkTurn } from "./stalled-network-turn";
 import { describeAbandonedHumanEditing } from "./abandoned-human-editing";
@@ -1414,6 +1414,14 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         flockBinary,
         this.opts.env,
       ));
+      // #1767 —— 锁到手就说明这个项目没有别的活 TUI;上次被打断在 post-stop 之前留下的
+      // 精确占位现在可以安全回收。回收失败只 warn:prepare 已把它们当非可执行来源放行。
+      try {
+        const reclaimed = reclaimStaleProjectSandboxPlaceholders(this.opts.cwd);
+        if (reclaimed.length) this.log(`[grok-copresence] reclaimed ${reclaimed.length} stale project placeholder(s) left by an interrupted stop: ${reclaimed.join(" ")}`);
+      } catch (error) {
+        this.warn(`[grok-copresence] could not reclaim stale project placeholders: ${errorMessage(error)}`);
+      }
       const leaderLockKey = createHash("sha256").update(this.leaderSocket).digest("hex").slice(0, 20);
       const sessionLockDir = join(realpathSync(this.opts.grokHome), "copresence-locks");
       ensurePrivateRuntimeDirectory(sessionLockDir);


### PR DESCRIPTION
Closes #1767。

进程被 SIGTERM / `anet node stop`(tmux kill)打断在 post-stop 清理之前,项目目录里留下 `.grok .claude .cursor .mcp.json .envrc` 五个 0 字节 0444 占位(grok 自己种的 read-deny 锚点),下一次 `prepare` 被 `assertNoProjectGrokExecutableSources` 拒绝(`expected a real directory`),要人手删。今天在 DEV grok-v1 上两次 `anet node stop` 之后五个占位都在,每次都要手清。

## 改法

- **prepare 准入**:形状恰好是「本人、0 字节、0444、单链接、非符号链接」的那五个名字不算可执行来源(`.grok` 是占位时也不再去 lstat `.grok/hooks`,那会 ENOTDIR);任何别的形状照旧拒。
- **回收点**:`runtime.open` 在 `acquireGrokProjectTurnLock` 成功之后调用 `reclaimStaleProjectSandboxPlaceholders(cwd)` —— 锁到手就说明同一项目没有别的活 TUI,这时回收不会碰到活 grok 的锚点。回收复用 post-stop 那条「整批校验再 unlink」链(任一候选不是占位就整批拒、不做部分清理),未知 0444 文件、真目录一律不碰;失败只 warn。

## 证据

- `grok-build-cli-home.test.ts` +1:五占位 prepare 不再抛;回收恰好五个并留下未知文件;`.envrc` 换成真文件仍拒 `project executable configuration`。修前该用例红(import 不存在 + prepare 抛),修后 44/44;runtime 测试 77/77。
- typecheck 棘轮 81/81(中途因 `ReturnType<typeof lstatSync>` 含 bigint/undefined 多出 7 条,改为 `Stats` 后回到基线);doc-symbol-pins 两种参数 rc=0。

## 没做的

SIGTERM 处理器里优先 unlink 占位(issue 的第二个建议)没做:回收放在下一次启动的锁后面已经覆盖所有「起不来」的情形,而在信号处理器里做文件删除会和 post-stop 校验链打架。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD