### PR TITLE
fix(hub): #695 Bun.serve 加 error 回调 —— fetch 抛出时回带异常 message 的 JSON

### DIFF
--- a/server/src/serve-error.test.ts
+++ b/server/src/serve-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { buildServeErrorResponse, serveErrorBody } from "./serve-error.js";
+
+// 注:「没有 error 回调时 Bun 回默认非 JSON 500」这一半没法在 bun test 里当用例:
+// 运行器会把 fetch 里抛出的异常当成未处理错误直接判这条用例失败(实测),证据在 #695 末评。
+describe("#695 fetch exceptions become JSON with the exception's own message", () => {
+  test("body carries THE message, both JSON-RPC-shaped and REST-shaped", () => {
+    const b = serveErrorBody(new Error("boom-695: sqlite is locked"));
+    expect(b.error.code).toBe(-32603);
+    expect(b.error.message).toBe("boom-695: sqlite is locked");
+    expect(b.message).toBe("boom-695: sqlite is locked");
+    expect(b.ok).toBe(false);
+    // 不是固定 JSON:换一个异常,message 跟着变
+    expect(serveErrorBody(new Error("other")).error.message).toBe("other");
+    expect(serveErrorBody("plain string").error.message).toBe("plain string");
+    expect(serveErrorBody(new Error("")).error.message).toBe("internal error");
+  });
+
+  test("real Bun.serve: a throwing fetch answers 500 + application/json + the message (was a non-JSON default page)", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() { throw new Error("boom-695-live"); },
+      error: (err) => buildServeErrorResponse(err),
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(500);
+      expect(res.headers.get("content-type") ?? "").toContain("application/json");
+      const json = await res.json() as { error: { code: number; message: string }; ok: boolean };
+      expect(json.error.code).toBe(-32603);
+      expect(json.error.message).toBe("boom-695-live");
+      expect(json.ok).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+});

--- a/server/src/serve-error.ts
+++ b/server/src/serve-error.ts
@@ -1,0 +1,27 @@
+// #695 —— Bun.serve 没注册 `error` 回调时,fetch 处理器抛出的异常会变成 Bun 的默认 500,
+// body 不是 JSON;MCP 客户端于是只能报一个泛化的 -32603,拿不到任何一句人话。
+// 这里把异常变成一个带 message 的 JSON 响应:/mcp 的客户端按 JSON-RPC 形状读 error.message,
+// REST 客户端按本仓其它路由的 { ok:false, error, message } 形状读。
+// 🔴 判据(#695 末评):同一个异常,响应里要带**那个异常的 message**,不是一个固定 JSON。
+
+export interface ServeErrorBody {
+  jsonrpc: "2.0";
+  id: null;
+  error: { code: -32603; message: string };
+  ok: false;
+  message: string;
+}
+
+export function serveErrorBody(err: unknown): ServeErrorBody {
+  const raw = err instanceof Error ? err.message : String(err);
+  const message = (raw && raw.trim()) ? raw.trim().slice(0, 500) : "internal error";
+  return { jsonrpc: "2.0", id: null, error: { code: -32603, message }, ok: false, message };
+}
+
+export function buildServeErrorResponse(err: unknown): Response {
+  const body = serveErrorBody(err);
+  return new Response(JSON.stringify(body), {
+    status: 500,
+    headers: { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" },
+  });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,4 @@
+import { buildServeErrorResponse } from "./serve-error.js";
 import { redactMessageRow } from "./redact-tokens.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parseDbTimestampMs } from "./db-timestamp.js";
@@ -786,6 +787,9 @@ return Bun.serve({
   // route. Default Bun ceiling is 128 MiB which is too permissive for
   // a hub now exposed to the public internet.
   maxRequestBodySize: MAX_REQUEST_CONTENT_LENGTH,
+  // #695 —— fetch 处理器抛出时不要让 Bun 回默认的非 JSON 500;带上异常 message,
+  //   /mcp 客户端按 JSON-RPC 读 error.message,REST 客户端按 { ok:false, message } 读。
+  error: (err) => buildServeErrorResponse(err),
 
   async fetch(req, server) {
     const url = new URL(req.url, `http://localhost:${PORT}`);


### PR DESCRIPTION
#695 末评读代码找到的结构性根因:`Bun.serve({ … })` 没注册 `error` 回调,fetch 处理器一抛,Bun 回默认 500 且 body 不是 JSON → MCP 客户端归成泛化的 `-32603 Internal error`,拿不到一句人话。

## 改法

- `server/src/serve-error.ts`:`serveErrorBody(err)` / `buildServeErrorResponse(err)` —— 500 + `application/json`,body 同时是 JSON-RPC 形状(`error.code=-32603, error.message=<异常 message>`)与本仓 REST 形状(`ok:false, message`)。
- `server/src/server.ts`:`Bun.serve({ …, error: (err) => buildServeErrorResponse(err) })`。

## 证据(按末评要求的判据:**同一个异常,响应里得带那个异常的 message**,不是固定 JSON)

- 纯函数:三种异常三种 message;空 message 退回 `internal error`。
- 真 `Bun.serve`(port 0):fetch 抛 `boom-695-live` → `500` + `application/json` + `error.message === "boom-695-live"`。
- 「没有回调时 body 不是 JSON」那一半没法在 bun test 里当用例(运行器把 fetch 里的抛出当未处理错误直接判失败,实测),证据以 #695 末评为准。
- 到生产要发 commhub-server `.48` 并升 hub。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD