### PR TITLE
fix(hub): #1548 blocked 有出口 —— 终态 send_reply / send_task 把还标着 blocked 的发送方拉回 idle

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2063 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2063) + [tools.ts:2077 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2077) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2063 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2082) + [tools.ts:2077 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2096) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:193（列定义数组）+ db.ts:206（`ALTER TABLE inbox ADD COLUMN`）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L193)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/blocked-exit-on-reply.test.ts
+++ b/server/src/blocked-exit-on-reply.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { db } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+// #1548 —— 一个活着、能收发任务的节点可以在名册里永远显示 `blocked`:
+// 只有 report_completion 会把 sessions.status 拉回 idle,而现在大多数 agent 用
+// send_reply(终态)结束任务、用 send_task 派活 —— 这两条路径此前都不碰 sessions.status。
+// 「它刚回了我一条终态消息 / 刚派了一条任务」本身就是最强的活性证据。
+// 只出 `blocked`;`working` 可能真在忙别的任务,不碰(保守)。
+const NET_ID = "net_1548_blocked";
+const USER_ID = "u_1548";
+const NODE_ID = "node_1548_agent";
+const AGENT_ALIAS = "agent-1548";
+const DISPATCHER_NODE_ID = "node_1548_dispatcher";
+const DISPATCHER_ALIAS = "dispatcher-1548";
+const AGENT_TOK_ID = "tok_1548";
+
+type ToolHandler = (args: any, extra?: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  for (const [sql, params] of [
+    ["DELETE FROM tasks WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM inbox WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM task_events WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM sessions WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM nodes WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM api_tokens WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM network_members WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM networks WHERE network_id = ?1", [NET_ID]],
+    ["DELETE FROM users WHERE user_id = ?1", [USER_ID]],
+  ] as const) {
+    try { db.run(sql, params as any); } catch {}
+  }
+}
+beforeEach(cleanup);
+afterAll(cleanup);
+
+function seed(agentStatus: string) {
+  db.run(`INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?2, 'x', 'user', datetime('now'))`, [USER_ID, USER_ID]);
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?2, ?3, datetime('now'))`, [NET_ID, NET_ID, USER_ID]);
+  db.run(
+    `INSERT INTO network_members (user_id, network_id, role, joined_at)
+     VALUES (?1, ?2, 'owner', datetime('now'))`,
+    [USER_ID, NET_ID],
+  );
+  for (const [nodeId, alias] of [[DISPATCHER_NODE_ID, DISPATCHER_ALIAS], [NODE_ID, AGENT_ALIAS]] as const) {
+    db.run(
+      `INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+       VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'), 'active')`,
+      [nodeId, alias, alias, NET_ID, `host-${alias}`],
+    );
+  }
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+    [`res_${DISPATCHER_ALIAS}`, DISPATCHER_ALIAS, DISPATCHER_NODE_ID, NET_ID],
+  );
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'))`,
+    [`res_${AGENT_ALIAS}`, AGENT_ALIAS, agentStatus, NODE_ID, NET_ID],
+  );
+  db.run(
+    `INSERT INTO api_tokens (token_id, user_id, network_id, scope, name, token_hash, expires_at, revoked_at)
+     VALUES (?1, ?2, ?3, 'network', ?4, ?5, NULL, NULL)`,
+    [AGENT_TOK_ID, USER_ID, NET_ID, `node:${AGENT_ALIAS}`, `hash_${AGENT_TOK_ID}`],
+  );
+}
+function makeTask(): string {
+  const id = "t_" + Math.random().toString(36).slice(2, 14);
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, to_name, to_node_id, priority, status, content, requires_response, created_at, network_id)
+     VALUES (?1, ?2, ?3, ?4, 'normal', 'delivered', 'test', 'reply', datetime('now'), ?5)`,
+    [id, DISPATCHER_ALIAS, AGENT_ALIAS, NODE_ID, NET_ID],
+  );
+  return id;
+}
+function buildHandlers(): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, _schema: any, handler: ToolHandler) => { tools[name] = handler; return origTool(name, _desc, _schema, handler); };
+  const origRegisterTool = server.registerTool?.bind(server);
+  if (origRegisterTool) {
+    server.registerTool = (name: string, _cfg: any, handler: ToolHandler) => { tools[name] = handler; return origRegisterTool(name, _cfg, handler); };
+  }
+  registerTools(server, undefined, NET_ID, USER_ID, AGENT_ALIAS, true, AGENT_TOK_ID);
+  return tools;
+}
+async function call(handler: ToolHandler, args: any): Promise<any> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0]!.text);
+}
+function agentStatus(): string {
+  return (db.get("SELECT status FROM sessions WHERE alias = ?1 AND network_id = ?2", [AGENT_ALIAS, NET_ID]) as { status: string }).status;
+}
+
+describe("#1548 blocked has an exit: a terminal reply or an outbound task proves the agent is alive", () => {
+  test("terminal send_reply from a blocked agent puts it back to idle", async () => {
+    seed("blocked");
+    const tools = buildHandlers();
+    const taskId = makeTask();
+    const r = await call(tools.send_reply!, { text: "done", in_reply_to: taskId, status: "replied", from_session: AGENT_ALIAS, network_id: NET_ID });
+    expect(r.ok, JSON.stringify(r)).toBe(true);
+    expect(agentStatus()).toBe("idle");
+  });
+  test("send_task from a blocked agent puts it back to idle", async () => {
+    seed("blocked");
+    const tools = buildHandlers();
+    const r = await call(tools.send_task!, { alias: DISPATCHER_ALIAS, task: "ping", priority: "normal", from_session: AGENT_ALIAS, network_id: NET_ID });
+    expect(r.ok, JSON.stringify(r)).toBe(true);
+    expect(agentStatus()).toBe("idle");
+  });
+  test("a working agent is left alone (it may be busy with another task)", async () => {
+    seed("working");
+    const tools = buildHandlers();
+    const taskId = makeTask();
+    await call(tools.send_reply!, { text: "done", in_reply_to: taskId, status: "replied", from_session: AGENT_ALIAS, network_id: NET_ID });
+    expect(agentStatus()).toBe("working");
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -362,6 +362,19 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     return sql;
   };
 
+  /** #1548 —— 把一个还标着 blocked 的会话拉回 idle。只在「它刚发出终态回复 / 刚派了任务」这两个活性证据处调用。 */
+  const releaseBlockedSession = (alias: string | null | undefined, networkId: string | null | undefined): void => {
+    if (!alias) return;
+    const params: any[] = [alias];
+    let sql = "UPDATE sessions SET status = 'idle', updated_at = datetime('now') WHERE alias = ?1 AND status = 'blocked'";
+    sql = addScope(sql, params, networkId ?? null);
+    try {
+      db.run(sql, params);
+    } catch {
+      // 展示层的一次修正失败不能影响主路径。
+    }
+  };
+
   type ReadScope = { networkId?: string | null; networkIds?: string[] | null; denied?: string };
 
   // Delegates to the shared membership query (network-scope.ts) — was a
@@ -1598,6 +1611,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         let touchSql = "UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE alias = ?2";
         touchSql = addScope(touchSql, touchParams, effectiveNetId);
         db.run(touchSql, touchParams);
+        // #1548 —— 能派活的发送方不可能真的 blocked;此处出 blocked → idle。
+        releaseBlockedSession(from_session, effectiveNetId);
       });
       logTaskEvent(id, null, "delivered", from_session, parentTaskId ? `→ ${targetAlias} (parent=${parentTaskId.slice(0,8)})` : `→ ${targetAlias}`);
       // Only stamp the dedup index after the inbox/tasks transaction
@@ -1938,6 +1953,9 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             throw new Error(`reply_atomic_cas_failed:${in_reply_to}`);
           }
           syncScheduledRunForTask(in_reply_to, effectiveNetId);
+          // #1548 —— 终态回复是最强的活性证据:一个还标着 blocked 的发送方在此回到 idle。
+          //   只出 blocked;working 可能真在忙别的任务,不碰。
+          releaseBlockedSession(from_session, effectiveNetId);
           return { ok: true as const, replyLogged: true };
         }
         return { ok: true as const, replyLogged: false };


### PR DESCRIPTION
#1548 建议 1(最小)。一个活着、能收发任务的节点可以在名册里永远显示 `blocked`:只有 `report_completion` 会把 `sessions.status` 拉回 idle,而现在大多数 agent 用**终态 `send_reply`** 结束任务、用 **`send_task`** 派活 —— 这两条路径此前都不碰 status。「它刚发出终态回复 / 刚派了任务」本身就是最强的活性证据。

## 改法(hub,`server/src/tools.ts`)

- `registerTools` 作用域里加 `releaseBlockedSession(alias, networkId)`:`UPDATE sessions SET status='idle' WHERE alias=? AND status='blocked'`(按网络 addScope);失败静默。
- `handleReply` 终态化成功之后、`send_task` 事务里写完 tasks/inbox 之后各调一次。
- **只出 `blocked`**:`working` 可能真在忙别的任务,不碰(与 issue 的保守建议一致);建议 2(blocked 最长停留后降 `unknown`)与 3(展示层带「距上次更新多久」)不在本 PR。

## 证据

- `server/src/blocked-exit-on-reply.test.ts`(InMemory McpServer + registerTools 直调,与 `send-reply-agent-warning.test.ts` 同一 harness):blocked → 终态 reply → idle;blocked → send_task → idle;working 保持 working。
- 变异去掉两处调用 → 2 fail;还原 → 3 pass。
- `bun run test`(CI 同法 test-aggregate):101 个文件 1246 pass,此前唯一红的就是本文件(修 seed 前)。

## 到真机

要发 commhub-server 新 preview(.47)并升生产 hub;.45/.46 都没有这一条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD