### PR TITLE
chore(release): agent-network 2.3.0-preview.81 —— #849 端口探针 + #171 claude-code model 上报

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.80",
+  "version": "2.3.0-preview.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.80",
+      "version": "2.3.0-preview.81",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.80",
+  "version": "2.3.0-preview.81",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.80";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.81";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.63";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.80 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.81 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.80` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.81` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.80 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.81 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.80`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.81`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.81.md
+++ b/docs/tests/release-v2.3.0-preview.81.md
@@ -1,0 +1,32 @@
+# `@sleep2agi/agent-network@2.3.0-preview.81`
+
+## 为什么发这一版:两条 claude/codex 节点的「看得见」修复
+
+`.80` 之后 `agent-network/bin|src` 两个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `3e644288` | #1798 | **#849** —— codex 共存 ① 就绪探针按端口探,不再等一句 codex 二进制不会打印的「listening on:」(此前每次等满 25 s 判失败) |
+| `71bcbf13` | #1799 | **#171** —— claude-code 裸节点把配置里的 `model` 报给 hub(在线 38/38 此前为空) |
+
+| 用户看到的 | `.80` | `.81` |
+|---|---|---|
+| `anet node start <codex 节点> --copresence` ① 步 | 等 25 s 后 `❌ app-server did not bind` | app-server 一绑上端口就 `READY`(实测 1.1 s) |
+| Dashboard 上 claude-code 节点的 model | 空 | `anet node create --model X` 写的那个 X;没写仍为空 |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.81
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.81
+anet node stop <name> && anet node start <name>   # claude-code 节点的 .anet/node-server.js 启动时重生成
+```
+
+## 边界
+
+- codex 共存的端口探针没有在真机起过三件套验证(需登录的 codex);行为与 Windows 启动器一致,端口绑上但服务未就绪的情形由下一步 bridge 探针兜底。


### PR DESCRIPTION
`.80` 之后包内容两个提交:#1798(#849)与 #1799(#171)。

- 戳:package.json / lock ×2 / PAIRED_AGENT_NETWORK_VERSION / getting-started zh+en .80→.81;说明含 Install/Upgrade
- version-claims rc=0;symbol-pins 两种参数 rc=0;pair 测试 6/6
- promote 判据发布后从 .80/.81 产物 diff 取(两条改动都不带新字面量)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD