### PR TITLE
chore(release): agent-node .65 + agent-network .83 + commhub-server .49(#1809 两侧修复)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.82",
+  "version": "2.3.0-preview.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.82",
+      "version": "2.3.0-preview.83",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.82",
+  "version": "2.3.0-preview.83",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.82";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.64";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.83";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.65";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.64",
+  "version": "2.5.0-preview.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.64",
+      "version": "2.5.0-preview.65",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.64",
+  "version": "2.5.0-preview.65",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.82 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.83 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.82` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.83` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.82 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.83 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.82`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.83`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.49.md
+++ b/docs/tests/release-v0.9.0-preview.49.md
@@ -1,0 +1,38 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.49`
+
+## 为什么发这一版:**名册里的 version / 遥测不再在换手上报时被清空**(#1809)
+
+`.48` 之后 `server/src` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `8a2d2cae` | #1810 | **#1809** —— `report_status` 对同 alias「另一个 resume_id」的行走 DELETE+INSERT 时,INSERT 之后把没上报(仍为 NULL)的描述性列(version / agent / hostname / 六个遥测字段 / model / channels / registered_at …)从被替换的那行接手;状态类列(status / task / output / progress / score)仍以本次上报为准 |
+
+| 用户看到的 | `.48` | `.49` |
+|---|---|---|
+| grok 共存 / claude 节点回复一条任务后的名册 version | 变空,3 分钟后心跳补回 | 一直在 |
+| 同类节点的六个遥测字段 | 周期性出现又消失 | 一直在 |
+| `registered_at` | 每次换手被改成当下 | 保留首次注册时间 |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.49
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.49
+# 生产 hub 走 deploy/hub/README.md 的六步(改 launcher 的 RUNTIME_DIR 那一行,pm2 restart),不要整文件覆盖
+```
+
+## 证据
+
+- `report-status-resume-id-handover.test.ts` 4 条(换手保留 / 上报覆盖 / 来回换手 / 全新 alias 行为不变);变异去掉 version 接手 → 2 红;test698 的 sed 变异在本地重新见证红。
+- server 全量 101 文件 rc=0;PR #1810 在 main 上 109 项检查全绿(2026-09-04)。
+- DEV 真机(hub 日志 12:46:47–54):grok-v1 三次上报后 version .64 → NULL,即本版修的现象。
+
+## promote 时的 must_contain
+
+`"version": "0.9.0-preview.49"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json;`.48` 产物 0 命中)。

--- a/docs/tests/release-v2.3.0-preview.83.md
+++ b/docs/tests/release-v2.3.0-preview.83.md
@@ -1,0 +1,25 @@
+# `@sleep2agi/agent-network@2.3.0-preview.83`
+
+## 为什么发这一版:配对 agent-node `.65`(同日成对规则)
+
+`.82` 之后 `agent-network/bin|src` **没有**功能提交;本版只把配对版本推到 agent-node `.65`(#1809 的 agent-node 侧防御),让 `anet node create` 装到带修复的 agent-node,并让 published-pins 门与 main 一致。
+
+| 用户看到的 | `.82` | `.83` |
+|---|---|---|
+| `anet node create` 配对装的 agent-node | `.64` | `.65` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.83
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.83
+```
+
+## 边界
+
+- anet 自身行为与 `.82` 逐字相同;不需要重启节点。

--- a/docs/tests/release-v2.5.0-preview.65.md
+++ b/docs/tests/release-v2.5.0-preview.65.md
@@ -1,0 +1,33 @@
+# agent-node 2.5.0-preview.65
+
+`.64` 之后 `agent-node/` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `b2575551` | #1811 | **#1809** —— 每次 `report_status` 都带 `version`(此前只有 3 分钟心跳带),旧 hub 上换 resume_id 后「没版本」的窗口从「到下一次心跳」缩到「到下一次状态变化」 |
+
+## 这一版带给用户什么
+
+名册里 grok 共存 / claude 节点的 version 列不再在每次任务后消失几分钟(hub 侧根治在 commhub-server `.49`,见 `release-v0.9.0-preview.49.md`;两边任一升级都有效,都升最好)。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.65
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.65
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `report-status-carries-version.test.ts` 2 条(状态上报字面量 + 心跳 payload);变异去掉新加行 → 1 红。typecheck 棘轮 81/81。
+- PR #1811 在 main 上 109 项检查全绿(2026-09-04)。
+
+## promote 时的 must_contain
+
+`"version": "2.5.0-preview.65"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json;`.64` 产物 0 命中)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.48",
+  "version": "0.9.0-preview.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.48",
+      "version": "0.9.0-preview.49",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.48",
+  "version": "0.9.0-preview.49",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
| 包 | 版本 | 内容 |
|---|---|---|
| agent-node | 2.5.0-preview.65 | `b2575551` #1811 —— 每次 report_status 带 version |
| commhub-server | 0.9.0-preview.49 | `8a2d2cae` #1810 —— 换 resume_id 上报时描述性列从被替换行接手(#1809 根治) |
| agent-network | 2.3.0-preview.83 | 仅配对 .65(同日成对规则);getting-started en/zh 戳 |

- notes:`docs/tests/release-v2.5.0-preview.65.md` / `release-v2.3.0-preview.83.md` / `release-v0.9.0-preview.49.md`
- must_contain 三包均用 `"version": "<ver>"`(闸 4 对 package/ 整目录 grep,旧 tarball 0 命中,GNU grep 两向验)
- 本地:doc-version-claims 三包 rc=0;配对测试 6/6;hub-version-skew 8/8;pin 三门绿
- 合入后 release-gate 顺序:agent-node .65 → agent-network .83 → commhub-server .49;生产 hub 升级由 owner 定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD