### PR TITLE
feat(anet): #1845 层① opencode 包身份校验放开 darwin(平台门可注入,win32 仍拦)

### DIFF
--- a/agent-network/src/opencode-package-binary.test.ts
+++ b/agent-network/src/opencode-package-binary.test.ts
@@ -11,6 +11,7 @@ import {
 import { join } from "path";
 import {
   discoverOpencodeForbiddenRoots,
+  opencodeVerifierSupportsPlatform,
   resolveOpencodePackageBinaryFromPath,
   validateOpencodePackageBinary,
 } from "./opencode-package-binary";
@@ -253,5 +254,23 @@ describe("#739 cwd 参与信任判定", () => {
       expectedVersion: "1.18.1",
       forbiddenRoots: [project],
     })).toThrow("project/node-local");
+  });
+});
+
+// #1845 层① —— 平台门:linux / darwin 放行,win32 仍拦。用注入的 platform 在 Linux CI 上测三种分支;
+// 平台门在扫 PATH 之前,所以 win32 的拒绝与 PATH 内容无关(空 PATH 也拒的是平台,不是「没找到」)。
+describe("#1845 platform gate", () => {
+  test("linux and darwin are accepted, win32 is not", () => {
+    expect(opencodeVerifierSupportsPlatform("linux")).toBe(true);
+    expect(opencodeVerifierSupportsPlatform("darwin")).toBe(true);
+    expect(opencodeVerifierSupportsPlatform("win32")).toBe(false);
+  });
+  test("win32 is refused before PATH is scanned, naming the platform", () => {
+    expect(() => resolveOpencodePackageBinaryFromPath("", { expectedVersion: "1.18.1" }, "win32"))
+      .toThrow(/requires Linux or macOS \(got win32\)/);
+  });
+  test("darwin reaches the PATH scan (empty PATH → not-found, not a platform error)", () => {
+    expect(() => resolveOpencodePackageBinaryFromPath("", { expectedVersion: "1.18.1" }, "darwin"))
+      .toThrow(/no trusted exact opencode-ai package entrypoint found on PATH/);
   });
 });

--- a/agent-network/src/opencode-package-binary.ts
+++ b/agent-network/src/opencode-package-binary.ts
@@ -232,12 +232,22 @@ export function validateOpencodePackageBinary(
 
 /** Resolve the first *valid package-owned* OpenCode entry on PATH. Invalid
  * project-local shims are skipped so a later trusted global install can win. */
+/** #1845 层① —— 包身份校验只依赖 POSIX 的 lstat/uid/mode 语义,darwin 与 linux 等价
+ * (2026-09-07 Mac mini 真跑:home 前缀 npm 安装 → VALIDATE_OK;/tmp 下祖先 1777 仍被拒)。
+ * win32 没有 uid、也没有 0o111 可执行位,继续拦。平台可注入,便于在 Linux CI 上测三种分支。 */
+export const OPENCODE_VERIFIER_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
+
+export function opencodeVerifierSupportsPlatform(platform: NodeJS.Platform = process.platform): boolean {
+  return OPENCODE_VERIFIER_PLATFORMS.has(platform);
+}
+
 export function resolveOpencodePackageBinaryFromPath(
   searchPath: string,
   options: ValidateOpencodePackageBinaryOptions,
+  platform: NodeJS.Platform = process.platform,
 ): string {
-  if (process.platform !== "linux") {
-    throw new Error("opencode-cli package entrypoint verification currently requires Linux");
+  if (!opencodeVerifierSupportsPlatform(platform)) {
+    throw new Error(`opencode-cli package entrypoint verification currently requires Linux or macOS (got ${platform})`);
   }
   const rejected: string[] = [];
   for (const rawDir of searchPath.split(delimiter)) {


### PR DESCRIPTION
#1845 三层里的第一层。

- `resolveOpencodePackageBinaryFromPath` 的 `platform !== \"linux\"` → `opencodeVerifierSupportsPlatform(platform)`(linux / darwin),`platform` 形参默认 `process.platform`;win32 仍在扫 PATH 之前拒,并把平台名写进报错
- **校验规则逐字不动**:canonical 包路径、祖先/文件 owner-mode、可执行位、forbidden roots、package.json 无跟随读取、精确版本身份
- 依据:2026-09-07 Mac mini(uid 501)真跑同一份源码 —— home 前缀 `npm i -g --prefix` 安装的 opencode-ai → `validateOpencodePackageBinary` OK;/tmp 前缀因祖先 1777 仍被拒(#1222 评论有全链 stat)
- 测试:`opencode-package-binary.test.ts` +3(linux/darwin 放行、win32 拒且与 PATH 无关、darwin 走到 PATH 扫描 → not-found);16/16;doc-symbol-pins 两种参数、source-pins rc=0

本 PR 之后 macOS 上 opencode 节点仍会停在 `opencode-safe-root.ts`(层②),用户面没有变化;层②③ 各自 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD