### PR TITLE
ci(docker): 测试镜像关掉 npm audit/fund —— audit 端点间歇挂起把 Docker 构建拖到撞守卫

### DIFF
--- a/docker/feishu-deny-e2e/Dockerfile
+++ b/docker/feishu-deny-e2e/Dockerfile
@@ -19,6 +19,9 @@
 #
 # The tarball is .gitignored — it must be generated locally per run.
 FROM node:24-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /probe
 COPY agent-node.tgz /probe/agent-node.tgz

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 # Install Node.js
 RUN apt-get update && apt-get install -y curl python3 make g++ jq procps && \

--- a/tests/Dockerfile.npm
+++ b/tests/Dockerfile.npm
@@ -1,4 +1,7 @@
 FROM oven/bun:latest
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 # Install Node.js
 RUN apt-get update && apt-get install -y curl python3 && \

--- a/tests/qa-core-docs/Dockerfile
+++ b/tests/qa-core-docs/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /workspace/docs-site
 COPY docs-site/package.json docs-site/package-lock.json ./

--- a/tests/qa-daemon-lifecycle-e2e/Dockerfile
+++ b/tests/qa-daemon-lifecycle-e2e/Dockerfile
@@ -8,6 +8,9 @@
 # build-essential + python3, LOCAL source installed globally via npm pack
 # so `anet` on PATH is the code under test, not a registry build.
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl ca-certificates jq unzip procps \

--- a/tests/qa-frontdoor-docs/Dockerfile
+++ b/tests/qa-frontdoor-docs/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /workspace/docs-site
 COPY docs-site/package.json docs-site/package-lock.json ./

--- a/tests/test-desktop-update-endpoint/Dockerfile
+++ b/tests/test-desktop-update-endpoint/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git \

--- a/tests/test-npm-install/Dockerfile
+++ b/tests/test-npm-install/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test-rfc029-pr4-kernel-live/Dockerfile
+++ b/tests/test-rfc029-pr4-kernel-live/Dockerfile
@@ -16,6 +16,9 @@
 # fresh container reaches them out of the box.
 
 FROM oven/bun:1.3.1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash curl jq ca-certificates procps nodejs npm && \

--- a/tests/test1220-codex-tui-client-health/Dockerfile
+++ b/tests/test1220-codex-tui-client-health/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ENV BUN_VERSION=1.3.14
 ENV BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f

--- a/tests/test1225-opencode-copresence-onecommand/Dockerfile
+++ b/tests/test1225-opencode-copresence-onecommand/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG SOURCE_COMMIT
 ENV TEST1225_SOURCE_COMMIT=$SOURCE_COMMIT
 # Pinned bun, per the ratchet in .github/scripts/check-bun-install-pin.py.

--- a/tests/test1271-daemon-start-node/Dockerfile
+++ b/tests/test1271-daemon-start-node/Dockerfile
@@ -7,7 +7,13 @@ ARG SOURCE_COMMIT
 # multi-stage pattern as tests/qa-180-rename-ghost (a passing gate); version
 # pinned by digest for supply-chain safety.
 FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun-runtime
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
 RUN apt-get update && apt-get install -y --no-install-recommends bash build-essential ca-certificates curl python3 util-linux \
  && rm -rf /var/lib/apt/lists/* \

--- a/tests/test1280-desktop-user-push/Dockerfile
+++ b/tests/test1280-desktop-user-push/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates nodejs npm \

--- a/tests/test14-agent-node/Dockerfile
+++ b/tests/test14-agent-node/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test15-telegram-mock/Dockerfile
+++ b/tests/test15-telegram-mock/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test17-user-journey/Dockerfile
+++ b/tests/test17-user-journey/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 WORKDIR /app
 RUN apt-get update && apt-get install -y curl python3 nodejs npm && rm -rf /var/lib/apt/lists/*
 RUN npm i -g @sleep2agi/commhub-server@preview @sleep2agi/agent-network@preview @sleep2agi/agent-node@preview

--- a/tests/test19-real-collab/Dockerfile
+++ b/tests/test19-real-collab/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test219-grok-copresence/Dockerfile
+++ b/tests/test219-grok-copresence/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG SOURCE_COMMIT
 ENV TEST219_SOURCE_COMMIT=$SOURCE_COMMIT
 

--- a/tests/test22-agent-ux/Dockerfile
+++ b/tests/test22-agent-ux/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test225-grok-preview-package-live/Dockerfile
+++ b/tests/test225-grok-preview-package-live/Dockerfile
@@ -1,6 +1,9 @@
 ARG SOURCE_COMMIT
 
 FROM node:22-bookworm-slim AS packer
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ARG SOURCE_COMMIT
 
@@ -58,6 +61,9 @@ RUN mkdir -p /candidate \
 
 
 FROM node:22-bookworm-slim AS runtime
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ARG SOURCE_COMMIT
 ENV TEST225_SOURCE_COMMIT=$SOURCE_COMMIT

--- a/tests/test226-opencode-preview-release/Dockerfile
+++ b/tests/test226-opencode-preview-release/Dockerfile
@@ -6,6 +6,9 @@
 # process is used.
 
 FROM oven/bun:1.3.1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ARG OPENCODE_VERSION
 RUN test -n "$OPENCODE_VERSION"

--- a/tests/test25-agent-telegram/Dockerfile
+++ b/tests/test25-agent-telegram/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test28-pr-review-room/Dockerfile
+++ b/tests/test28-pr-review-room/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:20-bookworm
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app

--- a/tests/test292-e2e-agent-registration/Dockerfile
+++ b/tests/test292-e2e-agent-registration/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y curl jq python3 make g++ && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \

--- a/tests/test292-e2e-identity-fixtures/Dockerfile
+++ b/tests/test292-e2e-identity-fixtures/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y curl jq python3 make g++ && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \

--- a/tests/test292-e2e-residual-fixtures/Dockerfile
+++ b/tests/test292-e2e-residual-fixtures/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y curl jq python3 make g++ procps && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \

--- a/tests/test313-test-all-v3-fixtures/Dockerfile
+++ b/tests/test313-test-all-v3-fixtures/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl python3 make g++ nodejs npm \

--- a/tests/test380-daemon-telemetry-probe/Dockerfile
+++ b/tests/test380-daemon-telemetry-probe/Dockerfile
@@ -8,6 +8,9 @@
 # payload shape and DB writes are what we're after, not network routing.
 
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash curl jq ca-certificates sqlite3 procps unzip && \

--- a/tests/test380-gateway-topology-probe/Dockerfile.daemon
+++ b/tests/test380-gateway-topology-probe/Dockerfile.daemon
@@ -2,6 +2,9 @@
 # @sleep2agi/agent-network@preview + @sleep2agi/agent-node@preview.
 
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash curl jq ca-certificates sqlite3 procps && \

--- a/tests/test384-opencode-local-package-e2e/Dockerfile
+++ b/tests/test384-opencode-local-package-e2e/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ARG OPENCODE_VERSION=1.18.1
 # 🔴 故意留空:下面 line 72-73 把这两个 ARG 灌进 ENV *_UNDER_TEST,而 run.sh 用

--- a/tests/test4-base/Dockerfile
+++ b/tests/test4-base/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test520-ack-inbox-docs/Dockerfile
+++ b/tests/test520-ack-inbox-docs/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /workspace
 RUN apt-get update \

--- a/tests/test535-codex-copresence-docs/Dockerfile
+++ b/tests/test535-codex-copresence-docs/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22.13.1-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test648-probe-ip-pin/Dockerfile
+++ b/tests/test648-probe-ip-pin/Dockerfile
@@ -1,6 +1,12 @@
 FROM oven/bun:1.3.14 AS bun-runtime
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 FROM node:20-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates openssl \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun

--- a/tests/test725-agent-node-unit-ci/Dockerfile
+++ b/tests/test725-agent-node-unit-ci/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
 

--- a/tests/test745-agent-network-unit-ci/Dockerfile
+++ b/tests/test745-agent-network-unit-ci/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
 

--- a/tests/test750-codex-copresence-onecommand/Dockerfile
+++ b/tests/test750-codex-copresence-onecommand/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG SOURCE_COMMIT
 ENV TEST750_SOURCE_COMMIT=$SOURCE_COMMIT
 # Pinned bun, per the ratchet in .github/scripts/check-bun-install-pin.py.

--- a/tests/test798-server-unit-ci/Dockerfile
+++ b/tests/test798-server-unit-ci/Dockerfile
@@ -1,5 +1,8 @@
 ARG SOURCE_COMMIT
 FROM node:22-bookworm-slim
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
 

--- a/tests/test8-runtime/Dockerfile
+++ b/tests/test8-runtime/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 WORKDIR /app
 

--- a/tests/test813-grok-mcp-readiness/Dockerfile
+++ b/tests/test813-grok-mcp-readiness/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
+# npm audit 端点 2026-09-04 间歇挂起(DEV 实测 4/6 次 20s 超时),npm 自带重试让一个 4s 的 npm link 变 4 分钟;
+# 这些镜像里 npm 只负责装依赖,供应链检查另有门(check-supply-chain),关掉 audit/fund 不改变任何判据。
+ENV npm_config_audit=false npm_config_fund=false
 
 ARG SOURCE_COMMIT
 ARG BUN_VERSION=1.3.14


### PR DESCRIPTION
## 现象
2026-09-04 起 CI Docker 构建成批撞守卫(都是基建取消,不是测试红):
| job | 正常 | 今天 |
|---|---|---|
| e2e · Build Docker E2E image | 80–87 s | 414 / 526 / **613 s**(10 min 守卫撞 2 次) |
| doc source-pin floor · Build test813 | 43–72 s | 119 / 206 / **468 s**(8 min 守卫撞 2 次) |
| main 的 L0+L1 report-only | ~14 min | 30 min 取消 |

## 定位
慢的层全是 npm 步骤,而且慢的部分就是 **audit**:
- `npm link` → 「added 1 package, and audited 3 packages in **4m**」(正常 361 ms)
- `npm install @openai/codex-sdk` → 「audited 110 packages in **2m**」(正常 3.9 s)

DEV 直接量 `registry.npmjs.org/-/npm/v1/security/advisories/bulk`:9 次里 5 次 20–70 s 超时;同一时刻包元数据 GET 0.16 s。npm 默认 2 次重试 × 60 s 上限 ≈ 4 分钟,和日志吻合。status.npmjs.org 无公告。

## 改法
40 个跑 `npm install/ci/link` 的 Dockerfile,每个 `FROM` 后加一行
```
ENV npm_config_audit=false npm_config_fund=false
```
- 这些镜像里 npm 只负责装依赖;供应链检查另有门;`git grep 'npm audit|audited' tests scripts .github` = 0,没有测试读 audit 输出
- 已关 audit 的 `test-rename-identity` 不动;`docs/tests/` 下历史复现 Dockerfile 不动
- 不改任何 `timeout-minutes`:按 qa.yml 自己的原则守卫是 runaway 守卫,常态 1.7 min 对 8 min 已是 4.7 倍,问题不在守卫

## 验证
- 正控:本地按本 PR 的 test813 Dockerfile `--no-cache` 构建 → npm 输出「added 109 packages in 28s」,**不再出现 audited**,rc=0
- 本地门:check-test-file-coverage / test-suite-registration / l1-sha-binding / home-path-baseline / bun-install-pin 全 rc=0
- CI 上看 e2e 的 Build 步骤时长回到 ~90 s 即为线上验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD