### PR TITLE
fix(anet): #1832 sibling-first 先 realpath 入口(npm -g 的 bin/anet 是符号链接)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3162,8 +3162,8 @@ let grokAgentNodeLaunchPlan: AgentNodeLaunchPlan | null = null;
 // 返回 null 表示没有(全局散装、或 anet 以源码方式运行),调用方按原逻辑走 PATH / npx。
 function findSiblingAgentNode(): ReturnType<typeof siblingAgentNodeEntrypoint> {
   const entry = process.argv[1] ? resolve(process.argv[1]) : "";
-  return siblingAgentNodeEntrypoint(entry, {
-    exists: (path) => existsSync(path),
+  return siblingAgentNodeEntrypoint(entry, { // #1832 realpath:npm -g 的 bin/anet 是符号链接
+    exists: (path) => existsSync(path), realpath: (path) => realpathSync(path),
     readJson: (path) => JSON.parse(readFileSync(path, "utf8")),
   });
 }

--- a/agent-network/src/sibling-agent-node.test.ts
+++ b/agent-network/src/sibling-agent-node.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join, sep } from "node:path";
-import { binEntryFromPackageJson, nearestNodeModules, siblingAgentNodeEntrypoint, type SiblingFs } from "./sibling-agent-node";
+import { binEntryFromPackageJson, nearestNodeModules, resolveCliEntry, siblingAgentNodeEntrypoint, type SiblingFs } from "./sibling-agent-node";
 
 function fakeFs(files: Record<string, unknown>): SiblingFs {
   return {
@@ -59,5 +59,35 @@ describe("#1808 sibling agent-node", () => {
   test("unreadable package.json → null, never throws", () => {
     const fs: SiblingFs = { exists: () => true, readJson: () => { throw new Error("EACCES"); } };
     expect(siblingAgentNodeEntrypoint(CLI, fs)).toBeNull();
+  });
+
+  // #1832 —— npm -g / --prefix 布局:argv[1] 是 <prefix>/bin/anet 符号链接,真实入口在 lib/node_modules 下。
+  describe("#1832 symlinked bin entry (npm -g / --prefix layout)", () => {
+    const PREFIX = sep === "/" ? "/opt/p" : "C:\\opt\\p";
+    const LINK = join(PREFIX, "bin", "anet");
+    const LIB_NM = join(PREFIX, "lib", "node_modules");
+    const REAL = join(LIB_NM, "@sleep2agi", "agent-network", "dist", "bin", "anet.cjs");
+    const PKG = join(LIB_NM, "@sleep2agi", "agent-node", "package.json");
+    const BIN = join(LIB_NM, "@sleep2agi", "agent-node", "dist", "cli.js");
+    const files = { [PKG]: { version: "2.5.0-preview.66", bin: { "agent-node": "dist/cli.js" } }, [BIN]: "" };
+
+    test("without realpath the symlink layout misses (the #1832 defect shape)", () => {
+      expect(siblingAgentNodeEntrypoint(LINK, fakeFs(files))).toBeNull();
+    });
+
+    test("with realpath the sibling beside the real entry is found", () => {
+      const fs: SiblingFs = { ...fakeFs(files), realpath: (p) => (p === LINK ? REAL : p) };
+      const hit = siblingAgentNodeEntrypoint(LINK, fs);
+      expect(hit).not.toBeNull();
+      expect(hit!.entrypoint).toBe(BIN);
+      expect(hit!.version).toBe("2.5.0-preview.66");
+    });
+
+    test("realpath that throws (dangling link / EACCES) falls back to the given path, never throws", () => {
+      const fs: SiblingFs = { ...fakeFs(files), realpath: () => { throw new Error("ENOENT"); } };
+      expect(resolveCliEntry(LINK, fs)).toBe(LINK);
+      expect(siblingAgentNodeEntrypoint(LINK, fs)).toBeNull();
+      expect(resolveCliEntry("", fs)).toBe("");
+    });
   });
 });

--- a/agent-network/src/sibling-agent-node.ts
+++ b/agent-network/src/sibling-agent-node.ts
@@ -22,6 +22,18 @@ export interface SiblingAgentNode {
 export interface SiblingFs {
   exists(path: string): boolean;
   readJson(path: string): unknown;
+  /**
+   * #1832 —— npm -g / --prefix 布局下 process.argv[1] 是 `<prefix>/bin/anet` 符号链接,真实文件在
+   * `<prefix>/lib/node_modules/@sleep2agi/agent-network/…`;不解析就从 `<prefix>/bin` 往上找不到
+   * node_modules,旁边的 agent-node 永远命不中。可选:不提供或抛错时按传入路径原样找。
+   */
+  realpath?(path: string): string;
+}
+
+/** 入口路径先走 realpath(符号链接 → 真实文件);失败(不存在 / 无权限)退回原路径。 */
+export function resolveCliEntry(cliEntry: string, fs: SiblingFs): string {
+  if (!cliEntry || !fs.realpath) return cliEntry;
+  try { return fs.realpath(cliEntry); } catch { return cliEntry; }
 }
 
 /** 从 anet 入口文件路径往上,返回最近的 `…/node_modules` 目录;找不到返回 null。 */
@@ -50,7 +62,7 @@ export function binEntryFromPackageJson(pkg: unknown): string | null {
 }
 
 export function siblingAgentNodeEntrypoint(cliEntry: string, fs: SiblingFs): SiblingAgentNode | null {
-  const nm = nearestNodeModules(cliEntry);
+  const nm = nearestNodeModules(resolveCliEntry(cliEntry, fs));
   if (!nm) return null;
   const packageDir = join(nm, "@sleep2agi", "agent-node");
   const pkgJsonPath = join(packageDir, "package.json");


### PR DESCRIPTION
Closes #1832。

**缺陷:** `findSiblingAgentNode` 用 `resolve(process.argv[1])` = `<prefix>/bin/anet`(npm 建的符号链接),从 `<prefix>/bin` 往上找不到 `node_modules`,同一 prefix 里装好的 agent-node 永远命不中 → 退到 PATH 上另一棵树的老版本。Vincent 2026-09-07 的 Mac 就是这样让本机 daemon 以普通节点身份注册、进不了 host_supervisor 列表(app#271)。

**修法:** `SiblingFs` 加可选 `realpath`,入口先 `resolveCliEntry`(realpath 失败退回原路径、不抛);`cli.ts` 注入 `realpathSync`。cli.ts 改动不改行数,doc-symbol-pins 本地按 CI 参数跑过。

**测试:** `sibling-agent-node.test.ts` 新增 #1832 组:符号链接布局 无 realpath → null(缺陷形状,见证旧行为);有 realpath → 命中 `lib/node_modules/@sleep2agi/agent-node`;realpath 抛错 → 退回原路径。本地 `bun test` 10 pass。

**真跑验证计划:** 合并并发 preview 后在 DEV 按 issue 里的 `npm install -g --prefix` 布局复跑,期望日志出现「using the agent-node installed beside anet」而不是 npx 提示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD