### PR TITLE
chore(release): agent-network 2.3.0-preview.78 —— #1727 claude-code 裸节点的六个监控字段

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.77",
+  "version": "2.3.0-preview.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.77",
+      "version": "2.3.0-preview.78",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.77",
+  "version": "2.3.0-preview.78",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.77";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.78";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.62";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.77 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.78 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.77` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.78` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.77 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.78 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.77`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.78`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.78.md
+++ b/docs/tests/release-v2.3.0-preview.78.md
@@ -1,0 +1,33 @@
+# `@sleep2agi/agent-network@2.3.0-preview.78`
+
+## 为什么发这一版:**38 个 claude-code 裸节点在 Dashboard 上只剩「在线」两个字**(#1727)
+
+| 用户看到的 | `.77` | `.78` |
+|---|---|---|
+| Dashboard 节点卡片:`claude-code` 类型的 uptime / rss / cpu / load / disk | 全空(在线舰队 38/130,29%) | 有值 —— node-server 开机注册 / 重连 / 3 分钟心跳三处都带 `host` + `process_telemetry`,与 agent-node 同一份采集器 |
+| `version` 那一格 | 空 | 仍空(node-server 是 anet 生成的 bundle,没有自己的版本号;要填先定义报什么,单独开) |
+
+`.77` 之后 `agent-network/bin|src` 只有这一个提交(`3088eef6`,#1787)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.78
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.78
+# claude-code 节点的 .anet/node-server.js 是启动时由 anet 生成的,不重启不会换:
+anet node stop <name> && anet node start <name>
+```
+
+## 边界
+
+- 只对 `claude-code` 族(裸会话)有变化;agent-node 托管的节点本来就有这六个字段。
+- hub 的 `report_status` schema 早就收 `host` / `process_telemetry`(agent-node 一直在发),不需要升 hub。
+
+## promote 时的 must_contain
+
+`cpu_load_1min`(`.77` 产物 0 命中,已用闸 4 原样命令验)。


### PR DESCRIPTION
`.77` 之后包内容只有 #1787(node-server 三处身份载荷带 host / process_telemetry);38 个 claude-code 裸节点值得单独一版。

- 戳:package.json / lock ×2 / `PAIRED_AGENT_NETWORK_VERSION` / getting-started zh+en 的 preview 戳与表格行 .77→.78(latest 戳留 .76)
- `docs/tests/release-v2.3.0-preview.78.md` 含 Install/Upgrade;promote 判据 `cpu_load_1min`(.77 产物 0 命中)
- `check-doc-version-claims.py --package agent-network --version 2.3.0-preview.78 --verify-latest-from-npm` rc=0;symbol-pins 两种参数 rc=0;pair 测试 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD
