### PR TITLE
fix(node-server): #171 claude-code 族把配置里的 model 报给 hub —— 三处身份载荷带 model

### DIFF
--- a/agent-network/src/node-server-identity-payload.test.ts
+++ b/agent-network/src/node-server-identity-payload.test.ts
@@ -57,6 +57,8 @@ describe("node-server 的身份载荷(三处)", () => {
     // 三处身份载荷少任何一处,那条路径上的节点在 Dashboard 就只剩「在线」。
     for (const b of blocks) expect(b).toContain("host: getHostTelemetry()");
     for (const b of blocks) expect(b).toContain("process_telemetry: getProcessTelemetry()");
+    // #171 —— 配置里的 model 报给 hub(claude-code 族此前 0/38 有 model)。
+    for (const b of blocks) expect(b).toContain("model: NODE_MODEL");
   });
 
   it("🔴 三处都带 config_path —— 加第四处注册点时漏了会红", () => {

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -211,6 +211,18 @@ function nodeConfigPath(): string | undefined {
   }
 }
 const CONFIG_PATH = nodeConfigPath();
+// #171 —— claude-code 族在名册里 model 全空(在线 38/38):节点配置里 `anet node create --model X`
+// 写下的 `model` 从没被报给 hub。读一次配置,有就报;没有就照旧为空(不编一个默认值)。
+function nodeModelFromConfig(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  try {
+    const cfg = JSON.parse(readFileSync(path, "utf-8")) as { model?: unknown };
+    return typeof cfg.model === "string" && cfg.model.trim() ? cfg.model.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+const NODE_MODEL = nodeModelFromConfig(CONFIG_PATH);
 function log(msg: string) {
   const ts = new Date().toTimeString().slice(0, 8);
   const line = `[${ts}] [commhub] ${msg}`;
@@ -564,6 +576,7 @@ async function reregister(): Promise<void> {
       agent: "claude-code",
       project_dir: process.cwd(),
       config_path: CONFIG_PATH,
+      model: NODE_MODEL,
       // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
       // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
       host: getHostTelemetry(),
@@ -750,6 +763,7 @@ async function main() {
     agent: "claude-code",
     project_dir: process.cwd(),
     config_path: CONFIG_PATH,
+    model: NODE_MODEL,
     // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
     // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
     host: getHostTelemetry(),
@@ -770,6 +784,7 @@ async function main() {
       agent: "claude-code",
       project_dir: process.cwd(),
       config_path: CONFIG_PATH,
+      model: NODE_MODEL,
       // #1727 —— claude-code 裸节点没有 agent-node 进程,六个监控字段没人产;
       // node-server 是这条路径上唯一长期存活的自有进程,顺带采一次(与 agent-node 同一采集器)。
       host: getHostTelemetry(),


### PR DESCRIPTION
#171 里那一族:今天名册在线 129 个会话 54 个 model 为空(41%),其中 **claude-code 38/38** —— 它们没有 agent-node 进程,而 node-server 从没把 `anet node create --model X` 写进 `config.json` 的 `model` 报给 hub(hub 的 `report_status` 早就收 `model`)。

## 改法

- `node-server.ts`:起时按 `CONFIG_PATH` 读一次 `model`(字符串且非空才用),开机注册 / SSE 重连 / 3 分钟心跳三处身份载荷都带 `model: NODE_MODEL`;配置没写就不发(不编默认值 —— 裸 claude-code 会话实际跑什么模型只有 Claude Code 自己知道,配置没写时报空比报猜的诚实)。
- `node-server-identity-payload.test.ts`(反推门)+1:凡 `agent: "claude-code"` 载荷块都要有 `model: NODE_MODEL`;变异去掉心跳那处 → 1 fail,还原 → 绿。
- 与 #1787(#1727 遥测)同一条路;这一版 anet 发出去后 claude-code 节点重启即生效。

## 证据

- identity + payload 测试 13/13;agent-network `tsc --noEmit` 0 错;doc-symbol-pins 两种参数 rc=0。
- 边界:`agent-node:grok` 6 / `agent-node:claude` 4 的 model 为空是 agent-node 那一侧的事,不在此 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD