### PR TITLE
chore(release): commhub-server 0.9.0-preview.47 —— #1548 blocked 有出口

### DIFF
--- a/docs/tests/release-v0.9.0-preview.47.md
+++ b/docs/tests/release-v0.9.0-preview.47.md
@@ -1,0 +1,36 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.47`
+
+## 为什么发这一版:**名册里的 `blocked` 有出口了**(#1548)
+
+`.46` 之后 `server/` 只有一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `72b2ad74` | #1793 | 终态 `send_reply` / `send_task` 成功后,把还标着 `blocked` 的发送方拉回 `idle`(只碰 blocked;`working` 可能真在忙,不动) |
+
+| 用户看到的 | `.46` | `.47` |
+|---|---|---|
+| Dashboard 上一个活着、能收发任务的节点 | 可能永远显示 `blocked`(只有 `report_completion` 会拉回 idle,而多数 agent 用终态 `send_reply` 结束任务) | 它一回终态消息 / 一派任务就回到 `idle` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.47
+```
+
+## Upgrade
+
+生产 hub 按 `deploy/hub/README.md` 六步(sibling 安装 `~/.commhub/runtime-v4N-preview47`、VACUUM INTO 备份、bypass 9291 预启、只改启动器 RUNTIME_DIR 一行、`pm2 restart commhub-hub`、五点验证);自带 hub 的桌面端要等 sidecar 钉到 `.47`。
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.47   # 自托管
+```
+
+## 证据
+
+- `server/src/blocked-exit-on-reply.test.ts` 3 条(blocked → 终态 reply → idle;blocked → send_task → idle;working 不动);变异去掉两处调用 → 2 fail。
+- `bun run test`(test-aggregate,CI 同法):101 文件 1246 pass。
+
+## promote 时的 must_contain
+
+`releaseBlockedSession`(`.46` 产物 0 命中,已用闸 4 原样命令验;commhub-server 发的是 TS 源码,函数名保留)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.46",
+  "version": "0.9.0-preview.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.46",
+      "version": "0.9.0-preview.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.46",
+  "version": "0.9.0-preview.47",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
`.46` 之后 `server/` 只有 #1793(#1548:终态 send_reply / send_task 把 blocked 发送方拉回 idle)。

- server/package.json + lock ×2 .46 → .47;`docs/tests/release-v0.9.0-preview.47.md` 含 Install/Upgrade;promote 判据 `releaseBlockedSession`(.46 产物 0 命中)
- `check-doc-version-claims.py --package commhub-server --version 0.9.0-preview.47 --verify-latest-from-npm` rc=0
- `PINNED_SERVER_VERSION` 留 .46:闸 2 只认已在 npm 的版本;发布后再开一 PR 改 PIN + `deploy/hub/hub-daemon.sh` RUNTIME_DIR 记录(check-hub-launcher-pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD