### PR TITLE
chore(release): agent-network 2.3.0-preview.84(#1808 sibling agent-node)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.83",
+  "version": "2.3.0-preview.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.83",
+      "version": "2.3.0-preview.84",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.83",
+  "version": "2.3.0-preview.84",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.83";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.84";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.65";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.83 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.84 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.83` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.84` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.83 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.84 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.83`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.84`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.84.md
+++ b/docs/tests/release-v2.3.0-preview.84.md
@@ -1,0 +1,42 @@
+# `@sleep2agi/agent-network@2.3.0-preview.84`
+
+## 为什么发这一版:起节点优先用装在 anet 旁边的 agent-node(#1808)
+
+`.83` 之后 `agent-network/bin|src` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `27d3d153` | #1813 | **#1808** —— `anet node start` 解析 agent-node 时,在 `ANET_AGENT_NODE_BIN` 之后、PATH 之前加一层「与 anet 同一个 `node_modules` 里的 agent-node」;PATH 那一层的日志打印实际解析到的路径 |
+
+| 用户看到的 | `.83` | `.84` |
+|---|---|---|
+| 隔离前缀 / 多棵 node 树里 `anet node start`(grok 或默认 runtime) | 用 PATH 上另一棵树的老 agent-node(真机:.40 在占位文件上崩) | 用和 anet 一起装的那份,日志第二行写出路径与版本 |
+| 全局安装 | 同一份(PATH 与旁边是同一个文件) | 同一份,行为不变 |
+
+配对 agent-node 仍为 `2.5.0-preview.65`。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.84
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.84
+```
+
+## 证据
+
+- `sibling-agent-node.test.ts` 7 条;`bun tsc --noEmit` 0 错;agent-network 单测全绿;test225(grok 预览包真机套件)绿(日志契约句保留)。
+- PR #1813 在 main 上 109 项检查全绿(2026-09-04;report-only 一次 qa-cli-02 flake 重跑绿,见 #1593)。
+
+## 边界
+
+- codex / opencode 的解析本就按精确配对版本扫 PATH,本版不动。
+- 真机回验:DEV `~/anet-preview/node_modules/.bin/anet node start grok-v1`(不带 PATH 前缀)应打印 `beside anet: …/agent-node/dist/cli.js (2.5.0-preview.65)`。
+
+## promote 时的 must_contain
+
+`"version": "2.3.0-preview.84"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json;`.83` 产物 0 命中)。


### PR DESCRIPTION
Version bump for agent-network 2.3.0-preview.84 carrying `27d3d153` (#1813 / #1808). Paired agent-node stays 2.5.0-preview.65.

- notes: `docs/tests/release-v2.3.0-preview.84.md`(Install / Upgrade / must_contain `"version": "2.3.0-preview.84"`)
- getting-started en/zh 戳 .83→.84;本地 doc-version-claims rc=0、配对测试 6/6、pin 三门绿
- 合入后 release-gate 发 .84,再在 DEV 用不带 PATH 前缀的隔离安装真机回验

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD