### PR TITLE
chore(release): commhub-server 0.9.0-preview.52(#1843 向导可读 create 失败原因)

### DIFF
--- a/docs/tests/release-v0.9.0-preview.52.md
+++ b/docs/tests/release-v0.9.0-preview.52.md
@@ -1,0 +1,35 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.52`
+
+## 为什么发这一版:**桌面向导能看到 daemon 回的「为什么建不起来」**(#1843)
+
+`.51` 之后 `server/src` 一个功能提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `bf643241` | #1843 | 新增 `GET /api/node-create-requests?request_id=`:读一条 create_node 请求的 status / error(daemon 通过 `ack_create_request` 写回);网络作用域同其它 REST;不存在与不在作用域同形 404;无用户上下文 401;缺参 400 |
+
+| 用户看到的 | `.51` | `.52` + 桌面端 ≥ 0.2.60(app#286) |
+|---|---|---|
+| 向导建节点、daemon 起不来 | 「已下发,但 24s 内未看到子节点注册」 | 立刻显示 daemon 回的原因(如 opencode-cli 校验 Linux-only) |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.52
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.52
+# 生产 hub 走 deploy/hub/README.md 的六步(改 launcher 的 RUNTIME_DIR 那一行,pm2 restart),不要整文件覆盖
+```
+
+## 证据
+
+- `server/src/node-create-request-status-http.test.ts` 5 用例(bootServer 真 HTTP):本网读到 error 原文、别网 404 与不存在同形、pending 无 error、400、401。
+- `docs-site/docs/api/rest.md` zh/en 已写该接口;doc-symbol-pins / docs-integrity / channel-assertions 本地 rc=0。
+
+## promote 时的 must_contain
+
+`"version": "0.9.0-preview.52"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.51",
+  "version": "0.9.0-preview.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.51",
+      "version": "0.9.0-preview.52",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.51",
+  "version": "0.9.0-preview.52",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
把 #1843 发到 preview。stamps:server/package.json + package-lock;新增 docs/tests/release-v0.9.0-preview.52.md。合并后 `gh workflow run release.yml -f package=commhub-server -f version=0.9.0-preview.52 -f publish=true`;随后桌面端把捆绑 Hub pin 抬到 .52(另开)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD