### PR TITLE
chore(anet): PINNED_SERVER_VERSION .46 → .47 + 启动器 RUNTIME_DIR 记录

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1813,7 +1813,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.46";
+const PINNED_SERVER_VERSION = "0.9.0-preview.47";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/src/hub-version-skew.test.ts
+++ b/agent-network/src/hub-version-skew.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { formatHubVersionDetail } from "./hub-version-skew";
 
 const HUB = "http://127.0.0.1:9200";
-const PIN = "0.9.0-preview.46";
+const PIN = "0.9.0-preview.47";
 
 describe("formatHubVersionDetail (#1595)", () => {
   test("一致时不多说一句", () => {

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -92,9 +92,10 @@ set -uo pipefail
 #          无迁移) + 门铃 rules_file；另 #1687/#1651 UTC 时间解析、#1632 daemon 报错文案
 #   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准)
 # 2026-09-03: preview45 → preview46（跟随 PINNED_SERVER_VERSION；#1756 tools/list 抛 schema._zod 的修复 #1763）
+# 2026-09-03: preview46 → preview47（跟随 PINNED_SERVER_VERSION；#1548 名册 blocked 有出口的修复 #1793）
 #   内容 = 四处单参 z.record 改双参;无新表无迁移
 #   回滚目标 = 生产机器上当前值(以该机器为准,不以本文件为准);生产 hub 现跑 bun 1.4.0(hub.env BUN_BIN,#1769)
-RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview46"
+RUNTIME_DIR="$HOME/.commhub/runtime-v35-preview47"
 ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
 ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
 # bun 解析：显式路径优先，其次走 PATH。

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.46' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.47' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
commhub-server `0.9.0-preview.47` 已在 npm preview(#1794,含 #1548 blocked 出口)。

- `agent-network/bin/cli.ts` PINNED_SERVER_VERSION .46 → .47;`hub-version-skew.test.ts` PIN;`tests/test766-bunx-preflight/run.sh` 字面量
- `deploy/hub/hub-daemon.sh` RUNTIME_DIR → 下一个 sibling 目录 + 变更历史一行(check-hub-launcher-pin 要求 PIN 与启动器记录一起动)
- 本地:check-hub-launcher-pin、hub-version-skew 测试见提交后 CI

生产 hub 仍在 .45;升到 .47 走 deploy/hub/README.md 六步,待 Vincent 点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD