### PR TITLE
chore(release): commhub-server 0.9.0-preview.48 —— #695 /mcp 出错回带 message 的 JSON

### DIFF
--- a/docs/tests/release-v0.9.0-preview.48.md
+++ b/docs/tests/release-v0.9.0-preview.48.md
@@ -1,0 +1,37 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.48`
+
+## 为什么发这一版:**/mcp 出错时客户端能拿到一句人话**(#695)
+
+`.47` 之后 `server/` 只有一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `f345b79a` | #1801 | `Bun.serve` 加 `error` 回调:fetch 处理器抛出时回 500 + `application/json`,body 带那个异常的 message(JSON-RPC 与 REST 双形状),不再是 Bun 默认的非 JSON 500 |
+
+| 用户看到的 | `.47` | `.48` |
+|---|---|---|
+| hub 内部抛异常时 send_task 等 MCP 调用 | `-32603 Internal error`(一句话都没有) | `-32603` + `error.message` = 真正的异常信息 |
+
+生产 hub 从 `.45` 直接升到 `.48` 可一并拿到 `.46`(#1756 tools/list schema)、`.47`(#1548 blocked 出口)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.48
+```
+
+## Upgrade
+
+生产 hub 按 `deploy/hub/README.md` 六步;`PINNED_SERVER_VERSION` 暂留 `.47`(下一次 anet bump 再跟)。
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.48   # 自托管
+```
+
+## 证据
+
+- `server/src/serve-error.test.ts` 2 条(纯函数 message 随异常变;真 Bun.serve port 0 抛出 → 500 + JSON + 同一条 message)。
+
+## promote 时的 must_contain
+
+`buildServeErrorResponse`(`.47` 产物 0 命中,已用闸 4 原样命令验)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.47",
+  "version": "0.9.0-preview.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.47",
+      "version": "0.9.0-preview.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.47",
+  "version": "0.9.0-preview.48",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
`.47` 之后 `server/` 只有 #1801(#695)。

- server/package.json + lock ×2 .47 → .48;说明含 Install/Upgrade;promote 判据 `buildServeErrorResponse`(.47 产物 0 命中)
- version-claims rc=0;`PINNED_SERVER_VERSION` 暂留 .47(下一次 anet bump 再跟,避免今晚再发一版 anet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD