### PR TITLE
chore(release): commhub-server 0.9.0-preview.51(#1828 按 agent 分未读 + ack 覆盖 inbox 回复)

### DIFF
--- a/docs/tests/release-v0.9.0-preview.51.md
+++ b/docs/tests/release-v0.9.0-preview.51.md
@@ -1,0 +1,38 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.51`
+
+## 为什么发这一版:**agent 的回复终于进未读角标,而且按 agent 分**(#1828)
+
+`.50` 之后 `server/src` 一个功能提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `d76b7f65` | #1838 | **#1828** —— `GET /api/messages?scope=user` 新增 `unread_by_agent`(user_inbox acked=0 + inbox 里 `session_name = 调用者用户名`、`type ∈ reply/task/message`、acked=0 的行,按 from_session 分)与 `unread_total`;`POST /api/messages/ack` 同一批 id 也 ack inbox 里发给调用者用户名的回复行,响应加 `acked_user_inbox` / `acked_inbox`;用户名与节点 alias 撞名时 inbox 半边整体跳过 |
+
+`unread` / `pending_count` 口径**不变**(只算 user_inbox;`tests/qa-hub-14-user-unread` 钉着)。
+
+| 用户看到的 | `.50` | `.51` + 桌面端 ≥ 0.2.58(app#278) |
+|---|---|---|
+| agent 回复了你的任务,你没看 | 角标靠客户端本地水位线估算(重装/换机就丢) | hub 权威数,按 agent 分,换机一致 |
+| 你在聊天窗看到底 | 只推进本地水位线 | 同时向 hub ack(两表),别的设备也清零 |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.51
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.51
+# 生产 hub 走 deploy/hub/README.md 的六步(改 launcher 的 RUNTIME_DIR 那一行,pm2 restart),不要整文件覆盖
+```
+
+## 证据
+
+- `server/src/user-inbox-by-agent-http.test.ts` 7 用例(bootServer 真 HTTP):合并数、同网隔离、撞名跳过、B 拿 A 的 id ack 到 0 行、两表分开计数且幂等、status 行不 ack、撞名节点待办不 ack。变异:去掉撞名守卫 2 红;去掉 `session_name = ?1` 2 红。
+- `user-inbox-read-http.test.ts` 13/13 不变;doc-symbol-pins 两种参数 rc=0;`docs-site/docs/api/rest.md` zh/en 已写新字段。
+
+## promote 时的 must_contain
+
+`"version": "0.9.0-preview.51"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.50",
+  "version": "0.9.0-preview.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.50",
+      "version": "0.9.0-preview.51",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.50",
+  "version": "0.9.0-preview.51",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
把 #1838 发到 preview。stamps:server/package.json + package-lock;新增 docs/tests/release-v0.9.0-preview.51.md(Install/Upgrade/证据/must_contain)。合并后 `gh workflow run release.yml -f package=commhub-server -f version=0.9.0-preview.51 -f publish=true`;生产 hub 升级等 Vincent 一声「升」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD