### PR TITLE
feat(anet): #1845 层② opencode 安全启动隔离支持 darwin(默认 base = $TMPDIR,规则不变)

### DIFF
--- a/agent-network/src/opencode-safe-root-platform.test.ts
+++ b/agent-network/src/opencode-safe-root-platform.test.ts
@@ -1,0 +1,64 @@
+// #1845 层② —— safe-root 的平台门与默认 base:linux 与 darwin 共用同一套祖先/权限规则,只是默认 base 不同。
+// 在 Linux CI 上用注入的 platform/env 测 darwin 分支;真机验证见 #1845(Mac mini)。
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "fs";
+import { join } from "path";
+import { defaultOpencodeRuntimeBase, resolveOpencodeTrustedRuntimeBase } from "./opencode-safe-root";
+
+const cleanup: string[] = [];
+afterEach(() => { for (const p of cleanup.splice(0)) rmSync(p, { recursive: true, force: true }); });
+
+function privateBase(): string {
+  if (process.platform !== "linux" || process.getuid === undefined) {
+    throw new Error("safe-root platform tests need Linux uid semantics (/run/user/<uid>)");
+  }
+  const userRoot = `/run/user/${process.getuid()}`;
+  mkdirSync(userRoot, { recursive: true, mode: 0o700 });
+  chmodSync(userRoot, 0o700);
+  const base = mkdtempSync(join(userRoot, "anet-safe-root-darwin-"));
+  chmodSync(base, 0o700);
+  cleanup.push(base);
+  return base;
+}
+
+describe("#1845 safe-root platform gate", () => {
+  test("win32 is refused with the platform named", () => {
+    expect(() => resolveOpencodeTrustedRuntimeBase(undefined, "win32", {}))
+      .toThrow(/requires Linux or macOS uid semantics \(got win32\)/);
+  });
+  test("darwin default base is $TMPDIR; missing or relative TMPDIR is refused", () => {
+    expect(() => defaultOpencodeRuntimeBase(501, "darwin", {})).toThrow(/needs an absolute per-user TMPDIR/);
+    expect(() => defaultOpencodeRuntimeBase(501, "darwin", { TMPDIR: "relative/tmp" })).toThrow(/needs an absolute per-user TMPDIR/);
+    expect(defaultOpencodeRuntimeBase(501, "darwin", { TMPDIR: "/private/var/folders/xx/yy/T/" })).toBe("/private/var/folders/xx/yy/T");
+  });
+  test("darwin: a uid-owned 0700 TMPDIR under trusted ancestors is accepted", () => {
+    const base = privateBase();
+    const id = resolveOpencodeTrustedRuntimeBase(undefined, "darwin", { TMPDIR: base });
+    expect(id.path).toBe(base);
+  });
+  test("darwin: TMPDIR reached through a symlink resolves to its real 0700 directory", () => {
+    const base = privateBase();
+    const link = join(base, "..", `link-${Date.now()}`);
+    symlinkSync(base, link);
+    cleanup.push(link);
+    expect(resolveOpencodeTrustedRuntimeBase(undefined, "darwin", { TMPDIR: link }).path).toBe(base);
+  });
+  test("darwin: a group-writable TMPDIR is refused by the same rule as linux", () => {
+    const base = privateBase();
+    chmodSync(base, 0o770);
+    expect(() => resolveOpencodeTrustedRuntimeBase(undefined, "darwin", { TMPDIR: base }))
+      .toThrow(/refuses untrusted runtime-base ancestor|must be uid-owned with mode 0700/);
+  });
+  test("explicit ANET_OPENCODE_SAFE_BASE keeps the canonical-only rule on darwin too", () => {
+    const base = privateBase();
+    const link = join(base, "..", `elink-${Date.now()}`);
+    symlinkSync(base, link);
+    cleanup.push(link);
+    expect(() => resolveOpencodeTrustedRuntimeBase(undefined, "darwin", { ANET_OPENCODE_SAFE_BASE: link, TMPDIR: base }))
+      .toThrow(/refuses a symlinked safe runtime base/);
+    expect(resolveOpencodeTrustedRuntimeBase(undefined, "darwin", { ANET_OPENCODE_SAFE_BASE: base }).path).toBe(base);
+  });
+  test("linux default base is /run/user/<uid> (unchanged)", () => {
+    expect(defaultOpencodeRuntimeBase(process.getuid!(), "linux", {})).toBe(`/run/user/${process.getuid!()}`);
+  });
+});

--- a/agent-network/src/opencode-safe-root.ts
+++ b/agent-network/src/opencode-safe-root.ts
@@ -117,12 +117,44 @@ function ensureRootRuntimeDirectory(path: string, parent: string): void {
   mkdirSync(path, { mode: 0o700 });
 }
 
-export function resolveOpencodeTrustedRuntimeBase(explicit?: string): PathIdentity {
-  if (process.platform !== "linux" || process.getuid === undefined) {
-    throw new Error("OpenCode safe launch isolation currently requires Linux uid/procfs semantics");
+/** #1845 层② —— 运行时隔离 base 的平台策略。规则(祖先不可符号链接、非 root 只能是本 uid、无 0o022 写位、
+ * base 本身 uid-owned 0700)三平台一样;不同的只有**默认 base 在哪**:
+ *   linux  → /run/user/<uid>(systemd 的每用户 0700 运行目录;缺失时仅 root 可建)
+ *   darwin → realpath($TMPDIR)(macOS 每用户 0700 的 /private/var/folders/xx/<hash>/T;2026-09-07 Mac mini 量过
+ *            全链:T 700 uid、<hash> 755 uid、其余 755 root,满足同一套祖先规则)
+ *   其它   → 拦(win32 没有 uid 语义)
+ * 显式 base(参数或 ANET_OPENCODE_SAFE_BASE)三平台通用。platform / env 可注入,便于在 Linux CI 上测 darwin 分支。 */
+export const OPENCODE_SAFE_ROOT_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
+
+export function defaultOpencodeRuntimeBase(
+  uid: number,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === "darwin") {
+    const tmp = env.TMPDIR;
+    if (!tmp || !isAbsolute(tmp) || tmp.includes("\0")) {
+      throw new Error("OpenCode on macOS needs an absolute per-user TMPDIR, or set ANET_OPENCODE_SAFE_BASE");
+    }
+    // 去掉尾部的 /;真实路径在下面统一 realpath,这里只做「请求路径」。
+    return resolve(tmp);
+  }
+  if (!lstatIfPresent("/run/user")) ensureRootRuntimeDirectory("/run/user", "/run");
+  const requested = `/run/user/${uid}`;
+  if (!lstatIfPresent(requested)) ensureRootRuntimeDirectory(requested, "/run/user");
+  return requested;
+}
+
+export function resolveOpencodeTrustedRuntimeBase(
+  explicit?: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): PathIdentity {
+  if (!OPENCODE_SAFE_ROOT_PLATFORMS.has(platform) || process.getuid === undefined) {
+    throw new Error(`OpenCode safe launch isolation currently requires Linux or macOS uid semantics (got ${platform})`);
   }
   const uid = process.getuid();
-  const configured = explicit ?? process.env.ANET_OPENCODE_SAFE_BASE;
+  const configured = explicit ?? env.ANET_OPENCODE_SAFE_BASE;
   let requested: string;
   if (configured !== undefined) {
     if (!isAbsolute(configured) || configured.includes("\0")) {
@@ -130,12 +162,15 @@ export function resolveOpencodeTrustedRuntimeBase(explicit?: string): PathIdenti
     }
     requested = resolve(configured);
   } else {
-    if (!lstatIfPresent("/run/user")) ensureRootRuntimeDirectory("/run/user", "/run");
-    requested = `/run/user/${uid}`;
-    if (!lstatIfPresent(requested)) ensureRootRuntimeDirectory(requested, "/run/user");
+    requested = defaultOpencodeRuntimeBase(uid, platform, env);
   }
+  // macOS 的 $TMPDIR 是 /var/folders/…(/var → /private/var 符号链接),显式 base 也可能写成带链接的路径;
+  // 「请求路径」允许经符号链接到达,但 canonical 之后的每一级祖先仍然逐级校验不可为符号链接。
+  // Linux 的 /run/user/<uid> 与显式 base 的原语义(必须 canonical)保留:只有 darwin 默认 base 走 realpath 归一。
   const canonical = realpathSync(requested);
-  if (canonical !== requested) throw new Error("OpenCode refuses a symlinked safe runtime base");
+  if (canonical !== requested && !(platform === "darwin" && configured === undefined)) {
+    throw new Error("OpenCode refuses a symlinked safe runtime base");
+  }
 
   let current = canonical;
   let baseStat: ReturnType<typeof lstatSync> | undefined;


### PR DESCRIPTION
#1845 三层里的第二层(层① #1847 已合)。

- `resolveOpencodeTrustedRuntimeBase(explicit?, platform = process.platform, env = process.env)`:linux 默认 `/run/user/<uid>` **逐字不变**;darwin 默认 `realpath($TMPDIR)`(macOS 每用户 0700 的 `/private/var/folders/xx/<hash>/T`);win32 仍拦并写明平台
- **规则不放松**:祖先不可符号链接、非 root 只能本 uid、无 0o022 写位、base 必须 uid-owned 0700 —— 三平台同一段代码;唯一的平台差异是 darwin 默认 base 的「请求路径」允许经 `/var → /private/var` 符号链接到达(canonical 后每一级仍逐级校验),显式 `ANET_OPENCODE_SAFE_BASE` 保持 canonical-only
- **Mac mini 真跑**(uid 501,`node --experimental-strip-types` 直接调本模块):默认 TMPDIR → OK;显式 `/tmp` → 拒(symlinked);`TMPDIR=/tmp` → 拒(祖先 `/private/tmp` 1777);`TMPDIR=$HOME`(755)→ 拒(必须 0700);`createOpencodeSafeExternalRoot({prefix})` + `revalidateOpencodeSafeExternalRoot` → OK(9 级祖先)
- 测试:`opencode-safe-root-platform.test.ts` 7 用例(win32 拒 / TMPDIR 缺失·相对 / darwin 接受 0700 base / 经符号链接到达 / 770 拒 / 显式 base 仍 canonical-only / linux 默认不变);`opencode-smoke-env.test.ts` 4/4 不变;doc gates rc=0

本 PR 之后 macOS 上 opencode 节点会走到 agent-node 的 /proc 归属(层③)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD