### PR TITLE
feat(codex-sdk): #1645 起线程前检查 codex models 缓存里的推理档位 —— 不认识的档位提前说,不再等 300s 超时

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -18,6 +18,7 @@ import {
   copresenceDowngradeNotice as grokCopresenceDowngradeNotice,
 } from "./runtime/grok-copresence/platform";
 import { activeNetworkTaskMarkerPathInCredentialDir } from "./runtime/grok-copresence/active-network-task-marker.js";
+import { describeUnknownReasoningEfforts } from "./runtime/codex-models-cache-check.js";
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
@@ -3032,6 +3033,9 @@ async function processWithCodex(
       sandboxMode: (typeof cfgFlags.sandboxMode === "string" ? cfgFlags.sandboxMode : "danger-full-access") as any,
       modelReasoningEffort: "low" as const,
     };
+    // #1645 —— 起线程前看一眼 codex 自己的 models 缓存:上游给了本机不认识的档位,
+    // resume 会以 unknown variant 致命退出、表现为 300s 超时。只警告,不拦。
+    for (const line of describeUnknownReasoningEfforts()) warn(line);
     if (SESSION_ID) {
       codexThread = codex.resumeThread(SESSION_ID, codexOpts);
       log(`codex resumed thread: ${SESSION_ID}`);

--- a/agent-node/src/runtime/codex-models-cache-check.test.ts
+++ b/agent-node/src/runtime/codex-models-cache-check.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  KNOWN_REASONING_EFFORTS,
+  codexModelsCachePath,
+  collectReasoningEffortsFromModelsCache,
+  describeUnknownReasoningEfforts,
+  findUnknownReasoningEfforts,
+} from "./codex-models-cache-check.js";
+
+// 2026-09-03 DEV 本机 ~/.codex/models_cache.json 的真实形状(只保留相关字段)。
+const REAL_SHAPE = {
+  fetched_at: "2026-09-03T00:00:00Z",
+  client_version: "0.149.1",
+  models: [
+    {
+      slug: "gpt-5.5",
+      description: "Frontier model with maximum effort available",
+      default_reasoning_level: "medium",
+      supported_reasoning_levels: [
+        { effort: "low", description: "Fast" },
+        { effort: "medium", description: "Balanced" },
+        { effort: "high", description: "Thorough" },
+        { effort: "xhigh", description: "Deeper" },
+        { effort: "max", description: "Maximum" },
+        { effort: "ultra", description: "Ultra" },
+      ],
+    },
+  ],
+};
+
+describe("#1645 codex models cache reasoning-effort gate", () => {
+  test("known set mirrors types/codex/ReasoningEffort.ts", () => {
+    expect([...KNOWN_REASONING_EFFORTS]).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+  test("collects efforts from the real cache shape without picking up prose", () => {
+    expect(collectReasoningEffortsFromModelsCache(REAL_SHAPE)).toEqual(["high", "low", "max", "medium", "ultra", "xhigh"]);
+  });
+  test("names exactly the variants the local codex does not know", () => {
+    const report = findUnknownReasoningEfforts(REAL_SHAPE);
+    expect(report.unknown).toEqual(["max", "ultra"]);
+    expect(report.clientVersion).toBe("0.149.1");
+  });
+  test("a cache with only known variants is silent", () => {
+    const ok = { models: [{ default_reasoning_level: "low", supported_reasoning_levels: [{ effort: "low" }, { effort: "high" }] }] };
+    expect(findUnknownReasoningEfforts(ok).unknown).toEqual([]);
+  });
+  test("string-array and bare-string shapes are also read", () => {
+    expect(collectReasoningEffortsFromModelsCache({ supported_reasoning_levels: ["low", "max"], default_reasoning_level: "ultra" }))
+      .toEqual(["low", "max", "ultra"]);
+  });
+  test("describe: missing / malformed file → no lines; real shape → two lines naming max and ultra", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-cache-"));
+    try {
+      expect(describeUnknownReasoningEfforts(join(dir, "missing.json"))).toEqual([]);
+      writeFileSync(join(dir, "bad.json"), "{not json");
+      expect(describeUnknownReasoningEfforts(join(dir, "bad.json"))).toEqual([]);
+      writeFileSync(join(dir, "real.json"), JSON.stringify(REAL_SHAPE));
+      const lines = describeUnknownReasoningEfforts(join(dir, "real.json"));
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain("max, ultra");
+      expect(lines[0]).toContain("0.149.1");
+      expect(lines[1]).toContain("#1645");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test("path honours CODEX_HOME", () => {
+    expect(codexModelsCachePath({ CODEX_HOME: "/x/codex" })).toBe(join("/x/codex", "models_cache.json"));
+    expect(codexModelsCachePath({})).toContain(join(".codex", "models_cache.json"));
+  });
+});

--- a/agent-node/src/runtime/codex-models-cache-check.ts
+++ b/agent-node/src/runtime/codex-models-cache-check.ts
@@ -1,0 +1,78 @@
+// #1645 —— codex-sdk 节点 resume 长线程时一天 17 次「300s 超时」,日志里的真因之一是
+// `unknown variant \`max\`, expected one of none/minimal/low/medium/high/xhigh`:
+// 上游 models 响应带了本机 codex 不认识的推理档位,codex 的 models cache 解不动,
+// rmcp worker 致命退出,一整轮走不下去。这里在起线程之前读同一份缓存文件,
+// 把「本机 codex 认不认得上游给的档位」变成一条启动时就能看见的警告。
+// 只读、只警告、不阻断:缓存不存在 / 不是 JSON / 形状不认识 都当「没证据」。
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ReasoningEffort } from "../types/codex/ReasoningEffort.js";
+
+/** 与 types/codex/ReasoningEffort.ts 的联合类型逐项对应(测试钉住)。 */
+export const KNOWN_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ReasoningEffort[];
+
+export function codexModelsCachePath(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CODEX_HOME && env.CODEX_HOME.trim() ? env.CODEX_HOME.trim() : join(homedir(), ".codex");
+  return join(home, "models_cache.json");
+}
+
+const EFFORT_KEY = /effort|reasoning_level/i;
+
+/** 收集缓存里所有「推理档位」字符串:键名含 effort / reasoning_level 的字符串、字符串数组、或对象里的 effort 字段。 */
+export function collectReasoningEffortsFromModelsCache(cache: unknown): string[] {
+  const found = new Set<string>();
+  const visit = (value: unknown, keyHint: string): void => {
+    if (typeof value === "string") {
+      if (EFFORT_KEY.test(keyHint)) found.add(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, keyHint);
+      return;
+    }
+    if (value && typeof value === "object") {
+      for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+        // `{ effort: "max", ... }` 这种对象:effort 字段是档位;其它字段继续往下走,
+        // 但不把父级键名当作 effort 提示传下去(避免把 description 之类的字符串当成档位)。
+        visit(inner, key);
+      }
+    }
+  };
+  visit(cache, "");
+  return [...found].sort();
+}
+
+export interface UnknownReasoningEffortReport {
+  unknown: string[];
+  clientVersion: string | null;
+}
+
+export function findUnknownReasoningEfforts(
+  cache: unknown,
+  known: readonly string[] = KNOWN_REASONING_EFFORTS,
+): UnknownReasoningEffortReport {
+  const efforts = collectReasoningEffortsFromModelsCache(cache);
+  const unknown = efforts.filter((effort) => !known.includes(effort));
+  const clientVersion = cache && typeof cache === "object" && typeof (cache as { client_version?: unknown }).client_version === "string"
+    ? (cache as { client_version: string }).client_version
+    : null;
+  return { unknown, clientVersion };
+}
+
+/** 读文件 + 判断;任何读/解析失败都返回 null(没证据 ≠ 没问题,但也不能把节点吓停)。 */
+export function describeUnknownReasoningEfforts(path: string = codexModelsCachePath()): string[] {
+  let cache: unknown;
+  try {
+    cache = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return [];
+  }
+  const report = findUnknownReasoningEfforts(cache);
+  if (report.unknown.length === 0) return [];
+  return [
+    `[codex] 上游 models 缓存里有本机 codex 不认识的推理档位: ${report.unknown.join(", ")}`
+      + `(本机只认 ${KNOWN_REASONING_EFFORTS.join("/")}${report.clientVersion ? `;缓存由 codex ${report.clientVersion} 写下` : ""})。`,
+    `[codex] resume 线程时 codex 会以 \`unknown variant\` 致命退出,表现为 300s 超时(#1645)。升级 codex-cli 后重启节点;缓存文件: ${path}`,
+  ];
+}


### PR DESCRIPTION
#1645 第 2 项。上游 models 响应带了本机 codex 不认识的推理档位,codex 解 `models_cache.json` 失败 → rmcp worker 致命退出 → resume 线程表现为「300s 超时」,一天 17 次;文案那一半 #1646 已修,这里把**原因提前到起线程之前**。

## 改法

- `runtime/codex-models-cache-check.ts`:读 `$CODEX_HOME/models_cache.json`(默认 `~/.codex`),收集所有键名含 `effort` / `reasoning_level` 的字符串(真实形状是 `supported_reasoning_levels: [{effort, description}]` + `default_reasoning_level`),与 `types/codex/ReasoningEffort.ts` 的六个值比对,不在集合里的与缓存的 `client_version` 一起 warn 两行(含 #1645 与缓存路径)。**只警告不拦**;文件不存在 / 不是 JSON / 形状不认识都沉默。
- `cli.ts` codex-sdk 路径:`resumeThread` / `startThread` 之前调一次。
- `KNOWN_REASONING_EFFORTS … satisfies readonly ReasoningEffort[]`:类型集合改了这里编译先红。

## 证据

- 测试 7 条(真实缓存形状;只认识的档位沉默;数组/裸字符串形状;文件缺失/坏 JSON 沉默;CODEX_HOME)。
- **DEV 本机真实缓存实跑**:`上游 models 缓存里有本机 codex 不认识的推理档位: max, ultra(本机只认 none/minimal/low/medium/high/xhigh;缓存由 codex 0.148.0 写下)` —— 正是 issue 里那个 `unknown variant \`max\``。
- typecheck 棘轮 81/81;doc-symbol-pins 两种参数 rc=0。

## 没做的

第 3 项(resume 前知道线程有多大)另开;这条不阻断 resume,只是让人在超时前 5 分钟就看到该升 codex-cli。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD