### PR TITLE
fix(create_node): 模型名允许 provider/model 一个斜杠(hub + daemon 两份镜像)

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -168,6 +168,13 @@ describe("buildAnetArgsDaemon now reaches flag value validation", () => {
       name: "x", runtime: "claude-agent-sdk", model: "",
     })).toThrow(/model_invalid/);
   });
+  test("provider/model (OpenCode co-presence) passes; two slashes, edge slashes and dot-only segments are rejected", () => {
+    const args = buildAnetArgsDaemon({ name: "x", runtime: "opencode-cli", model: "opencode/mimo-v2.5-free" });
+    expect(args).toContain("opencode/mimo-v2.5-free");
+    for (const bad of ["a/b/c", "/model", "provider/", "../x", "x/.", "open code/m"]) {
+      expect(() => buildAnetArgsDaemon({ name: "x", runtime: "opencode-cli", model: bad })).toThrow(/model_invalid/);
+    }
+  });
   test("smuggled string maxTurns rejected by daemon even if hub missed", () => {
     expect(() => buildAnetArgsDaemon({
       name: "x", runtime: "claude-agent-sdk", model: "x",

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -483,7 +483,11 @@ export function minimalEnv(
 // compromises hub still can't smuggle a bad spec past the daemon.
 
 const NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/;
-const MODEL_RE = /^[a-zA-Z0-9._:\-]+$/;
+// 与 server/src/create-node-validate.ts 同镜像:允许恰好一个 `/` 分隔的 provider/model(OpenCode 共存,
+// 桌面向导 0.2.61 起发 `opencode/mimo-v2.5-free`),每段仍是原字符集且不能是纯点段。
+const MODEL_SEGMENT = "[a-zA-Z0-9._:\\-]+";
+const MODEL_RE = new RegExp(`^${MODEL_SEGMENT}(?:/${MODEL_SEGMENT})?$`);
+const MODEL_DOT_ONLY_SEGMENT = /(^|\/)\.+(\/|$)/;
 // #1298 — 必须与 agent-network/src/normalize-runtime.ts 的 SUPPORTED_RUNTIME_NAMES
 // 逐字一致。两个包之间没有依赖关系（agent-node 不 import agent-network），所以这里
 // 只能是一份副本；而副本靠纪律会漂 —— 本仓 im/access-resolve.ts 那对镜像就没有门。
@@ -558,7 +562,7 @@ export function buildAnetArgsDaemon(spec: DaemonNodeSpec): string[] {
   if (!spec.name || !NAME_RE.test(spec.name)) throw new Error("node_name_invalid");
   if (!VALID_RUNTIMES.has(spec.runtime)) throw new Error("runtime_invalid");
   if (spec.model !== undefined && spec.model !== null &&
-      (spec.model.length === 0 || spec.model.length > 100 || !MODEL_RE.test(spec.model))) throw new Error("model_invalid");
+      (spec.model.length === 0 || spec.model.length > 100 || !MODEL_RE.test(spec.model) || MODEL_DOT_ONLY_SEGMENT.test(spec.model))) throw new Error("model_invalid");
   if (Array.isArray(spec.channels) && spec.channels.length > 0) throw new Error("channels_not_supported_in_p1");
   const args: string[] = ["node", "create", spec.name, "--runtime", spec.runtime];
   if (spec.model) args.push("--model", spec.model);

--- a/server/src/create-node-validate.test.ts
+++ b/server/src/create-node-validate.test.ts
@@ -35,6 +35,15 @@ describe("validateRuntime / validateModel (§4.2.2)", () => {
     expect(() => validateModel("gpt-4o")).not.toThrow();
     expect(() => validateModel("bad model")).toThrow(ValidationError);
     expect(() => validateModel("x;rm")).toThrow(ValidationError);
+    // provider/model(OpenCode 共存;桌面向导 0.2.61 起发这种形状,Vincent 2026-09-08 撞到 model_invalid)
+    expect(() => validateModel("opencode/mimo-v2.5-free")).not.toThrow();
+    expect(() => validateModel("anthropic/claude-sonnet-4")).not.toThrow();
+    expect(() => validateModel("a/b/c")).toThrow(ValidationError);      // 只许一个斜杠
+    expect(() => validateModel("/model")).toThrow(ValidationError);     // 不能以斜杠开头
+    expect(() => validateModel("provider/")).toThrow(ValidationError);  // 不能以斜杠结尾
+    expect(() => validateModel("../x")).toThrow(ValidationError);       // 纯点段(路径穿越形状)
+    expect(() => validateModel("x/.")).toThrow(ValidationError);
+    expect(() => validateModel("open code/m")).toThrow(ValidationError);
     expect(() => validateModel("")).toThrow(ValidationError);
   });
 });

--- a/server/src/create-node-validate.ts
+++ b/server/src/create-node-validate.ts
@@ -58,7 +58,11 @@ const ENV_KEY_RE = /^[A-Z][A-Z0-9_]{0,63}$/;
 
 // §4.2.2 name + model.
 const NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/;
-const MODEL_RE = /^[a-zA-Z0-9._:\-]+$/;
+// OpenCode 共存的模型带 provider 前缀(`opencode/mimo-v2.5-free`,agent-node parseModelRef 按第一个 `/` 切),
+// 桌面向导 0.2.61 起就发这种形状 —— 允许**恰好一个**斜杠分隔的两段;每段仍是原字符集,且不能是纯点(`..`/`.`)。
+const MODEL_SEGMENT = "[a-zA-Z0-9._:\\-]+";
+const MODEL_RE = new RegExp(`^${MODEL_SEGMENT}(?:/${MODEL_SEGMENT})?$`);
+const MODEL_DOT_ONLY_SEGMENT = /(^|\/)\.+(\/|$)/;
 
 export function validateName(s: unknown): asserts s is string {
   if (typeof s !== "string" || !NAME_RE.test(s)) {
@@ -90,7 +94,7 @@ export function validateRuntime(s: unknown): asserts s is Runtime {
 
 export function validateModel(s: unknown): asserts s is string | undefined | null {
   if (s === undefined || s === null) return;
-  if (typeof s !== "string" || s.length === 0 || s.length > 100 || !MODEL_RE.test(s)) {
+  if (typeof s !== "string" || s.length === 0 || s.length > 100 || !MODEL_RE.test(s) || MODEL_DOT_ONLY_SEGMENT.test(s)) {
     throw new ValidationError("model_invalid", { value: typeof s === "string" ? s.slice(0, 80) : typeof s });
   }
 }


### PR DESCRIPTION
Vincent 2026-09-08 桌面向导建 OpenCode 节点:「创建失败:model_invalid」。OpenCode 共存要求 `provider/model`(agent-node `parseModelRef` 按第一个 `/` 切;向导 0.2.61 起发 `opencode/mimo-v2.5-free`),而 hub `create-node-validate.ts` 与 daemon `create-node-daemon.ts` 的 `MODEL_RE` 都不认斜杠。昨天 Mac mini 端到端用的是 CLI create,不经这道校验,所以没撞到。

- 两份镜像同改:恰好一个 `/` 分隔的两段,每段仍是 `[a-zA-Z0-9._:-]+`,纯点段(`../x`、`x/.`)拒;`a/b/c`、`/model`、`provider/`、含空格仍拒
- 测试:`create-node-validate.test.ts` +9(37/37);`create-node-daemon.test.ts` +1 正例 + 6 反例;doc pins rc=0

发版:commhub-server .53(hub)+ agent-node .68 + anet .88(配对)→ 桌面捆绑 Hub pin → 0.2.62;Vincent 的桌面 daemon 用 @latest,仍需 promote。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD