### PR TITLE
fix(fleet): #1332 boot sweep 只拉起判定为缺的别名(project up --only)

### DIFF
--- a/deploy/fleet/anet-nodes-boot.sh
+++ b/deploy/fleet/anet-nodes-boot.sh
@@ -269,8 +269,13 @@ for ((round=1; round<=MAX_ROUNDS; round++)); do
     first5="${missing[*]:0:5}"; more=""
     [ "${#missing[@]}" -gt 5 ] && more=" (+$((${#missing[@]}-5)) more)"
     log "  $proj_name: 缺 ${#missing[@]}/${#aliases[@]} → project up · timeout=${PROJECT_TIMEOUT}s · 缺: $first5$more"
+    # #1332(2026-09-04 事故):`project up` 会把**整个 project** 拉起,包括上面刚判成
+    # 「进程在跑但不在 tmux(不算缺)」的那些 —— 于是给 daemon-dev / grok-vansin 各起了第二份,
+    # 第二份退出时把 hub 行报成 offline(#1130 的接管问题)。sweep 明明算出了缺的是谁,
+    # 就只起那几个:`--only a,b`(anet 自带的别名过滤,见 `anet project up --help`)。
+    only_csv=$(IFS=,; echo "${missing[*]}")
 
-    if ( cd "$proj" && timeout "$PROJECT_TIMEOUT" "$ANET" project up --stagger "$STAGGER" 2>&1 \
+    if ( cd "$proj" && timeout "$PROJECT_TIMEOUT" "$ANET" project up --stagger "$STAGGER" --only "$only_csv" 2>&1 \
           | sed "s|^|      [$proj_name] |" ); then
       round_up=$((round_up+1))
     else


### PR DESCRIPTION
Refs #1332(事故记录见该 issue 2026-09-04 的两条评论)

## 机制
sweep 按别名分类(缺 / 在跑但不在 tmux / 跳过),但启动按 **project** 做:`anet project up` 把整个 project 拉起,包括刚判成「在跑但不在 tmux(不算缺)」的节点 → 第二份实例 → 退出时把 hub 行报成 offline(#1130)。

## 改法
把算好的 `missing[]` 用 `IFS=,` 拼成 `--only a,b` 传给 `anet project up`(anet 自带的别名过滤,`anet project up --help`);`missing` 为空时早已 `continue`。`bash -n` 通过。

## 没做的(留在 #1332)
- sweep 的 ExecStart 走 node v20 树的 anet .76(没有 #1130 守卫)
- 「停着」≠「缺」的语义

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD