### PR TITLE
fix(hub): #1823 send_reply 附件写到 meta_json.reply_attachments,不再覆盖提问者的 attachments

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2132 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2132) + [tools.ts:2146 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2146) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:2146 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2146) + [tools.ts:2160 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L2160) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:193（列定义数组）+ db.ts:206（`ALTER TABLE inbox ADD COLUMN`）](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L193)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/send-reply-attachments.test.ts
+++ b/server/src/send-reply-attachments.test.ts
@@ -175,8 +175,10 @@ describe("#507 — send_reply attachments (positive)", () => {
 
     // Verify persistence — the echo must come from what actually landed on disk.
     const taskMeta = readTaskMeta(taskId);
-    expect(taskMeta?.attachments?.length).toBe(2);
-    expect(taskMeta.attachments.map((a: any) => a.file_id).sort()).toEqual([a1.file_id, a2.file_id].sort());
+    // #1823 —— 任务行上回复附件在 reply_attachments;attachments 键留给提问者自己带的附件
+    expect(taskMeta?.attachments).toBeUndefined();
+    expect(taskMeta?.reply_attachments?.length).toBe(2);
+    expect(taskMeta.reply_attachments.map((a: any) => a.file_id).sort()).toEqual([a1.file_id, a2.file_id].sort());
 
     const inboxMeta = readInboxMeta(reply.message_id!);
     expect(inboxMeta?.attachments?.length).toBe(2);
@@ -196,8 +198,10 @@ describe("#507 — send_reply attachments (positive)", () => {
     expect(reply.ok).toBe(true);
     expect(reply.attachments_saved!.length).toBe(1);
     const persisted = readTaskMeta(taskId);
-    expect(persisted?.attachments?.[0]?.file_id).toBe(a1.file_id);
-    expect(persisted?.other_field).toBe("preserved"); // meta merge preserves siblings
+    expect(persisted?.reply_attachments?.[0]?.file_id).toBe(a1.file_id);
+    expect(persisted?.attachments).toBeUndefined();
+    // #1823 —— 回复 meta 的兄弟字段属于回复(inbox 行),不写进提问者的任务行
+    expect(readInboxMeta(reply.message_id)?.other_field).toBe("preserved");
   });
 
   test("P3: top-level attachments WIN over meta.attachments when both supplied (parity with REST /api/task L2101)", async () => {
@@ -217,9 +221,26 @@ describe("#507 — send_reply attachments (positive)", () => {
     expect(reply.attachments_saved!.length).toBe(1);
     expect(reply.attachments_saved![0].file_id).toBe(topLevel.file_id);
     const persisted = readTaskMeta(taskId);
-    expect(persisted?.attachments?.length).toBe(1);
-    expect(persisted?.attachments?.[0]?.file_id).toBe(topLevel.file_id);
-    expect(persisted?.other).toBe("kept");
+    expect(persisted?.reply_attachments?.length).toBe(1);
+    expect(persisted?.reply_attachments?.[0]?.file_id).toBe(topLevel.file_id);
+    expect(readInboxMeta(reply.message_id)?.other).toBe("kept");
+  });
+
+  // #1823 —— 提问者随任务带的附件必须留在 attachments;回复附件另放 reply_attachments。
+  // (Vincent 2026-09-06:回复的图被画进提问者气泡;以前整体 COALESCE 替换还会把提问者的附件覆盖掉)
+  test("P6 (#1823): asker's attachments survive a reply with attachments; reply goes to reply_attachments", async () => {
+    const { taskId } = seed();
+    const asked = att("11111111111111111111111111111111", { name: "asked.png" });
+    db.run("UPDATE tasks SET meta_json = ?1 WHERE task_id = ?2", [JSON.stringify({ attachments: [asked], origin: "dashboard" }), taskId]);
+    const handler = await getSendReplyHandler();
+    const answer = att("22222222222222222222222222222222", { name: "answer.md" });
+    const reply = await callReply(handler, { alias: AGENT_ALIAS, text: "here", in_reply_to: taskId, status: "replied" as const, attachments: [answer] });
+    expect(reply.ok).toBe(true);
+    const persisted = readTaskMeta(taskId);
+    expect(persisted?.attachments?.map((a: any) => a.file_id)).toEqual([asked.file_id]);
+    expect(persisted?.origin).toBe("dashboard");
+    expect(persisted?.reply_attachments?.map((a: any) => a.file_id)).toEqual([answer.file_id]);
+    expect(readInboxMeta(reply.message_id)?.attachments?.[0]?.file_id).toBe(answer.file_id);
   });
 });
 

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1981,7 +1981,21 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           // against clobbering pre-existing meta_json when this reply
           // brings no attachments (metaJson === null → keep the existing
           // task meta_json unchanged). Reverse-(e) invariant.
-          const updateParams: any[] = [replyStatus, text, metaJson, in_reply_to];
+          // #1823 —— 回复的附件写到 tasks.meta_json.reply_attachments,**不碰** meta_json.attachments:
+          // 那个键是提问者随任务带的附件,客户端把它画在提问者的气泡里。以前这里用回复的 metaJson
+          // 整体 COALESCE 替换,于是 agent 回的图出现在提问者气泡下面、提问者自己带的附件被覆盖
+          // (Vincent 2026-09-06 实测「好像没成功发送给我」)。inbox 行(收件方视角)照旧写 metaJson。
+          const replyTaskMetaJson = (() => {
+            if (!attachmentsResult.attachments.length) return null;
+            const rowParams: any[] = [in_reply_to];
+            let rowSql = "SELECT meta_json FROM tasks WHERE task_id = ?1";
+            rowSql = addScope(rowSql, rowParams, effectiveNetId);
+            const existing = db.get<{ meta_json: string | null }>(rowSql, ...rowParams)?.meta_json ?? null;
+            let base: Record<string, unknown> = {};
+            if (existing) { try { const parsed = JSON.parse(existing); if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) base = parsed; } catch {} }
+            return JSON.stringify({ ...base, reply_attachments: attachmentsResult.attachments });
+          })();
+          const updateParams: any[] = [replyStatus, text, replyTaskMetaJson, in_reply_to];
           let updateSql = `UPDATE tasks
              SET status = ?1,
                  result = ?2,


### PR DESCRIPTION
Closes #1823(Vincent 2026-09-06「好像没成功发送给我诶」:agent 回复的图/文件被画进提问者自己的气泡)。

## 机制
`send_reply` 的 #507 分支用回复的 `metaJson` 对任务行 `meta_json = COALESCE(?, meta_json)` **整体替换**;任务行的 `meta_json.attachments` 在客户端语义里是「提问者随任务带的附件」,于是回复附件被画到提问者气泡,提问者自己的附件还会被覆盖。

## 改动
- 有回复附件时:读任务行现有 `meta_json`,合并写入 `reply_attachments`;`attachments` 与其他键原样保留。无附件:仍 `COALESCE(NULL, meta_json)` 不动(R-e4 不变)。
- inbox 行(收件方视角)照旧写回复的 `metaJson`(含 attachments 与兄弟字段)。
- `send-reply-attachments.test.ts`:P1/P2/P3 改为断言任务行 `reply_attachments`、`attachments` 为 undefined、回复 meta 的兄弟字段在 inbox 行;新增 **P6**:任务行原有 `attachments` + `origin` 在带附件回复后原样保留。
- 本地 `COMMHUB_DB=<scratch> bun test` 5 个相关文件 48/48(send-reply-attachments / scheduled-run-terminal / peer-reply-atomic / reply-target-derivation / send-reply-agent-warning)。

客户端配套:sleep2agi/agent-network-app#257(回复气泡读 `reply_attachments`)。生效需要 hub 发新 preview 并升级 Vincent 的生产 hub(仍是 0.9.0-preview.45)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD