### PR TITLE
chore(release): agent-node 2.5.0-preview.64 + agent-network 2.3.0-preview.82(#1104 派单锚点 / #1130 start 守卫)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.81",
+  "version": "2.3.0-preview.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.81",
+      "version": "2.3.0-preview.82",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.81",
+  "version": "2.3.0-preview.82",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.81";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.63";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.64";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.81";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.82";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.64";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.63",
+  "version": "2.5.0-preview.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.63",
+      "version": "2.5.0-preview.64",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.63",
+  "version": "2.5.0-preview.64",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.81 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.82 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.81` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.82` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.81 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.82 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.81`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.82`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.82.md
+++ b/docs/tests/release-v2.3.0-preview.82.md
@@ -1,0 +1,33 @@
+# `@sleep2agi/agent-network@2.3.0-preview.82`
+
+## 为什么发这一版:一条 `anet node start` 的守卫 + 配对 agent-node `.64`
+
+`.81` 之后 `agent-network/bin|src` 一个提交,外加配对版本:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `22fac026` | #1804 | **#1130** —— `anet node start` 对已在跑的节点拒绝起第二个会话(读 `.pid`、`kill -0` 存活且命令行是 agent-node 才算在跑;pid 复用不算),给出 `restart` / `stop && start` 两条路 |
+| 本版 | — | `PAIRED_AGENT_NODE_VERSION` `.63` → `.64`(#1104 派单锚点修复,见 `release-v2.5.0-preview.64.md`) |
+
+| 用户看到的 | `.81` | `.82` |
+|---|---|---|
+| 对已在跑的节点再 `anet node start` | 第二个进程接管 alias,退出时把它报成 offline,原进程还活着而 hub 不再推送 | 立即拒绝并提示 `anet node restart <name>` 或 `stop` + `start` |
+| `anet node create` 配对装的 agent-node | `.63` | `.64` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.82
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.82
+anet node stop <name> && anet node start <name>
+```
+
+## 边界
+
+- 守卫只在 `launchAgent` 入口生效;`project up` 原本就有 skip already-running,行为对齐而非新增语义。
+- 读不到 `/proc/<pid>/cmdline` 的平台按「活着」处理(宁可多拒一次,也不接管别人的 alias)。

--- a/docs/tests/release-v2.5.0-preview.64.md
+++ b/docs/tests/release-v2.5.0-preview.64.md
@@ -1,0 +1,33 @@
+# agent-node 2.5.0-preview.64
+
+`.63` 之后 `agent-node/` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `661518c2` | #1805 | **#1104** —— explicit-delegation 最后那条「让/请/麻烦 X …」模式加 `^` 锚点(`m` 标志,行首也算):只有整句/整行以它开头才算派单 |
+
+## 这一版带给用户什么
+
+claude-agent-sdk 节点在散文中间提到「…它能让 TM网站运维 免于…」「…请 TM负责人 确认…」时,不再被切片成一条 send_task 转发给第三方。TM 运维线 9 例幽灵任务(5 节点 4 机器)全部来自这一条模式;两条真实误判原文进了回归测试(必须 null),两条阳性照旧命中。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.64
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.64
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `cli-explicit-delegation.test.ts` +4(两条 TM 真实误判原文 → null,两条行首阳性);变异去掉 `^` 锚点 → 两条阴性红。
+- PR #1805 在 main 上 109 项检查全绿(2026-09-04,重跑基线为 #1806 关掉 npm audit 之后)。
+
+## promote 时的 must_contain
+
+`/^(?:让|请|麻烦)`(`.63` 产物 0 命中、`.64` 产物命中;`^` 不在 BRE 模式开头故为字面量,已用闸 4 原样 `grep -rq` 两向验)。


### PR DESCRIPTION
同日成对发版(agent-node 配对版本变了就必须当天发 agent-network preview,否则 published-pins 每天红)。

| 包 | 版本 | 内容 |
|---|---|---|
| agent-node | 2.5.0-preview.64 | `661518c2` #1104 —— explicit-delegation「让/请/麻烦 X …」加 `^` 锚点,散文中间的提及不再切片成幽灵任务 |
| agent-network | 2.3.0-preview.82 | `22fac026` #1130 —— `anet node start` 对在跑节点拒绝第二个会话;`PAIRED_AGENT_NODE_VERSION` .63→.64 |

- release notes:`docs/tests/release-v2.5.0-preview.64.md`、`docs/tests/release-v2.3.0-preview.82.md`(含 Install/Upgrade/must_contain)
- getting-started en/zh version-claim 戳 .81→.82;本地 `check-doc-version-claims` 两包 rc=0
- must_contain 两向验(GNU grep,闸 4 原样 `grep -rq`):agent-node `/^(?:让|请|麻烦)` .63 tarball 0 命中 / 本地 .64 build 命中

合入后按 CLAUDE.md 发版规则走 `release-gate (v0)`:先 agent-node .64,再 agent-network .82。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD