### PR TITLE
feat(hub): #1828 scope=user 按 agent 分未读(user_inbox + inbox 回复行)+ 用户 ack 覆盖 inbox 回复

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1220,9 +1220,13 @@ curl "http://localhost:9200/api/messages?scope=user&unacked=1&limit=50" \
     }
   ],
   "unread": 3,
-  "pending_count": 3
+  "pending_count": 3,
+  "unread_by_agent": { "代码1号": 2, "通信龙": 3 },
+  "unread_total": 5
 }
 ```
+
+**`unread_by_agent` / `unread_total`(#1828)**:按 `from_session` 分的未读数,来源是**两张表**——`user_inbox`(agent 主动发给用户的,acked=0)加 `inbox` 里 `session_name = 你的用户名`、`type ∈ reply/task/message`、acked=0 的行(agent 对你任务的回复;这些行原本没人 ack)。`unread_total` 是两者之和。客户端角标应优先读 `unread_by_agent`。🔴 你的用户名恰好也是本 scope 内某个节点的 alias 时,`inbox` 那半边**整体不算**(那些行是节点的待办,不是你的)。
 
 🔴 **`unread` 与 `pending_count` 恒等** —— 是**同一个数的两个名字**（`unread` 给角标读，`pending_count` 与上面 alias 分支的字段名保持一致），**一处计算**，不是两处实现。**不要拿它们互相比对**去判断状态。
 
@@ -1263,7 +1267,7 @@ curl -X POST "http://localhost:9200/api/messages/ack" \
 
 **请求体**：`{"message_id": "dm_x"}` 或 `{"message_ids": ["dm_x", "dm_y"]}`（二选一，后者**上限 500 条**）。
 
-**响应**：`{"ok": true, "acked": 2}` —— `acked` 是**实际改动的行数**，不是你传了几个 id。已经 ack 过的、不属于你的、不存在的，都不计入。
+**响应**：`{"ok": true, "acked": 2, "acked_user_inbox": 1, "acked_inbox": 1}` —— `acked` 是**实际改动的行数**（两张表之和；#1828 起同一批 id 也会 ack `inbox` 里发给你用户名的 `reply/task/message` 行，即 agent 对你任务的回复；用户名与节点 alias 撞名时 `inbox` 半边跳过），不是你传了几个 id。已经 ack 过的、不属于你的、不存在的，都不计入。
 
 **错误**：
 

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -1171,9 +1171,13 @@ curl "http://localhost:9200/api/messages?scope=user&unacked=1&limit=50" \
     }
   ],
   "unread": 3,
-  "pending_count": 3
+  "pending_count": 3,
+  "unread_by_agent": { "代码1号": 2, "通信龙": 3 },
+  "unread_total": 5
 }
 ```
+
+**`unread_by_agent` / `unread_total`** (#1828): unread counts keyed by `from_session`, drawn from **two tables** — `user_inbox` (agent-initiated messages to you, acked=0) plus the `inbox` rows with `session_name = your username`, `type ∈ reply/task/message`, acked=0 (agent replies to your tasks; nobody used to ack those). `unread_total` is their sum. Badge clients should prefer `unread_by_agent`. 🔴 If your username happens to also be a node alias inside this scope, the `inbox` half is **skipped entirely** (those rows are that node's work queue, not yours).
 
 🔴 **`unread` and `pending_count` are always equal** — they are **two names for one number** (`unread` reads naturally for a badge; `pending_count` matches the field name used by the alias branch above). It is computed **once**, not twice. **Do not compare them against each other** to infer state.
 
@@ -1214,7 +1218,7 @@ curl -X POST "http://localhost:9200/api/messages/ack" \
 
 **Body**: either `{"message_id": "dm_x"}` or `{"message_ids": ["dm_x", "dm_y"]}` (the latter **capped at 500**).
 
-**Response**: `{"ok": true, "acked": 2}` — `acked` is the number of rows **actually changed**, not how many ids you sent. Rows already acked, not yours, or nonexistent do not count.
+**Response**: `{"ok": true, "acked": 2, "acked_user_inbox": 1, "acked_inbox": 1}` — `acked` is the number of rows **actually changed** (sum over both tables; since #1828 the same ids also ack `inbox` rows addressed to your username with `type ∈ reply/task/message`, i.e. agent replies to your tasks; the `inbox` half is skipped when your username collides with a node alias), not how many ids you sent. Rows already acked, not yours, or nonexistent do not count.
 
 **Errors**:
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2637,6 +2637,15 @@ return Bun.serve({
       }
     }
 
+    // #1828 —— 用户名与某个节点 alias 撞名时,inbox 里 session_name=用户名 的行属于那个节点,
+    //    不能当成用户的未读、也不能替它 ack。只看当前 REST scope 内的节点。
+    const userInboxAliasCollides = (username: string, scope: RestNetworkScope): boolean => {
+      const p: any[] = [username];
+      let q = "SELECT 1 AS hit FROM nodes WHERE alias = ?1";
+      q = addNetworkScope(q, p, scope);
+      return !!db.get<{ hit: number }>(q + " LIMIT 1", ...p);
+    };
+
     // ── REST: per-user desktop inbox (#1459 ① P3) ──
     // 🔴 只在 ?scope=user 时走这条；下面按 alias 寻址的既有分支一行未动
     //    （dashboard 依赖那条 inbox 查询）。
@@ -2667,6 +2676,27 @@ return Bun.serve({
       countSql = addNetworkScope(countSql, countParams, restScope);
       const unread = db.get<{ cnt: number }>(countSql, ...countParams)?.cnt ?? 0;
 
+      // #1828 —— 按 agent 分的未读:user_inbox(agent 主动发给用户)+ inbox 里发给**这个用户名**的
+      //    reply/task/message 行(agent 对用户任务的回复;acked 从来没人置 1,见 app#260)。
+      //    `unread`/`pending_count` 口径不动(只算 user_inbox,qa-hub-14 钉着);两表之和另给 `unread_total`。
+      //    🔴 用户名恰好也是某个节点 alias 时,inbox 里那些行是节点的待办,不是用户的 —— 跳过 inbox 半边。
+      const byAgent: Record<string, number> = {};
+      const addByAgent = (agentRows: Array<{ agent: string | null; n: number }>) => {
+        for (const r of agentRows) byAgent[r.agent || "hub"] = (byAgent[r.agent || "hub"] ?? 0) + Number(r.n ?? 0);
+      };
+      const uiAgentParams: any[] = [callerUserId];
+      let uiAgentSql = "SELECT from_session AS agent, COUNT(*) AS n FROM user_inbox WHERE user_id = ?1 AND acked = 0";
+      uiAgentSql = addNetworkScope(uiAgentSql, uiAgentParams, restScope);
+      addByAgent(db.all<{ agent: string | null; n: number }>(uiAgentSql + " GROUP BY from_session", ...uiAgentParams));
+      const callerUsername = restAuth?.username ?? "";
+      if (callerUsername && !userInboxAliasCollides(callerUsername, restScope)) {
+        const ibParams: any[] = [callerUsername];
+        let ibSql = "SELECT from_session AS agent, COUNT(*) AS n FROM inbox WHERE session_name = ?1 AND acked = 0 AND type IN ('reply', 'task', 'message')";
+        ibSql = addNetworkScope(ibSql, ibParams, restScope);
+        addByAgent(db.all<{ agent: string | null; n: number }>(ibSql + " GROUP BY from_session", ...ibParams));
+      }
+      const unreadTotal = Object.values(byAgent).reduce((a, b) => a + b, 0);
+
       // 🔴 redact-at-read：写入方是 agent，不受信任。存储侧已做跨主机路径脱敏，
       //    这一层单独防"有人把凭据塞进正文/标题/meta"。
       const messages = rows.map(redactMessageRow);
@@ -2678,6 +2708,8 @@ return Bun.serve({
         // 同一个数的两个名字：`unread` 给角标读，`pending_count` 与 alias 分支
         // 的字段名保持一致。**一处计算**，不是两处实现。
         pending_count: unread,
+        unread_by_agent: byAgent,
+        unread_total: unreadTotal,
       }));
     }
 
@@ -2733,7 +2765,19 @@ return Bun.serve({
                  WHERE user_id = ?1 AND message_id IN (${placeholders}) AND acked = 0`;
       sql = addNetworkScope(sql, params, restScope);
       const res = db.run(sql, params);
-      return withCors(req, Response.json({ ok: true, acked: res.changes ?? 0 }));
+      // #1828 —— 同一批 id 也可能是 inbox 里发给这个用户名的 reply/task/message 行(agent 回复);
+      //    用户看过就 ack 掉。只动 session_name = 调用者用户名 的行,别人的 id 匹配不到;
+      //    用户名与节点 alias 撞名时跳过(那是节点的待办)。
+      let inboxAcked = 0;
+      const callerUsername = restAuth?.username ?? "";
+      if (callerUsername && !userInboxAliasCollides(callerUsername, restScope)) {
+        const ibParams: any[] = [callerUsername, ...ids];
+        let ibSql = `UPDATE inbox SET acked = 1
+                     WHERE session_name = ?1 AND id IN (${placeholders}) AND acked = 0 AND type IN ('reply', 'task', 'message')`;
+        ibSql = addNetworkScope(ibSql, ibParams, restScope);
+        inboxAcked = db.run(ibSql, ibParams).changes ?? 0;
+      }
+      return withCors(req, Response.json({ ok: true, acked: (res.changes ?? 0) + inboxAcked, acked_user_inbox: res.changes ?? 0, acked_inbox: inboxAcked }));
     }
 
     // ── REST: stats summary ──

--- a/server/src/user-inbox-by-agent-http.test.ts
+++ b/server/src/user-inbox-by-agent-http.test.ts
@@ -1,0 +1,161 @@
+// #1828 —— /api/messages?scope=user 按 agent 分的未读 + 用户 ack 覆盖 inbox 里的回复行。
+//
+// 生产 hub 24h:admin 收到的 70 条 agent 回复全在 `inbox`(session_name='admin', type='reply',
+// acked 永远 0),`user_inbox` 只有 2 行;角标链只读 user_inbox,所以回复从不进未读(app#260)。
+// 这里让 scope=user 同时给 `unread_by_agent`(两表合并)与 `unread_total`,`unread`/`pending_count`
+// 口径不动(qa-hub-14 钉着);POST /api/messages/ack 也能 ack inbox 里发给调用者用户名的回复行。
+//
+// 承重的是两条边界:
+//   ① 只算/只 ack **调用者自己用户名** 的 inbox 行 —— B 拿 A 的 id 来 ack 匹配不到;
+//   ② 用户名与某节点 alias 撞名时,inbox 那半边整体跳过(那是节点的待办,不是用户的)。
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-user-inbox-by-agent-"));
+process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
+
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let aToken = "", bToken = "", cToken = "";
+let aUserId = "", bUserId = "", cUserId = "", aNet = "", cNet = "";
+let aName = "", bName = "", cName = "";
+
+const get = async (path: string, token: string) => {
+  const r = await fetch(`${base}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+  return { status: r.status, body: await r.json() as any };
+};
+const post = async (path: string, token: string, body: unknown) => {
+  const r = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json() as any };
+};
+
+function seedUserInbox(mid: string, userId: string, netId: string, from: string) {
+  const { db } = require("./db.js");
+  db.run(
+    `INSERT INTO user_inbox (message_id, network_id, user_id, from_session, kind, title, content, severity, meta_json, acked)
+     VALUES (?1, ?2, ?3, ?4, 'agent_message', NULL, 'dm', 'info', NULL, 0)`,
+    [mid, netId, userId, from],
+  );
+}
+function seedInbox(id: string, sessionName: string, netId: string, from: string, type = "reply", acked = 0) {
+  const { db } = require("./db.js");
+  db.run(
+    `INSERT INTO inbox (id, session_name, type, priority, content, from_session, acked, network_id, created_at)
+     VALUES (?1, ?2, ?3, 'normal', 'reply body', ?4, ?5, ?6, datetime('now'))`,
+    [id, sessionName, type, from, acked, netId],
+  );
+}
+
+beforeAll(async () => {
+  process.env.COMMHUB_AUTH_TOKEN ||= "legacy-master-token-for-test";
+  const { db } = await import("./db.js");
+  const { register, addNetworkMember } = await import("./auth.js");
+  const stamp = Date.now();
+
+  // 首个注册用户 = 全局 admin;探针 A/B/C 都不是 admin(admin 走不过滤分支,隔离断言会白过)。
+  const admin = register(`uba_admin_${stamp}`, "UbaAdmin-Strong-1!");
+  expect(admin.ok).toBe(true);
+  aName = `uba_a_${stamp}`; bName = `uba_b_${stamp}`; cName = `uba_c_${stamp}`;
+  const a = register(aName, "UbaA-Strong-1!");
+  const b = register(bName, "UbaB-Strong-1!");
+  const c = register(cName, "UbaC-Strong-1!");
+  expect(a.ok && b.ok && c.ok).toBe(true);
+  aToken = a.token!; bToken = b.token!; cToken = c.token!;
+  aNet = a.network_id!; cNet = c.network_id!;
+  const uid = (name: string) => db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", name)!.user_id;
+  aUserId = uid(aName); bUserId = uid(bName); cUserId = uid(cName);
+  for (const id of [aUserId, bUserId, cUserId]) {
+    expect(db.get<{ role: string }>("SELECT role FROM users WHERE user_id = ?1", id)?.role).toBe("user");
+  }
+  // B 与 A 同网:user_id / session_name 过滤是唯一的隔离手段。
+  expect(addNetworkMember(aNet, bUserId, "member").ok).toBe(true);
+
+  // A:user_inbox 两条(node-x),inbox 回复两条(peer-1)+ 一条已 ack + 一条 status 类(不算)。
+  seedUserInbox("dm_a1", aUserId, aNet, "node-x");
+  seedUserInbox("dm_a2", aUserId, aNet, "node-x");
+  seedInbox("ib_a1", aName, aNet, "peer-1");
+  seedInbox("ib_a2", aName, aNet, "peer-1");
+  seedInbox("ib_a_acked", aName, aNet, "peer-1", "reply", 1);
+  seedInbox("ib_a_status", aName, aNet, "peer-1", "status");
+  // B 同网:自己的一条回复;不该出现在 A 的数里。
+  seedInbox("ib_b1", bName, aNet, "peer-2");
+  // C:用户名撞节点 alias —— inbox 里那行是节点的待办。
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at)
+     VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))`,
+    [`node_${stamp}`, cName, cName, cNet],
+  );
+  seedInbox("ib_c_node_task", cName, cNet, "leader", "task");
+  seedUserInbox("dm_c1", cUserId, cNet, "node-y");
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("#1828 GET /api/messages?scope=user unread_by_agent", () => {
+  test("A:user_inbox + inbox 回复按 agent 合并;unread/pending_count 口径不变", async () => {
+    const { status, body } = await get("/api/messages?scope=user", aToken);
+    expect(status).toBe(200);
+    expect(body.unread).toBe(2);                 // 只算 user_inbox(qa-hub-14 钉着)
+    expect(body.pending_count).toBe(2);
+    expect(body.unread_by_agent).toEqual({ "node-x": 2, "peer-1": 2 }); // 已 ack 与 status 类不算
+    expect(body.unread_total).toBe(4);
+  });
+
+  test("B(同网):只看到自己的回复,看不到 A 的", async () => {
+    const { body } = await get("/api/messages?scope=user", bToken);
+    expect(body.unread_by_agent).toEqual({ "peer-2": 1 });
+    expect(body.unread_total).toBe(1);
+  });
+
+  test("🔴 C 的用户名撞节点 alias:inbox 半边整体跳过,只剩 user_inbox", async () => {
+    const { body } = await get("/api/messages?scope=user", cToken);
+    expect(body.unread_by_agent).toEqual({ "node-y": 1 });
+    expect(body.unread_total).toBe(1);
+  });
+});
+
+describe("#1828 POST /api/messages/ack covers inbox reply rows", () => {
+  test("🔴 B 拿 A 的 inbox id 来 ack:匹配不到,A 的数不动", async () => {
+    const { body } = await post("/api/messages/ack", bToken, { message_ids: ["ib_a1"] });
+    expect(body).toMatchObject({ ok: true, acked: 0, acked_inbox: 0 });
+    const a = await get("/api/messages?scope=user", aToken);
+    expect(a.body.unread_by_agent["peer-1"]).toBe(2);
+  });
+
+  test("A ack 一条 inbox 回复 + 一条 user_inbox:两边各减一,响应分开计数", async () => {
+    const { body } = await post("/api/messages/ack", aToken, { message_ids: ["ib_a1", "dm_a1"] });
+    expect(body).toMatchObject({ ok: true, acked: 2, acked_user_inbox: 1, acked_inbox: 1 });
+    const a = await get("/api/messages?scope=user", aToken);
+    expect(a.body.unread).toBe(1);
+    expect(a.body.unread_by_agent).toEqual({ "node-x": 1, "peer-1": 1 });
+    expect(a.body.unread_total).toBe(2);
+    // 再 ack 同一条:幂等,0 行。
+    const again = await post("/api/messages/ack", aToken, { message_ids: ["ib_a1"] });
+    expect(again.body.acked).toBe(0);
+  });
+
+  test("status 类 inbox 行不会被用户 ack 掉(不是发给用户的消息)", async () => {
+    const { body } = await post("/api/messages/ack", aToken, { message_ids: ["ib_a_status"] });
+    expect(body.acked_inbox).toBe(0);
+  });
+
+  test("🔴 C 撞名:节点的待办不能被用户 ack 走", async () => {
+    const { body } = await post("/api/messages/ack", cToken, { message_ids: ["ib_c_node_task"] });
+    expect(body.acked_inbox).toBe(0);
+    const { db } = require("./db.js");
+    expect(db.get<{ acked: number }>("SELECT acked FROM inbox WHERE id = 'ib_c_node_task'")?.acked).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1828(配套 app#260 / app#275:客户端拿到权威数后退位)。

**读:** `GET /api/messages?scope=user` 新增 `unread_by_agent`(`{from_session: n}`,= user_inbox acked=0 + inbox 里 `session_name = 调用者用户名`、`type ∈ reply/task/message`、acked=0 的行)和 `unread_total`。`unread`/`pending_count` **口径不变**(只算 user_inbox;`tests/qa-hub-14-user-unread` 钉着 0→1)。

**写:** `POST /api/messages/ack` 同一批 id 也 ack inbox 里发给调用者用户名的回复行;响应 `acked` = 两表之和,另给 `acked_user_inbox` / `acked_inbox`。

**边界:** 用户名恰好也是 scope 内某节点的 alias 时,inbox 那半边整体跳过(读不算、写不 ack)—— 那些行是节点的待办。

**测试:** `server/src/user-inbox-by-agent-http.test.ts` 7 用例(bootServer 真 HTTP):合并数、同网 B 只见自己的、撞名只剩 user_inbox、B 拿 A 的 inbox id ack 到 0 行、A ack 两表各减一且幂等、status 行不被 ack、撞名节点待办不被 ack。变异:去掉撞名守卫 → 2 红;去掉 `session_name = ?1` → 2 红;恢复 7/7。doc-symbol-pins 两种参数 rc=0。server tsc 的 54 个既有错误全在 *.test.ts,server.ts 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD