### PR TITLE
chore(release): agent-network 2.3.0-preview.79 —— 配对钉跟上 agent-node .63(published-pins 门)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.78",
+  "version": "2.3.0-preview.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.78",
+      "version": "2.3.0-preview.79",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.78",
+  "version": "2.3.0-preview.79",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.78";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.79";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.63";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.78 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.79 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.78` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.79` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.78 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.79 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.78`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.79`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.79.md
+++ b/docs/tests/release-v2.3.0-preview.79.md
@@ -1,0 +1,27 @@
+# `@sleep2agi/agent-network@2.3.0-preview.79`
+
+## 为什么发这一版:**配对钉跟上 agent-node `.63`**(published-artifact-drift 的 `published-pins` 要求)
+
+`.78` 之后 `agent-network/bin|src` 没有功能改动;只有 `PAIRED_AGENT_NODE_VERSION` 从 `.62` 走到 `.63`(agent-node 今天发了 `.63`,#1645 两道门)。`scripts/verify-published-pins.sh preview` 每天拿 main 的配对钉比已发布的 preview 包,agent-node 发了而 anet 没跟着发就会红 —— 这一版就是让它对上。
+
+| 用户看到的 | `.78` | `.79` |
+|---|---|---|
+| `anet` 与 `agent-node` 的配对钉 | `.62` | `.63` |
+| 其它 | — | 无变化 |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.79
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.79 @sleep2agi/agent-node@2.5.0-preview.63
+anet daemon restart <daemon>
+```
+
+## promote 时的 must_contain
+
+`2.5.0-preview.63`(`.78` 产物 0 命中——它钉的是 .62)。


### PR DESCRIPTION
`published-artifact-drift` 的 `published-pins` 连红 3 天,今天的原因是 main 的 `PAIRED_AGENT_NODE_VERSION` 已走到 .63 而 npm preview 的 anet(.78)里还是 .62 —— agent-node 发了、anet 没跟着发,这道门(#1430 有意为之)就红。这一版只为把配对钉发出去,没有功能改动。

- 戳:package.json / lock ×2 / `PAIRED_AGENT_NETWORK_VERSION` / getting-started zh+en preview 戳与表格行 .78→.79
- 说明含 Install/Upgrade;promote 判据 `2.5.0-preview.63`(.78 产物 0 命中)
- version-claims rc=0;symbol-pins 两种参数 rc=0;pair 测试 6/6;本地 `verify-published-pins.sh preview` 对 .78 红(预期),发 .79 后应绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD