### PR TITLE
chore(release): agent-node 2.5.0-preview.67 + agent-network 2.3.0-preview.87(#1845 opencode 共存 macOS 三层)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.86",
+  "version": "2.3.0-preview.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.86",
+      "version": "2.3.0-preview.87",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.86",
+  "version": "2.3.0-preview.87",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.86";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.66";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.87";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.67";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.66",
+  "version": "2.5.0-preview.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.66",
+      "version": "2.5.0-preview.67",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.66",
+  "version": "2.5.0-preview.67",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.86 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.87 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.86` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.87` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.86 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.87 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.86`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.87`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.87.md
+++ b/docs/tests/release-v2.3.0-preview.87.md
@@ -1,0 +1,37 @@
+# `@sleep2agi/agent-network@2.3.0-preview.87`
+
+## 为什么发这一版:opencode 共存移植 macOS 的层①②(#1845)+ 配对 agent-node `.67`
+
+`.86` 之后 `agent-network/src` 两个功能提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `efebe85f` | #1847 | **#1845 层①** —— opencode 包身份校验 `resolveOpencodePackageBinaryFromPath` 平台门 linux/darwin(win32 仍拦),规则逐字不动;Mac mini 真跑 VALIDATE_OK |
+| `89325307` | #1848 | **#1845 层②** —— `resolveOpencodeTrustedRuntimeBase` darwin 默认 base `realpath($TMPDIR)`,祖先/权限规则不变;Mac mini 真跑:默认 OK,/tmp 与 755 目录仍拒 |
+
+| 用户看到的 | `.86` | `.87` + agent-node `.67` |
+|---|---|---|
+| macOS 上起 opencode-cli 共存节点 | 「verification currently requires Linux」 | 走到真正的启动(host smoke 进行中,见 #1845) |
+| Linux 上一切 | 不变 | 不变 |
+| `anet node create` 配对装的 agent-node | `2.5.0-preview.66` | `2.5.0-preview.67` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.87
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.87
+```
+
+## 证据
+
+- `opencode-package-binary.test.ts` 16/16(+3 平台门);`opencode-safe-root-platform.test.ts` 7/7;`opencode-smoke-env.test.ts` 4/4;doc gates rc=0。
+- Mac mini(uid 501)真跑两层模块源码:见 #1222 / #1845 评论。
+
+## 边界
+
+- macOS 完整链路(daemon → opencode 共存节点注册 → 收发任务)尚未验收;桌面端 daemon 装的是 `@latest`,promote 前 Vincent 的 Mac 用不到本版。

--- a/docs/tests/release-v2.5.0-preview.67.md
+++ b/docs/tests/release-v2.5.0-preview.67.md
@@ -1,0 +1,33 @@
+# agent-node 2.5.0-preview.67
+
+`.66` 之后 `agent-node/` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `cfaf68af` | #1849 | **#1845 层③** —— opencode 共存在 macOS 上的等价物:启动隔离 base darwin 默认 `realpath($TMPDIR)`(规则同 Linux);进程身份 `ps -o lstart=,state=`;启动树引用 `lsof -Fp +D`(macOS 同 uid 也读不到别进程环境,不能照搬 /proc/environ);win32 仍拦 |
+
+## 这一版带给用户什么
+
+配合 agent-network `2.3.0-preview.87`(层①②),macOS 上的 daemon 起 opencode-cli 共存节点不再在「requires Linux」处停下。Linux 行为逐字不变。**尚未在 macOS 上做完整 host smoke**(见 #1845),先发 preview 供 Mac mini 真跑。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.67
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.67
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `runtime/opencode-acp/child-env-darwin.test.ts` 9 用例(Linux 上注入 darwin;ps / lsof 解析用 2026-09-07 Mac mini 真机样本);`child-env.test.ts` 18/18 不变。
+- agent-node `tsc --noEmit` 错误数与 main 相同(既有 81,本版未新增)。
+
+## promote 时的 must_contain
+
+`"version": "2.5.0-preview.67"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json)。


### PR DESCRIPTION
把 #1847 / #1848(anet)与 #1849(agent-node)发到 preview,同日成对。

- agent-node `.67`:层③(child-env darwin 等价物)
- agent-network `.87`:层①②(包身份校验 + 安全启动隔离 darwin)+ 配对 agent-node `.67`
- stamps 齐(两个 package.json/lock、PAIRED_* 两个常量、getting-started zh/en version-claim);两份 release notes(Install/Upgrade/证据/must_contain);version-claims 两种参数与 doc pins rc=0

合并后:先 `release.yml -f package=agent-node -f version=2.5.0-preview.67 -f publish=true`,再 `agent-network 2.3.0-preview.87`(published-pins 门要先看到 agent-node .67);随后 Mac mini host smoke(#1845)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD