### PR TITLE
feat(agent-node): #1845 层③ opencode 共存的 macOS 等价物($TMPDIR 隔离 / ps 身份 / lsof 引用)

### DIFF
--- a/agent-node/src/runtime/opencode-acp/child-env-darwin.test.ts
+++ b/agent-node/src/runtime/opencode-acp/child-env-darwin.test.ts
@@ -1,0 +1,84 @@
+// #1845 层③ —— agent-node 侧 opencode 共存在 macOS 上的三处等价物,在 Linux 上用注入/真机样本测:
+//   ① 启动隔离 base:darwin 默认 realpath($TMPDIR),规则与 linux 同;win32 拦
+//   ② 进程身份:`ps -o lstart=,state=` 解析(样本取自 2026-09-07 Mac mini)
+//   ③ 启动树引用:`lsof -Fp +D` 解析(样本同上)
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "fs";
+import { join } from "path";
+import {
+  defaultOpencodeLaunchBase,
+  parseDarwinPsStat,
+  parseLsofPids,
+  resolveTrustedLaunchBase,
+} from "./child-env";
+
+const cleanup: string[] = [];
+afterEach(() => { for (const p of cleanup.splice(0)) rmSync(p, { recursive: true, force: true }); });
+
+function privateBase(): string {
+  if (process.platform !== "linux" || process.getuid === undefined) {
+    throw new Error("these tests need Linux uid semantics (/run/user/<uid>)");
+  }
+  const userRoot = `/run/user/${process.getuid()}`;
+  mkdirSync(userRoot, { recursive: true, mode: 0o700 });
+  chmodSync(userRoot, 0o700);
+  const base = mkdtempSync(join(userRoot, "anet-child-env-darwin-"));
+  chmodSync(base, 0o700);
+  cleanup.push(base);
+  return base;
+}
+
+describe("#1845 ③ launch base platform policy", () => {
+  test("win32 refused, naming the platform", () => {
+    expect(() => resolveTrustedLaunchBase(undefined, "win32", {})).toThrow(/requires Linux or macOS uid semantics \(got win32\)/);
+  });
+  test("darwin default base is $TMPDIR (absolute, trailing slash trimmed); missing → refused", () => {
+    expect(defaultOpencodeLaunchBase(501, "darwin", { TMPDIR: "/private/var/folders/xx/yy/T/" })).toBe("/private/var/folders/xx/yy/T");
+    expect(() => defaultOpencodeLaunchBase(501, "darwin", {})).toThrow(/needs an absolute per-user TMPDIR/);
+  });
+  test("darwin accepts a uid-owned 0700 TMPDIR, also when reached through a symlink", () => {
+    const base = privateBase();
+    expect(resolveTrustedLaunchBase(undefined, "darwin", { TMPDIR: base }).path).toBe(base);
+    const link = join(base, "..", `l-${Date.now()}`);
+    symlinkSync(base, link); cleanup.push(link);
+    expect(resolveTrustedLaunchBase(undefined, "darwin", { TMPDIR: link }).path).toBe(base);
+  });
+  test("darwin refuses a 0770 TMPDIR by the shared rule; explicit base stays canonical-only", () => {
+    const base = privateBase();
+    chmodSync(base, 0o770);
+    expect(() => resolveTrustedLaunchBase(undefined, "darwin", { TMPDIR: base })).toThrow(/group\/other writable|must be owned by uid/);
+    chmodSync(base, 0o700);
+    const link = join(base, "..", `e-${Date.now()}`);
+    symlinkSync(base, link); cleanup.push(link);
+    expect(() => resolveTrustedLaunchBase(undefined, "darwin", { ANET_OPENCODE_SAFE_BASE: link })).toThrow(/symlinks are not allowed/);
+  });
+  test("linux default base unchanged", () => {
+    expect(defaultOpencodeLaunchBase(process.getuid!(), "linux", {})).toBe(`/run/user/${process.getuid!()}`);
+  });
+});
+
+describe("#1845 ③ darwin process identity via ps", () => {
+  test("parses lstart + state from the real ps shape", () => {
+    const stat = parseDarwinPsStat("Mon Sep  7 17:38:47 2026    Ss\n", 323);
+    expect(stat?.state).toBe("S");
+    expect(stat?.identity).toBe(`323:${Math.floor(Date.parse("Mon Sep  7 17:38:47 2026") / 1000)}`);
+  });
+  test("zombie state keeps Z; empty output (pid gone) → undefined", () => {
+    expect(parseDarwinPsStat("Mon Sep  7 17:38:47 2026 Z\n", 500)?.state).toBe("Z");
+    expect(parseDarwinPsStat("\n", 1)).toBeUndefined();
+    expect(parseDarwinPsStat("garbage", 1)).toBeUndefined();
+  });
+  test("identity changes when the same pid has a different start time (pid reuse)", () => {
+    const a = parseDarwinPsStat("Mon Sep  7 17:38:47 2026 S", 9)!.identity;
+    const b = parseDarwinPsStat("Mon Sep  7 17:38:48 2026 S", 9)!.identity;
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("#1845 ③ darwin launch-root references via lsof", () => {
+  test("parses -F pid records, ignores other fields and duplicates", () => {
+    expect(parseLsofPids("p507\nfcwd\np507\nfcwd\np800\ntxt\n")).toEqual([507, 800]);
+    expect(parseLsofPids("")).toEqual([]);
+    expect(parseLsofPids("pabc\n")).toEqual([]);
+  });
+});

--- a/agent-node/src/runtime/opencode-acp/child-env.ts
+++ b/agent-node/src/runtime/opencode-acp/child-env.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { randomBytes } from "crypto";
 import {
   closeSync,
@@ -382,16 +383,38 @@ function ensureRootRuntimeDirectory(path: string, parent: string): void {
  * it prevents deletion of our random root but does not prevent another user
  * from planting an ancestor opencode.json between validation and first prompt.
  */
-function resolveTrustedLaunchBase(explicit?: string): {
+/** #1845 层③ —— 与 anet 的 opencode-safe-root 同一套平台策略:linux 默认 /run/user/<uid>,darwin 默认
+ * realpath($TMPDIR)(每用户 0700 的 /private/var/folders/xx/<hash>/T),win32 拦;祖先/权限规则三平台一样。 */
+export const OPENCODE_LAUNCH_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
+
+export function defaultOpencodeLaunchBase(uid: number, platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+  if (platform === "darwin") {
+    const tmp = env.TMPDIR;
+    if (!tmp || !isAbsolute(tmp) || tmp.includes("\0")) {
+      throw new Error("opencode on macOS needs an absolute per-user TMPDIR, or set ANET_OPENCODE_SAFE_BASE");
+    }
+    return resolve(tmp);
+  }
+  if (!lstatIfPresent("/run/user")) ensureRootRuntimeDirectory("/run/user", "/run");
+  const requested = `/run/user/${uid}`;
+  if (!lstatIfPresent(requested)) ensureRootRuntimeDirectory(requested, "/run/user");
+  return requested;
+}
+
+export function resolveTrustedLaunchBase(
+  explicit?: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): {
   path: string;
   dev: number | bigint;
   ino: number | bigint;
 } {
-  if (process.platform !== "linux" || process.getuid === undefined) {
-    throw new Error("opencode safe launch isolation currently requires Linux uid/procfs semantics");
+  if (!OPENCODE_LAUNCH_PLATFORMS.has(platform) || process.getuid === undefined) {
+    throw new Error(`opencode safe launch isolation currently requires Linux or macOS uid semantics (got ${platform})`);
   }
   const uid = process.getuid();
-  const configured = explicit ?? process.env.ANET_OPENCODE_SAFE_BASE;
+  const configured = explicit ?? env.ANET_OPENCODE_SAFE_BASE;
   let requested: string;
   if (configured !== undefined) {
     if (!isAbsolute(configured) || configured.includes("\0")) {
@@ -399,13 +422,13 @@ function resolveTrustedLaunchBase(explicit?: string): {
     }
     requested = resolve(configured);
   } else {
-    if (!lstatIfPresent("/run/user")) ensureRootRuntimeDirectory("/run/user", "/run");
-    requested = `/run/user/${uid}`;
-    if (!lstatIfPresent(requested)) ensureRootRuntimeDirectory(requested, "/run/user");
+    requested = defaultOpencodeLaunchBase(uid, platform, env);
   }
 
+  // darwin 的 $TMPDIR 是 /var/folders/…(/var → /private/var 符号链接):默认 base 允许请求路径经链接到达,
+  // canonical 之后每一级祖先仍逐级校验;显式 base 与 linux 保持「必须 canonical」。
   const canonical = realpathSync(requested);
-  if (canonical !== requested) {
+  if (canonical !== requested && !(platform === "darwin" && configured === undefined)) {
     throw new Error(`opencode refuses runtime base ${requested}: symlinks are not allowed`);
   }
 
@@ -654,7 +677,7 @@ function atomicWritePrivateFile(path: string, body: string, label: string): void
 
 export interface OpencodeExitedProcessIdentity {
   pid: number;
-  /** Linux /proc start-ticks identity; unavailable on Windows/macOS. */
+  /** Linux `/proc` start-ticks identity, or macOS `pid:<lstart epoch>` (#1845); unavailable on Windows. */
   identity: string | null;
   nativeExitObserved: true;
 }
@@ -688,8 +711,38 @@ function readLinuxProcessStat(pid: number): LinuxProcessStat | undefined {
   }
 }
 
+/** #1845 层③ —— macOS 没有 procfs:用 `ps -o lstart=,state= -p <pid>` 取启动时间(秒级)与状态。
+ * 同 uid 的进程都能读;启动时间作 PID 复用的区分度比 Linux 的 tick 粗,但同一秒内复用同一 PID 的概率可忽略。
+ * 纯解析函数单独导出以便在 Linux 上用真机样本测试。 */
+export function parseDarwinPsStat(output: string, pid: number): LinuxProcessStat | undefined {
+  const line = output.replace(/\r/g, "").split("\n").map(l => l.trim()).find(l => l.length > 0);
+  if (!line) return undefined;
+  // lstart 形如 "Mon Sep  7 17:38:47 2026",后面跟 state(如 "Ss" / "Z")。lstart 内部有多个空格,不能按空格切。
+  const match = /^([A-Za-z]{3}\s+[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(\S+)\s*$/.exec(line);
+  if (!match) return undefined;
+  const started = Date.parse(match[1]);
+  if (!Number.isFinite(started)) return undefined;
+  return { identity: `${pid}:${Math.floor(started / 1000)}`, state: match[2].charAt(0) };
+}
+
+function readDarwinProcessStat(pid: number): LinuxProcessStat | undefined {
+  try {
+    const out = execFileSync("/bin/ps", ["-o", "lstart=,state=", "-p", String(pid)], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000,
+    });
+    return parseDarwinPsStat(out, pid);
+  } catch {
+    return undefined;
+  }
+}
+
+function readProcessStat(pid: number): LinuxProcessStat | undefined {
+  if (process.platform === "darwin") return readDarwinProcessStat(pid);
+  return readLinuxProcessStat(pid);
+}
+
 export function readOpencodeProcessIdentity(pid: number): string | undefined {
-  return readLinuxProcessStat(pid)?.identity;
+  return readProcessStat(pid)?.identity;
 }
 
 function isPidAlive(pid: number): boolean {
@@ -727,11 +780,53 @@ function markerOwnerIsLive(marker: LaunchOwnerMarker): boolean {
  * permanently leak every credential-bearing launch tree. A positive exact
  * environment/cwd match still retains the root.
  */
+/** #1845 层③ —— macOS 不能读别的进程的环境(即使同 uid),改问「谁的 cwd / 打开文件在这棵树下」:
+ * `lsof -Fp +D <root>`(Mac mini 实测 0.25 s,树很小)。自己与刚被观测退出的那个 pid 不算。
+ * 纯解析函数单独导出以便测试。 */
+export function parseLsofPids(output: string): number[] {
+  const pids: number[] = [];
+  for (const raw of output.split("\n")) {
+    const line = raw.trim();
+    if (!/^p\d+$/.test(line)) continue;
+    const pid = Number(line.slice(1));
+    if (Number.isSafeInteger(pid) && pid > 0 && !pids.includes(pid)) pids.push(pid);
+  }
+  return pids;
+}
+
+function launchRootReferencedByLiveProcessDarwin(
+  launchRoot: string,
+  safeWorkspace: string | undefined,
+  exitedProcess?: OpencodeExitedProcessIdentity,
+): boolean | undefined {
+  const roots = [launchRoot, ...(safeWorkspace && !pathIsWithin(launchRoot, safeWorkspace) ? [safeWorkspace] : [])];
+  for (const root of roots) {
+    let out = "";
+    try {
+      out = execFileSync("/usr/sbin/lsof", ["-Fp", "+D", root], {
+        encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 15_000,
+      });
+    } catch (error: any) {
+      // lsof exits 1 when nothing matches but still prints nothing; a spawn failure has no stdout either —
+      // distinguish by whether we got a Buffer back.
+      if (typeof error?.stdout === "string") out = error.stdout;
+      else return undefined;
+    }
+    for (const pid of parseLsofPids(out)) {
+      if (pid === process.pid) continue;
+      if (exitedProcess?.nativeExitObserved === true && exitedProcess.pid === pid) continue;
+      return true;
+    }
+  }
+  return false;
+}
+
 function launchRootReferencedByLiveProcess(
   launchRoot: string,
   safeWorkspace: string | undefined,
   exitedProcess?: OpencodeExitedProcessIdentity,
 ): boolean | undefined {
+  if (process.platform === "darwin") return launchRootReferencedByLiveProcessDarwin(launchRoot, safeWorkspace, exitedProcess);
   if (process.platform !== "linux") return undefined;
   let entries: string[];
   try {


### PR DESCRIPTION
#1845 第三层(层① #1847、层② #1848 已合)。`runtime/opencode-acp/child-env.ts` 里 Linux 专有的三处各给 darwin 等价物,**规则不放松**:

| 处 | Linux(不变) | darwin |
|---|---|---|
| 启动隔离 base `resolveTrustedLaunchBase` | `/run/user/<uid>` | `realpath($TMPDIR)`(每用户 0700);祖先不可符号链接 / 非 root 只能本 uid / 无 0o022 / base 0700 同一段代码;显式 `ANET_OPENCODE_SAFE_BASE` 仍 canonical-only;win32 拦 |
| 进程身份 `readOpencodeProcessIdentity` | `/proc/<pid>/stat` start ticks | `ps -o lstart=,state= -p` → `pid:<lstart 秒>` + 状态首字符(Z);同 uid 可读 |
| 启动树是否仍被活进程引用 `launchRootReferencedByLiveProcess` | 扫 `/proc/*/environ` + cwd | macOS **读不到别的进程环境(同 uid 也不行,Mac mini 实测 `ps -E`)**,改 `lsof -Fp +D <root>`(0.25 s);自己与已观测退出的 pid 不算;lsof 起不来 → `undefined`(沿用宽限期内保留的保守语义) |

- 测试:`child-env-darwin.test.ts` 9 用例(Linux 上注入 darwin;ps / lsof 解析用 2026-09-07 Mac mini 真机样本);`child-env.test.ts` 18/18 不变
- agent-node `tsc --noEmit`:错误数与 main **相同**(81;child-env 的 6 处是既有的 bigint 运算与 `exitedProcess` 未定义,本 PR 未新增、也未修 —— 另开)
- doc gates rc=0

下一步(本 PR 之后):Mac mini 上真起一个 opencode 共存节点做 host smoke;anet/agent-node 发 preview;桌面向导在 Vincent 的 Mac 上验收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD