### PR TITLE
fix(grok-copresence): #1422 stop 时占位文件在 leader 拆卸之前回收

### DIFF
--- a/agent-node/src/runtime/grok-copresence/placeholders-reclaimed-before-leader-teardown.test.ts
+++ b/agent-node/src/runtime/grok-copresence/placeholders-reclaimed-before-leader-teardown.test.ts
@@ -1,0 +1,34 @@
+// #1422 —— stop 时占位文件必须在 leader 拆卸**之前**回收。
+// 拆卸链原来是 …→ terminateOwnedPty → teardownOwnedLeader → finalizeStoppedState(才删占位文件);
+// `anet node stop` 只给 10 s 宽限,leader 拆卸吃掉宽限就 SIGKILL,占位文件留下(test225 偶红)。
+// 判据:teardownOwnedLeader 开始执行时,项目目录里 5 个 0 字节 0444 占位文件已经不在。
+import { describe, expect, test } from "bun:test";
+import { closeSync, existsSync, openSync } from "fs";
+import { join } from "path";
+import { withHumanTui } from "./copresence-human-fixture";
+
+const PLACEHOLDERS = [".grok", ".claude", ".cursor", ".mcp.json", ".envrc"];
+
+describe("#1422 project placeholders are reclaimed before leader teardown", () => {
+  test("teardownOwnedLeader observes an already-clean project dir", async () => {
+    await withHumanTui(async ({ fixture, runtime }) => {
+      for (const name of PLACEHOLDERS) {
+        closeSync(openSync(join(fixture.cwd, name), "wx", 0o444));
+      }
+      const present = () => PLACEHOLDERS.filter((name) => existsSync(join(fixture.cwd, name)));
+      expect(present()).toEqual(PLACEHOLDERS);
+
+      const seenAtLeaderTeardown: string[][] = [];
+      const original = (runtime as any).teardownOwnedLeader.bind(runtime);
+      (runtime as any).teardownOwnedLeader = async () => {
+        seenAtLeaderTeardown.push(present());
+        return original();
+      };
+
+      await runtime.close();
+      expect(seenAtLeaderTeardown).toHaveLength(1);
+      expect(seenAtLeaderTeardown[0]).toEqual([]);
+      expect(present()).toEqual([]);
+    });
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -1656,6 +1656,23 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
       this.retainLocksForUnconfirmedPty = true;
       this.warn(`[grok-copresence] PTY termination failed: ${errorMessage(error)}`);
     });
+    // #1422 —— 占位文件(.grok .claude .cursor .mcp.json .envrc)的回收原本是整条链的最后一步
+    // (finalizeStoppedState → cleanupGrokCliPostStopState)。`anet node stop` 只给 10 s 宽限,
+    // leader 拆卸吃掉宽限就被 SIGKILL,最后一步永远跑不到,项目目录里留下 5 个 0 字节文件
+    // (test225 那条「post-stop cleanup retained pinned project sandbox placeholder」)。
+    // TUI 已证死(terminateOwnedPty 返回且没进 retainLocks),这些文件就没有主人了 ——
+    // 在 leader 拆卸之前先用 #1767 那套只认「0 字节 0444 属主是自己」的回收器收掉。
+    // finalizeStoppedState 里的原路径保留(幂等),兜住 PTY 路径没走到这里的情形。
+    if (this.ownedAnyTuiGeneration && !this.retainLocksForUnconfirmedPty) {
+      try {
+        const reclaimed = reclaimStaleProjectSandboxPlaceholders(this.opts.cwd);
+        if (reclaimed.length > 0) {
+          this.log(`[grok-copresence] reclaimed ${reclaimed.length} project placeholder(s) before leader teardown: ${reclaimed.join(" ")}`);
+        }
+      } catch (error) {
+        this.warn(`[grok-copresence] early placeholder reclaim skipped: ${errorMessage(error)}`);
+      }
+    }
     await this.teardownOwnedLeader().catch((error) => {
       this.retainLocksForUnconfirmedPty = true;
       this.warn(`[grok-copresence] retaining locks: ${errorMessage(error)}`);


### PR DESCRIPTION
Refs #1422(机制见该 issue 2026-09-04 最后一条评论)

## 机制
`close()` 顺序:… → `terminateOwnedPty` → `teardownOwnedLeader` → `finalizeStoppedState`(才删占位文件)。`anet node stop` 10 s 宽限被 leader 拆卸吃掉 → SIGKILL → 最后一步不跑 → `.grok` 等 5 个 0 字节文件留下(test225 偶红的那条)。

## 改法
TUI 证死后、leader 拆卸前,先跑 #1767 的 `reclaimStaleProjectSandboxPlaceholders`(只认 0 字节 0444 属主是自己);原最后一步保留(幂等)。

## 验证
- `placeholders-reclaimed-before-leader-teardown.test.ts`:`withHumanTui` 种 5 个占位文件,包一层 `teardownOwnedLeader` 记录开始时的目录 → 必须已空;变异去掉提前回收 → 红
- grok-copresence 目录 288 测试全绿;typecheck 棘轮 81/81;pin 三门 + test-suite-registration 绿
- CI 上 test225(grok 预览包真机套件)是这条的线上判据

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD