### PR TITLE
chore(release): agent-node 2.5.0-preview.62 —— #1770 第三层 + #1767 占位回收

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.77";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.61";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.62";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.61",
+  "version": "2.5.0-preview.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.61",
+      "version": "2.5.0-preview.62",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.61",
+  "version": "2.5.0-preview.62",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/release-v2.5.0-preview.62.md
+++ b/docs/tests/release-v2.5.0-preview.62.md
@@ -1,0 +1,36 @@
+# agent-node 2.5.0-preview.62
+
+`.61` 之后 `agent-node/` 两个提交,都是共存节点在真机上踩出来的:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `e385aabc` | #1783 | **#1770 第三层** —— 标记路径真正传给运行时(写方),并从项目 `.anet/`(对沙箱内 node-server 是 deny 的)搬到 `<home>/.anet-grok-credentials/<key>/`(node-server 已在那里读 `.env`);同一个变量同时交给读写双方 |
+| `365ae45c` | #1784 | **#1767** —— 被 SIGTERM / `anet node stop` 打断在 post-stop 清理之前留下的五个 0 字节 0444 占位,下一次启动不再被拒:prepare 放行精确占位形状,runtime 拿到项目锁后回收 |
+
+## 这一版带给用户什么
+
+- 共存节点 `anet node stop` 之后再 `start` 不用再手删 `.grok .claude .cursor .mcp.json .envrc`(TMWork苹果打包狗、grok-v1 各踩过)。
+- 配合 anet `2.3.0-preview.77`,模型对任务发起方的重复 send_task / send_message 应被改写成不推送的进度上报;`.60`/`.61` 都因为路径没接到位而没生效,这是第一版真正把读写两端接在同一个可读位置的。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.62
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.62
+npm i -g @sleep2agi/agent-network@2.3.0-preview.77
+anet node stop <name> && anet node start <name> --copresence   # config.toml 启动时重生成;这一次 stop 后不用手删占位
+```
+
+## 证据
+
+- `active-network-task-marker.test.ts` +2(凭据目录拼法;cli.ts 两处用同一变量)、`grok-build-cli-home.test.ts` +1(五占位 prepare 不抛、回收恰好五个、真文件仍拒);typecheck 棘轮 81/81。
+- 发布后在 DEV grok-v1 做第四次探针,目标出站 = 1,结果回填 #1770。
+
+## promote 时的 must_contain
+
+`stale project placeholder`(`.61` 产物 0 命中,已用闸 4 原样命令验)。


### PR DESCRIPTION
`.61` 之后两个提交:#1783(#1770 标记路径真正传给运行时并搬到凭据目录)与 #1784(#1767 被打断的 stop 留下的占位不再让下一次启动被拒)。

- 四处戳 .61 → .62;`docs/tests/release-v2.5.0-preview.62.md` 含 Install/Upgrade;promote 判据 `stale project placeholder`(.61 产物 0 命中)。
- `check-doc-version-claims.py --package agent-node --version 2.5.0-preview.62 --verify-latest-from-npm` rc=0;pair 测试 6/6。

合并后 release-gate 发 preview → DEV grok-v1 第四次探针(目标出站 1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD