### PR TITLE
feat(hub): GET /api/node-create-requests?request_id= —— 向导能看到 daemon 回的 create 失败原因

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1252,6 +1252,27 @@ curl "http://localhost:9200/api/messages?scope=user&unacked=1&limit=50" \
 
 ---
 
+### GET /api/node-create-requests
+
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
+
+读一条 `create_node` 请求的结果 —— daemon 通过 `ack_create_request` 写回的 `status` / `error`。桌面向导用它把「子节点起不来」的原因显示出来,而不是只等注册超时。
+
+```bash
+curl "http://localhost:9200/api/node-create-requests?request_id=cr_59723b24-…" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+**响应**:`{"ok":true,"request":{"request_id","daemon_node_id","child_name","network_id","runtime","model","status","error","created_at","delivered_at","acked_at"}}`。`status` ∈ `pending` / `delivered` / `started` / `failed` / `rejected` / `runtime_capability_check_failed`;`error` 是 daemon 回的原文(最长 1000 字),没有则 `null`。
+
+| 状态 | 响应 | 何时 |
+|---|---|---|
+| 401 | `{"ok":false,"error":"auth_required"}` | 没有用户上下文 |
+| 400 | `{"ok":false,"error":"request_id_required"}` | 缺 `request_id` |
+| 404 | `{"ok":false,"error":"request_not_found"}` | 不存在,**或不在你的网络作用域内**(两者同形,不泄漏别的网络有没有这个 id) |
+
+---
+
 ### POST /api/messages/ack
 
 > [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · 自 `0.9.0-preview.41` 起

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -1203,6 +1203,27 @@ Replaced with `<prefix>***redacted***` — **the prefix is kept** so the reader 
 
 ---
 
+### GET /api/node-create-requests
+
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
+
+Read the outcome of one `create_node` request — the `status` / `error` the daemon wrote back via `ack_create_request`. The desktop wizard uses it to show *why* a child node did not come up instead of only timing out on registration.
+
+```bash
+curl "http://localhost:9200/api/node-create-requests?request_id=cr_59723b24-…" \
+  -H "Authorization: Bearer utok_xxx"
+```
+
+**Response**: `{"ok":true,"request":{"request_id","daemon_node_id","child_name","network_id","runtime","model","status","error","created_at","delivered_at","acked_at"}}`. `status` ∈ `pending` / `delivered` / `started` / `failed` / `rejected` / `runtime_capability_check_failed`; `error` is the daemon's text verbatim (≤ 1000 chars) or `null`.
+
+| Status | Response | When |
+|---|---|---|
+| 401 | `{"ok":false,"error":"auth_required"}` | no user context |
+| 400 | `{"ok":false,"error":"request_id_required"}` | `request_id` missing |
+| 404 | `{"ok":false,"error":"request_not_found"}` | nonexistent **or outside your network scope** (same shape, so other networks' ids are not probeable) |
+
+---
+
 ### POST /api/messages/ack
 
 > [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · since `0.9.0-preview.41`

--- a/server/src/node-create-request-status-http.test.ts
+++ b/server/src/node-create-request-status-http.test.ts
@@ -1,0 +1,92 @@
+// 桌面向导要看得到 daemon 回的失败原因:GET /api/node-create-requests?request_id=…
+// 承重:① 只在调用者的网络作用域里能读到(别的网络 → 404,与不存在同形);② 无用户上下文 401;③ 缺参 400;
+// ④ 回的是 daemon ack 写进去的 status/error 原文。
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-create-request-status-"));
+process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
+
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let aToken = "", bToken = "", aNet = "", bNet = "";
+const MASTER_TOKEN = "legacy-master-token-for-test";
+
+const get = async (path: string, token: string) => {
+  const r = await fetch(`${base}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+  return { status: r.status, body: await r.json() as any };
+};
+
+beforeAll(async () => {
+  process.env.COMMHUB_AUTH_TOKEN ||= MASTER_TOKEN;
+  const { db } = await import("./db.js");
+  const { register } = await import("./auth.js");
+  const stamp = Date.now();
+  const admin = register(`cr_admin_${stamp}`, "CrAdmin-Strong-1!");
+  expect(admin.ok).toBe(true);
+  const a = register(`cr_a_${stamp}`, "CrA-Strong-1!");
+  const b = register(`cr_b_${stamp}`, "CrB-Strong-1!");
+  expect(a.ok && b.ok).toBe(true);
+  aToken = a.token!; bToken = b.token!; aNet = a.network_id!; bNet = b.network_id!;
+  const uid = (name: string) => db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", name)!.user_id;
+  for (const id of [uid(`cr_a_${stamp}`), uid(`cr_b_${stamp}`)]) {
+    expect(db.get<{ role: string }>("SELECT role FROM users WHERE user_id = ?1", id)?.role).toBe("user");
+  }
+  db.run(
+    `INSERT INTO node_create_requests
+       (request_id, daemon_node_id, child_name, network_id, runtime, model, flags_json, env_keys, status, child_token_id, created_at, created_by_token, acked_at, error)
+     VALUES ('cr_a_failed', 'node_daemon_a', 'vansin-go', ?1, 'opencode-cli', NULL, '{}', '[]', 'failed', NULL, ?2, 'tok', ?2,
+             'opencode-cli package entrypoint verification currently requires Linux')`,
+    [aNet, Date.now()],
+  );
+  db.run(
+    `INSERT INTO node_create_requests
+       (request_id, daemon_node_id, child_name, network_id, runtime, model, flags_json, env_keys, status, child_token_id, created_at, created_by_token)
+     VALUES ('cr_b_pending', 'node_daemon_b', 'other', ?1, 'codex-app-server', NULL, '{}', '[]', 'pending', NULL, ?2, 'tok')`,
+    [bNet, Date.now()],
+  );
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("GET /api/node-create-requests?request_id=", () => {
+  test("A reads her own failed request with the daemon's error verbatim", async () => {
+    const { status, body } = await get("/api/node-create-requests?request_id=cr_a_failed", aToken);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.request).toMatchObject({
+      request_id: "cr_a_failed", child_name: "vansin-go", runtime: "opencode-cli", status: "failed",
+      error: "opencode-cli package entrypoint verification currently requires Linux",
+    });
+  });
+  test("🔴 B cannot read A's request — 404, same shape as nonexistent", async () => {
+    const other = await get("/api/node-create-requests?request_id=cr_a_failed", bToken);
+    const missing = await get("/api/node-create-requests?request_id=cr_nope", bToken);
+    expect(other.status).toBe(404);
+    expect(missing.status).toBe(404);
+    expect(other.body).toEqual(missing.body);
+  });
+  test("pending request reads as pending with no error", async () => {
+    const { body } = await get("/api/node-create-requests?request_id=cr_b_pending", bToken);
+    expect(body.request.status).toBe("pending");
+    expect(body.request.error).toBeNull();
+  });
+  test("missing request_id → 400", async () => {
+    const { status, body } = await get("/api/node-create-requests", aToken);
+    expect(status).toBe(400);
+    expect(body.error).toBe("request_id_required");
+  });
+  test("legacy master token (no user context) → 401", async () => {
+    const { status, body } = await get("/api/node-create-requests?request_id=cr_a_failed", MASTER_TOKEN);
+    expect(status).toBe(401);
+    expect(body.error).toBe("auth_required");
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3120,6 +3120,31 @@ return Bun.serve({
     // Mirror of the `list_host_supervisors` MCP tool for non-MCP callers.
     // Same SQL + role-extract + member-脱敏 logic; SEC-1 scoped via REST
     // auth pipeline (restScope). Returns {ok, daemons:[...], count}.
+    // ── REST: one node_create_request's outcome (app#… 桌面向导) ──
+    // 向导 POST create_node 后只会轮询「子节点注册了没」,daemon 回的失败原因(ack_create_request 写进
+    // node_create_requests.status/error)此前没有任何读接口 —— 用户只看到「24s 没注册」。
+    // 这里按 request_id 读一行;网络作用域与其它 REST 相同(addNetworkScope),无用户上下文 401。
+    if (url.pathname === "/api/node-create-requests" && req.method === "GET") {
+      if (!restAuth) {
+        return withCors(req, Response.json({ ok: false, error: "auth_required" }, { status: 401 }));
+      }
+      const requestId = url.searchParams.get("request_id")?.trim() ?? "";
+      if (!requestId) {
+        return withCors(req, Response.json({ ok: false, error: "request_id_required" }, { status: 400 }));
+      }
+      const params: any[] = [requestId];
+      let sql = `SELECT request_id, daemon_node_id, child_name, network_id, runtime, model, status, error,
+                        created_at, delivered_at, acked_at
+                 FROM node_create_requests WHERE request_id = ?1`;
+      sql = addNetworkScope(sql, params, restScope);
+      const row = db.get<Record<string, unknown>>(sql, ...params);
+      if (!row) {
+        // 不存在与不在你作用域内长一样:不泄漏别的网络里有没有这个 id。
+        return withCors(req, Response.json({ ok: false, error: "request_not_found" }, { status: 404 }));
+      }
+      return withCors(req, Response.json({ ok: true, request: row }));
+    }
+
     if (url.pathname === "/api/host-supervisors") {
       // #380 — utok callers with exactly one accessible network get a
       // safe fallback so the create-node wizard doesn't have to bake


### PR DESCRIPTION
Vincent 2026-09-07 在 Mac 上用桌面向导建 opencode-cli 共存节点:向导只显示「已下发,但 24s 内未看到子节点注册」;真因是 anet 的 opencode 校验 Linux-only(#1222),daemon 用 `ack_create_request` 把 status=failed + error 写进了 `node_create_requests`,但**没有任何读接口**,客户端看不到。

- 新增 `GET /api/node-create-requests?request_id=<id>`:返回该行的 request_id / daemon_node_id / child_name / network_id / runtime / model / status / error / created_at / delivered_at / acked_at;`addNetworkScope` 与其它 REST 同;不存在与不在作用域内同形 404(不泄漏别网 id);无用户上下文 401;缺参 400
- `node-create-request-status-http.test.ts` 5 用例(bootServer 真 HTTP:本网读到原文 error、别网 404 与不存在同形、pending 无 error、400、401)
- docs-site `api/rest.md` zh/en 补一节;doc-symbol-pins 两种参数、docs-integrity、channel-assertions 本地 rc=0

配套:桌面向导轮询它并直接显示原因(app PR 随后);桌面 Local workspace 要吃到得等捆绑 Hub pin 从 .45 抬到含本 PR 的版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD