### PR TITLE
chore(release): agent-network 2.3.0-preview.86(#1832 sibling-first realpath)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.85",
+  "version": "2.3.0-preview.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.85",
+      "version": "2.3.0-preview.86",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.85",
+  "version": "2.3.0-preview.86",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.85";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.86";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.66";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.85 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.86 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.85` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.86` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.85 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.86 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.85`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.86`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.86.md
+++ b/docs/tests/release-v2.3.0-preview.86.md
@@ -1,0 +1,38 @@
+# `@sleep2agi/agent-network@2.3.0-preview.86`
+
+## 为什么发这一版:#1832 sibling-first 在 npm -g / --prefix 布局下终于命中(#1834)
+
+`.85` 的 `findSiblingAgentNode` 用 `resolve(process.argv[1])` = `<prefix>/bin/anet`(npm 建的符号链接),
+从 `<prefix>/bin` 往上找不到 `node_modules`,同一 prefix 里装好的 agent-node **永远命不中**,退到 PATH 上另一棵树的
+老版本。Vincent 2026-09-07 的 Mac 就是这样(nvm v20 的旧 agent-node)让本机 daemon 以普通节点身份注册、进不了
+host_supervisor 列表(app#271)。本版入口先 `realpath`(失败退回原路径、不抛),旁边的 agent-node 才是第一优先。
+
+| 用户看到的 | `.85` | `.86` |
+|---|---|---|
+| `npm i -g --prefix $P @sleep2agi/agent-network @sleep2agi/agent-node` 后 `anet daemon start` / `node start` | 日志「agent-node will be lazy-fetched via npx」或用 PATH 上的旧版 | 日志「using the agent-node installed beside anet (…)」 |
+| 全局散装(旁边没有 agent-node) | PATH → npx | 不变:PATH → npx |
+| 配对 agent-node(`anet node create` 装的) | `2.5.0-preview.66` | `2.5.0-preview.66`(不变) |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.86
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.86
+```
+
+## 验证(发布后在 DEV 真跑)
+
+```bash
+P=$(mktemp -d); npm i -g --prefix "$P" @sleep2agi/agent-network@2.3.0-preview.86 @sleep2agi/agent-node@2.5.0-preview.66
+PATH=$(dirname "$(command -v node)"):/usr/bin:/bin "$P/bin/anet" node start <某个 claude-agent-sdk 节点> 2>&1 | grep -F 'beside anet'
+```
+
+## 边界
+
+- 只改 agent-node 的定位顺序;已在跑的节点不需要重启。`ANET_AGENT_NODE_BIN` 显式指定仍然最高优先。
+- 桌面端本机 daemon 安装器(desktop-v0.2.55)装的是 `@latest`,要等 promote 到 latest 才吃到;0.2.55 自己已用「私有 bin 放 PATH 最前」绕过。


### PR DESCRIPTION
把 #1834 发到 preview 通道。配对 agent-node 不动(2.5.0-preview.66)。

stamps:`agent-network/package.json`、package-lock(×2)、`opencode-agent-node-pair.ts` PAIRED_AGENT_NETWORK_VERSION、getting-started zh/en version-claim,新增 `docs/tests/release-v2.3.0-preview.86.md`(## Install / ## Upgrade / 发布后 DEV 真跑验证)。本地 check-doc-version-claims 按 CI 参数 rc=0。

合并后:`gh workflow run release.yml -f package=agent-network -f version=2.3.0-preview.86 -f publish=true`,绿后在 DEV 按 notes 里的 `--prefix` 布局真跑,期望日志出现「using the agent-node installed beside anet」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD