### PR TITLE
feat(codex-sdk): #1645 resume 前读 rollout 里最后一条 token_count —— 线程太大先说,不等 300s 超时

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./runtime/grok-copresence/platform";
 import { activeNetworkTaskMarkerPathInCredentialDir } from "./runtime/grok-copresence/active-network-task-marker.js";
 import { describeUnknownReasoningEfforts } from "./runtime/codex-models-cache-check.js";
+import { describeLargeCodexThreadBeforeResume } from "./runtime/codex-thread-size-check.js";
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { codexTuiAlignmentNotice } from "./codex-tui-alignment";
@@ -3037,6 +3038,9 @@ async function processWithCodex(
     // resume 会以 unknown variant 致命退出、表现为 300s 超时。只警告,不拦。
     for (const line of describeUnknownReasoningEfforts()) warn(line);
     if (SESSION_ID) {
+      // #1645 —— 线程有多大在 resume 前就写在 codex 的 rollout 文件里;太大的线程 resume 时
+      // 上游 compaction 常失败、表现为 300s 超时。这里先说一句,不拦。
+      for (const line of describeLargeCodexThreadBeforeResume(SESSION_ID)) warn(line);
       codexThread = codex.resumeThread(SESSION_ID, codexOpts);
       log(`codex resumed thread: ${SESSION_ID}`);
     } else {

--- a/agent-node/src/runtime/codex-thread-size-check.test.ts
+++ b/agent-node/src/runtime/codex-thread-size-check.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_LARGE_THREAD_TOKENS,
+  describeLargeCodexThread,
+  describeLargeCodexThreadBeforeResume,
+  findCodexRolloutFile,
+  readCodexThreadSize,
+} from "./codex-thread-size-check.js";
+
+const THREAD = "019fb0dd-c6eb-7393-a06b-7cc56285ce64";
+function tokenCount(total: number, window = 258_400): string {
+  return JSON.stringify({ timestamp: "t", type: "event_msg", payload: { type: "token_count", info: { total_token_usage: { total_tokens: 1 }, last_token_usage: { total_tokens: total }, model_context_window: window } } });
+}
+function makeSessions(root: string, total: number): string {
+  const dir = join(root, "sessions", "2026", "07", "30");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `rollout-2026-07-30T10-32-32-${THREAD}.jsonl`);
+  writeFileSync(file, [
+    JSON.stringify({ type: "session_meta", payload: { id: THREAD } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message" } }),
+    tokenCount(1000),
+    JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "token_count in prose must not confuse the parser" } }),
+    tokenCount(total),
+    JSON.stringify({ type: "response_item", payload: { type: "function_call_output" } }),
+  ].join("\n") + "\n");
+  return file;
+}
+
+describe("#1645 codex thread size before resume", () => {
+  test("finds the rollout file by thread id under year/month/day and reads the LAST token_count", () => {
+    const root = mkdtempSync(join(tmpdir(), "codex-home-"));
+    try {
+      const file = makeSessions(root, 195_436);
+      expect(findCodexRolloutFile(join(root, "sessions"), THREAD)).toBe(file);
+      expect(findCodexRolloutFile(join(root, "sessions"), "nope")).toBeNull();
+      expect(findCodexRolloutFile(join(root, "sessions"), "../x")).toBeNull();
+      const size = readCodexThreadSize(file)!;
+      expect(size.lastTurnTokens).toBe(195_436);
+      expect(size.contextWindow).toBe(258_400);
+      expect(size.fileBytes).toBeGreaterThan(100);
+      const lines = describeLargeCodexThreadBeforeResume(THREAD, { CODEX_HOME: root });
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain("195436");
+      expect(lines[1]).toContain("#1645");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+  test("a small thread is silent; threshold is min(150k, 60% of window)", () => {
+    expect(describeLargeCodexThread(THREAD, { lastTurnTokens: 40_235, contextWindow: 258_400, fileBytes: 1 }, "/p")).toEqual([]);
+    expect(describeLargeCodexThread(THREAD, { lastTurnTokens: CODEX_LARGE_THREAD_TOKENS, contextWindow: null, fileBytes: 1 }, "/p")).toHaveLength(2);
+    // 窗口只有 200k → 60% = 120k,低于 150k 的默认阈值时以窗口为准
+    expect(describeLargeCodexThread(THREAD, { lastTurnTokens: 125_000, contextWindow: 200_000, fileBytes: 1 }, "/p")).toHaveLength(2);
+    expect(describeLargeCodexThread(THREAD, { lastTurnTokens: 125_000, contextWindow: 258_400, fileBytes: 1 }, "/p")).toEqual([]);
+  });
+  test("missing home / missing file / no token_count → silent", () => {
+    const root = mkdtempSync(join(tmpdir(), "codex-home-"));
+    try {
+      expect(describeLargeCodexThreadBeforeResume(THREAD, { CODEX_HOME: join(root, "absent") })).toEqual([]);
+      const dir = join(root, "sessions", "2026", "01", "01"); mkdirSync(dir, { recursive: true });
+      const file = join(dir, `rollout-x-${THREAD}.jsonl`); writeFileSync(file, JSON.stringify({ type: "session_meta" }) + "\n");
+      expect(readCodexThreadSize(file)!.lastTurnTokens).toBeNull();
+      expect(describeLargeCodexThreadBeforeResume(THREAD, { CODEX_HOME: root })).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent-node/src/runtime/codex-thread-size-check.ts
+++ b/agent-node/src/runtime/codex-thread-size-check.ts
@@ -1,0 +1,111 @@
+// #1645 第 3 项 —— codex-sdk resume 一条已经很大的线程(实例:last_api_response_total_tokens=195436)
+// 时,上游 pre-sampling compaction 会失败,turn 走不下去,最后以 300s 超时收场。
+// 线程有多大在 resume 之前就写在 codex 自己的 rollout 文件里:
+//   ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<thread-id>.jsonl
+//   最后一条 {"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":N},"model_context_window":W}}}
+// 这里只读那一条,超过阈值就在 resume 前警告;只警告、不拦、任何读不到都沉默。
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function codexSessionsRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CODEX_HOME && env.CODEX_HOME.trim() ? env.CODEX_HOME.trim() : join(homedir(), ".codex");
+  return join(home, "sessions");
+}
+
+/** 在 sessions/ 下找 `rollout-*-<threadId>.jsonl`(按 年/月/日 三层目录走,不递归到别处)。 */
+export function findCodexRolloutFile(sessionsRoot: string, threadId: string): string | null {
+  if (!threadId || /[\\/\0]/.test(threadId)) return null;
+  const suffix = `-${threadId}.jsonl`;
+  let dirs: string[];
+  try {
+    dirs = [sessionsRoot];
+    for (let depth = 0; depth < 3; depth++) {
+      const next: string[] = [];
+      for (const dir of dirs) {
+        let entries: string[] = [];
+        try { entries = readdirSync(dir); } catch { continue; }
+        for (const entry of entries) {
+          const full = join(dir, entry);
+          try {
+            if (statSync(full).isDirectory()) next.push(full);
+          } catch { /* ignore */ }
+        }
+      }
+      dirs = next;
+    }
+  } catch {
+    return null;
+  }
+  for (const dir of dirs) {
+    let entries: string[] = [];
+    try { entries = readdirSync(dir); } catch { continue; }
+    const hit = entries.find((name) => name.startsWith("rollout-") && name.endsWith(suffix));
+    if (hit) return join(dir, hit);
+  }
+  return null;
+}
+
+export interface CodexThreadSize {
+  lastTurnTokens: number | null;
+  contextWindow: number | null;
+  fileBytes: number;
+}
+
+/** 读最后一条 token_count;文件太大时只读尾部 256 KB(那条记录总在最后几行)。 */
+export function readCodexThreadSize(path: string): CodexThreadSize | null {
+  let bytes: number;
+  let text: string;
+  try {
+    bytes = statSync(path).size;
+    const buf = readFileSync(path);
+    const tail = buf.length > 256 * 1024 ? buf.subarray(buf.length - 256 * 1024) : buf;
+    text = tail.toString("utf8");
+  } catch {
+    return null;
+  }
+  let lastTurnTokens: number | null = null;
+  let contextWindow: number | null = null;
+  for (const line of text.split("\n").reverse()) {
+    if (!line.includes('"token_count"')) continue;
+    try {
+      const rec = JSON.parse(line) as { payload?: { type?: string; info?: { last_token_usage?: { total_tokens?: unknown }; model_context_window?: unknown } } };
+      if (rec.payload?.type !== "token_count") continue;
+      const t = rec.payload.info?.last_token_usage?.total_tokens;
+      const w = rec.payload.info?.model_context_window;
+      lastTurnTokens = typeof t === "number" && Number.isFinite(t) ? t : null;
+      contextWindow = typeof w === "number" && Number.isFinite(w) ? w : null;
+      break;
+    } catch {
+      continue;
+    }
+  }
+  return { lastTurnTokens, contextWindow, fileBytes: bytes };
+}
+
+/** issue 里失败的那一轮是 195436 tokens;阈值取 150k,或上下文窗口的 60%(取小)。 */
+export const CODEX_LARGE_THREAD_TOKENS = 150_000;
+
+export function describeLargeCodexThread(
+  threadId: string,
+  size: CodexThreadSize | null,
+  path: string | null,
+  thresholdTokens: number = CODEX_LARGE_THREAD_TOKENS,
+): string[] {
+  if (!size || size.lastTurnTokens === null) return [];
+  const windowLimit = size.contextWindow ? Math.floor(size.contextWindow * 0.6) : Number.POSITIVE_INFINITY;
+  const limit = Math.min(thresholdTokens, windowLimit);
+  if (size.lastTurnTokens < limit) return [];
+  const windowText = size.contextWindow ? `,模型上下文窗口 ${size.contextWindow}` : "";
+  return [
+    `[codex] 即将 resume 的线程 ${threadId} 上一轮已用 ${size.lastTurnTokens} tokens${windowText}(rollout ${Math.round(size.fileBytes / 1024)} KB)。`,
+    `[codex] 这么大的线程 resume 时上游 pre-sampling compaction 常失败,表现为 300s 超时(#1645)。宁可 --new-session 起新线程;文件: ${path ?? "?"}`,
+  ];
+}
+
+/** 一步到位:定位文件 → 读大小 → 生成警告。任何一步拿不到都返回 []。 */
+export function describeLargeCodexThreadBeforeResume(threadId: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  const path = findCodexRolloutFile(codexSessionsRoot(env), threadId);
+  if (!path) return [];
+  return describeLargeCodexThread(threadId, readCodexThreadSize(path), path);
+}


### PR DESCRIPTION
#1645 第 3 项(最后一项)。上游 pre-sampling compaction 在 195k tokens 的线程上失败,turn 走不下去,最后是「300s 超时」。线程有多大 **resume 之前就写在 codex 自己的 rollout 文件里**:

```
~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<thread-id>.jsonl
{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":195436},"model_context_window":258400}}}
```

## 改法

- `runtime/codex-thread-size-check.ts`:按 `$CODEX_HOME/sessions/年/月/日` 三层找 `rollout-*-<thread>.jsonl`,只读尾部 256 KB 取**最后一条** `token_count` 的 `last_token_usage.total_tokens` 与 `model_context_window`;≥ min(150k, 窗口 60%) 就 warn 两行(数字、窗口、文件大小、`--new-session` 建议、文件路径)。只警告不拦;文件/记录缺失一律沉默。
- `cli.ts`:`codex.resumeThread(SESSION_ID)` 之前调一次(startThread 路径不调)。

## 证据

- 测试 3 条:真实文件布局 + prose 里出现 `token_count` 字样不干扰 + 取最后一条(1000 → 195436);阈值三种边界;缺 home / 缺文件 / 无记录沉默。
- 本机 1.6 MB 的真实 rollout(上一轮 40k tokens)实跑:沉默(应当沉默)。
- typecheck 棘轮 81/81;已 rebase 到含 #1789 的 main(只有 import 行冲突,两条都保留)。

合并后 #1645 三项全在 main,可关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD