### PR TITLE
chore(release): agent-node .66(#1422)+ agent-network .85(配对)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.84",
+  "version": "2.3.0-preview.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.84",
+      "version": "2.3.0-preview.85",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.84",
+  "version": "2.3.0-preview.85",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.84";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.65";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.85";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.66";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.65",
+  "version": "2.5.0-preview.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.65",
+      "version": "2.5.0-preview.66",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.65",
+  "version": "2.5.0-preview.66",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.84 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.85 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.84` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.85` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.84 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.85 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.84`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.85`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.85.md
+++ b/docs/tests/release-v2.3.0-preview.85.md
@@ -1,0 +1,25 @@
+# `@sleep2agi/agent-network@2.3.0-preview.85`
+
+## 为什么发这一版:配对 agent-node `.66`(同日成对规则)
+
+`.84` 之后 `agent-network/bin|src` **没有**功能提交;本版只把配对版本推到 agent-node `.66`(#1422 的 stop 时占位文件提前回收),让 `anet node create` 装到带修复的 agent-node,并让 published-pins 门与 main 一致。
+
+| 用户看到的 | `.84` | `.85` |
+|---|---|---|
+| `anet node create` 配对装的 agent-node | `.65` | `.66` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.85
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.85
+```
+
+## 边界
+
+- anet 自身行为与 `.84` 逐字相同;不需要重启节点。

--- a/docs/tests/release-v2.5.0-preview.66.md
+++ b/docs/tests/release-v2.5.0-preview.66.md
@@ -1,0 +1,33 @@
+# agent-node 2.5.0-preview.66
+
+`.65` 之后 `agent-node/` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `dab010e4` | #1817 | **#1422** —— grok 共存节点 stop 时,占位文件(.grok .claude .cursor .mcp.json .envrc)在 TUI 证死后、leader 拆卸之前就回收,不再依赖整条拆卸链在 10 s 宽限内跑完 |
+
+## 这一版带给用户什么
+
+`anet node stop` 之后项目目录不再残留 5 个 0 字节占位文件(此前拆卸链被 SIGKILL 打断时会留下,下一次启动才靠 .64 的回收器清掉);test225 那条偶红的形状随之消失。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.66
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.66
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `placeholders-reclaimed-before-leader-teardown.test.ts`(withHumanTui 种 5 个占位文件,leader 拆卸开始时目录必须已空;变异去掉提前回收 → 红);grok-copresence 288 测试全绿;typecheck 棘轮 81/81。
+- PR #1817 在 main 上 109 项检查全绿(2026-09-04)。
+
+## promote 时的 must_contain
+
+`"version": "2.5.0-preview.66"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json;`.65` 产物 0 命中)。


### PR DESCRIPTION
| 包 | 版本 | 内容 |
|---|---|---|
| agent-node | 2.5.0-preview.66 | #1817 / #1422 —— stop 时占位文件在 leader 拆卸前回收 |
| agent-network | 2.3.0-preview.85 | 仅配对 .66(同日成对规则);getting-started en/zh 戳 |

- notes:`docs/tests/release-v2.5.0-preview.66.md` / `release-v2.3.0-preview.85.md`;must_contain `"version": "<ver>"`
- 本地:doc-version-claims 两包 rc=0;配对测试 6/6;pin 三门绿
- 合入后 release-gate:agent-node .66 → agent-network .85;然后部署 anet.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD