### PR TITLE
fix(node-server): #1727 claude-code 裸节点也报六个监控字段 —— 三处身份载荷带上 host / process_telemetry

### DIFF
--- a/agent-network/src/host-telemetry.ts
+++ b/agent-network/src/host-telemetry.ts
@@ -1,0 +1,184 @@
+// Host telemetry sampler for #119 — appended to report_status payload so the
+// commhub server (step 2, 通信牛) can aggregate per-server stats for the
+// dashboard /api/servers sidebar (step 3, N站马).
+//
+// Linux → read /proc/loadavg + /proc/meminfo (kernel-accurate; MemAvailable is
+// the kernel's own estimate of reclaimable memory, which is what users care
+// about and is more accurate than freemem + buffers/cache heuristics).
+//
+// macOS/Win → node:os fallback (os.loadavg / os.totalmem / os.freemem). On
+// Windows os.loadavg() returns [0,0,0] — we keep it null in that case to
+// signal "unavailable" rather than a misleading zero.
+//
+// Every field can be null independently — payload always contains the `host`
+// key with all fields present, so downstream aggregation logic doesn't need
+// to handle a missing-host scenario.
+//
+// Cache 10s to amortize fs reads. agent-node's heartbeat is every 3min so the
+// cache is mostly defensive against bursts (working/idle transitions in
+// quick succession after a task completes).
+import { readFileSync } from "fs";
+import { execFileSync } from "child_process";
+import {
+  hostname as osHostname,
+  loadavg as osLoadavg,
+  totalmem as osTotalmem,
+  freemem as osFreemem,
+  cpus as osCpus,
+  networkInterfaces as osNetworkInterfaces,
+  platform as osPlatform,
+} from "os";
+
+export interface HostTelemetry {
+  hostname: string;
+  ip: string | null;
+  cpu_load_1min: number | null;
+  cpu_cores: number | null;
+  mem_total_gb: number | null;
+  mem_used_gb: number | null;
+  mem_avail_gb: number | null;
+  disk_total_gb: number | null;
+  disk_used_gb: number | null;
+  disk_avail_gb: number | null;
+}
+
+let _cache: { ts: number; value: HostTelemetry } | null = null;
+const CACHE_MS = 10_000;
+
+function firstNonInternalIPv4(): string | null {
+  try {
+    const ifaces = osNetworkInterfaces();
+    for (const ifs of Object.values(ifaces)) {
+      if (!ifs) continue;
+      for (const i of ifs) {
+        if (i.family === "IPv4" && !i.internal) return i.address;
+      }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function readLoadavg1Min(): number | null {
+  if (osPlatform() === "linux") {
+    try {
+      const raw = readFileSync("/proc/loadavg", "utf-8");
+      const v = parseFloat(raw.split(/\s+/)[0]);
+      if (Number.isFinite(v)) return v;
+    } catch { /* fall through to os.loadavg */ }
+  }
+  // os.loadavg() returns [0,0,0] on Windows — coerce that to null so callers
+  // can distinguish "unsupported" from "actually idle".
+  try {
+    const arr = osLoadavg();
+    if (!arr || arr.length === 0) return null;
+    if (osPlatform() === "win32" && arr[0] === 0 && arr[1] === 0 && arr[2] === 0) {
+      return null;
+    }
+    const v = arr[0];
+    return Number.isFinite(v) ? v : null;
+  } catch { /* ignore */ }
+  return null;
+}
+
+interface MemStats { total: number | null; used: number | null; avail: number | null }
+
+function readMemoryStats(): MemStats {
+  if (osPlatform() === "linux") {
+    try {
+      const raw = readFileSync("/proc/meminfo", "utf-8");
+      const parseKB = (key: string): number | null => {
+        // /proc/meminfo lines look like "MemTotal:       65978540 kB"
+        const m = raw.match(new RegExp(`^${key}:\\s+(\\d+)\\s+kB`, "m"));
+        return m ? parseInt(m[1], 10) * 1024 : null;
+      };
+      const total = parseKB("MemTotal");
+      const avail = parseKB("MemAvailable");
+      if (total != null && avail != null && avail <= total) {
+        return { total, used: total - avail, avail };
+      }
+    } catch { /* fall through to os.* */ }
+  }
+  try {
+    const total = osTotalmem();
+    const free = osFreemem();
+    // On non-Linux we can only approximate avail≈free (kernel doesn't expose
+    // MemAvailable). Mark used = total - free.
+    return { total, used: total - free, avail: free };
+  } catch {
+    return { total: null, used: null, avail: null };
+  }
+}
+
+interface DiskStats { total: number | null; used: number | null; avail: number | null }
+
+// RFC-014 §2.1 — disk telemetry via execFileSync('df', ['-k', '/']).
+// `-k` is POSIX-standard and reports KB on both Linux and macOS, so the
+// parse logic is unified — no `-B1` (Linux-only) vs `-k` (macOS) divergence.
+// execFileSync (not execSync + shell pipe) per repo shell-pipe audit hygiene.
+// Windows: graceful null (dashboard shows "—" rather than misleading 0).
+function readDiskStats(): DiskStats {
+  if (osPlatform() === "linux" || osPlatform() === "darwin") {
+    try {
+      const out = execFileSync("df", ["-k", "/"], { encoding: "utf-8", timeout: 1000 });
+      // df output: header line + one data row. Format:
+      //   <fs> <1K-blocks> <used> <available> <use%> <mountpoint>
+      // Take last non-empty line to skip the header.
+      const lines = out.trim().split(/\n/);
+      const lastLine = lines[lines.length - 1] || "";
+      const fields = lastLine.split(/\s+/);
+      const totalKb = parseInt(fields[1], 10);
+      const usedKb  = parseInt(fields[2], 10);
+      const availKb = parseInt(fields[3], 10);
+      if (Number.isFinite(totalKb) && Number.isFinite(usedKb) && Number.isFinite(availKb)) {
+        return { total: totalKb * 1024, used: usedKb * 1024, avail: availKb * 1024 };
+      }
+    } catch { /* fall through to null */ }
+  }
+  return { total: null, used: null, avail: null };
+}
+
+const toGb = (bytes: number | null): number | null =>
+  bytes == null ? null : Math.round((bytes / (1024 ** 3)) * 10) / 10;
+
+function cpuCores(): number | null {
+  try {
+    const n = osCpus().length;
+    return n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getHostTelemetry(): HostTelemetry {
+  const now = Date.now();
+  // `delta >= 0` guard: NTP step / VM live-migrate can jump the wall clock
+  // backward. Without this, `now - _cache.ts` goes negative and we'd serve
+  // a stale value forever (until the clock catches back up past CACHE_MS).
+  // Re-sampling on backward skew costs at most one extra /proc read + df.
+  if (_cache) {
+    const delta = now - _cache.ts;
+    if (delta >= 0 && delta < CACHE_MS) return _cache.value;
+  }
+  const mem = readMemoryStats();
+  const disk = readDiskStats();
+  const value: HostTelemetry = {
+    hostname: osHostname() || "unknown",
+    ip: firstNonInternalIPv4(),
+    cpu_load_1min: readLoadavg1Min(),
+    cpu_cores: cpuCores(),
+    mem_total_gb: toGb(mem.total),
+    mem_used_gb: toGb(mem.used),
+    mem_avail_gb: toGb(mem.avail),
+    disk_total_gb: toGb(disk.total),
+    disk_used_gb: toGb(disk.used),
+    disk_avail_gb: toGb(disk.avail),
+  };
+  _cache = { ts: now, value };
+  return value;
+}
+
+// Test-only: clear the cache. Not exported in the public API surface but
+// available for unit tests that want to verify cache behaviour.
+export function _clearHostTelemetryCache(): void {
+  _cache = null;
+}

--- a/agent-network/src/node-server-identity-payload.test.ts
+++ b/agent-network/src/node-server-identity-payload.test.ts
@@ -53,6 +53,10 @@ describe("node-server 的身份载荷(三处)", () => {
 
   it("三处都带 project_dir —— 这一格本来就有,当基准", () => {
     for (const b of blocks) expect(b).toContain("project_dir: process.cwd()");
+    // #1727 —— 六个监控字段(uptime/rss/cpu/load/disk/version 里的前五个)由这两把采集器产;
+    // 三处身份载荷少任何一处,那条路径上的节点在 Dashboard 就只剩「在线」。
+    for (const b of blocks) expect(b).toContain("host: getHostTelemetry()");
+    for (const b of blocks) expect(b).toContain("process_telemetry: getProcessTelemetry()");
   });
 
   it("🔴 三处都带 config_path —— 加第四处注册点时漏了会红", () => {

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -104,6 +104,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { decideReplyAlias, replyAliasArgs } from "./reply-originator.js";
 import { clampOutboundPriority, decideOutboundRewrite, parseActiveNetworkTask } from "./active-network-task.js";
+import { getHostTelemetry } from "./host-telemetry.js";
+import { getProcessTelemetry } from "./process-telemetry.js";
 
 // ── Load ~/.anet/config.json for token fallback ──────
 function loadAnetConfig(): Record<string, string> {
@@ -562,6 +564,10 @@ async function reregister(): Promise<void> {
       agent: "claude-code",
       project_dir: process.cwd(),
       config_path: CONFIG_PATH,
+      // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
+      // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
+      host: getHostTelemetry(),
+      process_telemetry: getProcessTelemetry(),
       tmux_name: TMUX_NAME || undefined,
     });
     log(`re-registered as "${ALIAS}" after SSE reconnect`);
@@ -744,6 +750,10 @@ async function main() {
     agent: "claude-code",
     project_dir: process.cwd(),
     config_path: CONFIG_PATH,
+    // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
+    // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
+    host: getHostTelemetry(),
+    process_telemetry: getProcessTelemetry(),
     tmux_name: TMUX_NAME || undefined,
   })
     .then(() => log(`registered as "${ALIAS}" (${RESUME_ID.slice(0, 8)})`))
@@ -760,6 +770,10 @@ async function main() {
       agent: "claude-code",
       project_dir: process.cwd(),
       config_path: CONFIG_PATH,
+      // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
+      // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
+      host: getHostTelemetry(),
+      process_telemetry: getProcessTelemetry(),
       tmux_name: TMUX_NAME || undefined,
     }).catch((e) => log(`heartbeat failed: ${e}`));
   }, 3 * 60 * 1000);

--- a/agent-network/src/process-telemetry.ts
+++ b/agent-network/src/process-telemetry.ts
@@ -1,0 +1,81 @@
+// Per-agent process telemetry for #142 (Track 2 of v0.10.0).
+//
+// Extends #119's host-telemetry.ts with metrics scoped to this agent-node
+// process — RSS, CPU%, uptime, in-flight task count. Aggregated by commhub-
+// server (T2.2, 通信牛) and rendered by dashboard sidebar/hover (T2.3,
+// N站马) alongside the existing per-host fields.
+//
+// All fields are nullable independently. CPU% is null on the first sample
+// because it needs a delta against a previous sample. After that it tracks
+// the rate of cpuUsage growth over wall-clock time.
+//
+// The in-flight counter is incremented when think() begins processing a
+// task and decremented when it returns (success or error). Race-free
+// because think() serializes through thinkQueue.
+
+export interface ProcessTelemetry {
+  rss_bytes: number;
+  rss_mb: number;
+  cpu_pct: number | null;
+  uptime_seconds: number;
+  in_flight_count: number;
+}
+
+interface CpuSample {
+  ts_ms: number;
+  user_us: number;
+  system_us: number;
+}
+
+let _lastCpu: CpuSample | null = null;
+let _inFlight = 0;
+
+export function incrementInFlight(): void {
+  _inFlight++;
+}
+
+export function decrementInFlight(): void {
+  _inFlight = Math.max(0, _inFlight - 1);
+}
+
+export function getInFlightCount(): number {
+  return _inFlight;
+}
+
+export function getProcessTelemetry(): ProcessTelemetry {
+  const now = Date.now();
+  const cpu = process.cpuUsage();
+
+  let cpu_pct: number | null = null;
+  if (_lastCpu) {
+    const wallDeltaMs = now - _lastCpu.ts_ms;
+    const userDeltaUs = cpu.user - _lastCpu.user_us;
+    const systemDeltaUs = cpu.system - _lastCpu.system_us;
+    const cpuDeltaMs = (userDeltaUs + systemDeltaUs) / 1000;
+    if (wallDeltaMs > 0) {
+      // cpu% can exceed 100 on multi-core systems (e.g. parallel I/O).
+      // Round to 1 decimal for readability.
+      cpu_pct = Math.round((cpuDeltaMs / wallDeltaMs) * 100 * 10) / 10;
+    }
+  }
+  _lastCpu = { ts_ms: now, user_us: cpu.user, system_us: cpu.system };
+
+  const mem = process.memoryUsage();
+  const rss_bytes = mem.rss;
+  const rss_mb = Math.round((rss_bytes / (1024 * 1024)) * 10) / 10;
+
+  return {
+    rss_bytes,
+    rss_mb,
+    cpu_pct,
+    uptime_seconds: Math.round(process.uptime()),
+    in_flight_count: _inFlight,
+  };
+}
+
+// Test-only: reset sampler state (cpu delta history + in-flight counter).
+// Not part of public API but available for unit tests.
+export function _resetProcessTelemetry(): void {
+  _lastCpu = null;
+  _inFlight = 0;
+}

--- a/agent-network/src/telemetry-source-parity.test.ts
+++ b/agent-network/src/telemetry-source-parity.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1727 —— node-server(agent-network)和 agent-node 用**同一份**采集器源码,
+// 这样 hub 名册里 claude-code 族与 agent-node 族的六个字段口径一致。
+// agent-network 不能 import agent-node(grok-build-drift.test.ts 禁止),所以是复制 + 这道门:
+// 任一边改了而另一边没跟上,这里先红。
+const HERE = import.meta.dir;
+const AGENT_NODE = join(HERE, "..", "..", "agent-node", "src");
+
+describe("#1727 telemetry collectors are byte-identical across packages", () => {
+  for (const name of ["host-telemetry.ts", "process-telemetry.ts"]) {
+    test(name, () => {
+      const ours = readFileSync(join(HERE, name), "utf8");
+      const theirs = readFileSync(join(AGENT_NODE, name), "utf8");
+      expect(ours.length).toBeGreaterThan(500);
+      expect(ours).toBe(theirs);
+    });
+  }
+});


### PR DESCRIPTION
#1727:在线舰队 38/130(29%)的 `claude-code` 节点在 hub 名册上六个监控字段全空 —— 它们没有 agent-node 进程,采集器 `host-telemetry.ts` 根本不跑。Dashboard 对这批节点只能显示「在线」。

## 改法

- `node-server.ts` 是这条路径上唯一长期存活的自有进程(它已经在写活动日志):**开机注册 / SSE 重连再注册 / 3 分钟心跳**三处身份载荷都带上 `host: getHostTelemetry()` 与 `process_telemetry: getProcessTelemetry()`。hub 的 `report_status` schema 早就收这两块(agent-node 一直在发,字段全 `.nullable().optional()`)。
- 采集器是 agent-node 那两份源码的**逐字复制**(`agent-network/src/{host,process}-telemetry.ts`);agent-network 不能 import agent-node,所以加 `telemetry-source-parity.test.ts` 钉两边 byte-identical,任一边改了另一边没跟上就红。
- `node-server-identity-payload.test.ts`(反推门:凡 `agent: "claude-code"` 的载荷块都要有同一组字段)加两条要求。

## 证据

- 四个测试文件 35/35;变异去掉心跳那处的 `host:` → identity 门 1 fail,还原 → 绿;agent-network `tsc --noEmit` 0 错。
- 采集器在本机直接跑一次:`host {load:0.82, cores:8, mem_total:61.4, disk_avail:94}`,`proc {rss_mb:33.2}` —— 主机级字段从 node-server 进程里拿得到(issue 里「未验证」的那一格)。

## 边界

- `version` 那一格这个 PR 不填:node-server 是 anet 生成的 bundle,没有自己的版本号;要填得先决定它报什么(anet 版本?)以及 hub/Dashboard 怎么区分两族。单独开。
- `cpu_pct` 对 node-server 进程本身意义不大(它几乎不占 CPU),但字段口径与 agent-node 一致。
- 到真机要发 agent-network 新版 + 重启 claude-code 节点(node-server.js 启动时重生成)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD