### PR TITLE
chore(release): commhub-server .53 + agent-node .68 + agent-network .88(#1853 模型名 provider/model)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.87",
+  "version": "2.3.0-preview.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.87",
+      "version": "2.3.0-preview.88",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.87",
+  "version": "2.3.0-preview.88",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.87";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.67";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.88";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.68";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.67",
+  "version": "2.5.0-preview.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.67",
+      "version": "2.5.0-preview.68",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.67",
+  "version": "2.5.0-preview.68",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.87 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.88 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.87` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.88` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.87 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.88 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.87`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.88`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v0.9.0-preview.53.md
+++ b/docs/tests/release-v0.9.0-preview.53.md
@@ -1,0 +1,34 @@
+# `@sleep2agi/commhub-server@0.9.0-preview.53`
+
+## 为什么发这一版:**create_node 的模型名放行 `provider/model`**(#1853)
+
+`.52` 之后 `server/src` 一个功能提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `a2831ecc` | #1853 | `create-node-validate.ts` 的 MODEL_RE 允许恰好一个 `/` 分隔的两段(OpenCode 共存的 `opencode/mimo-v2.5-free`);纯点段、多斜杠、首尾斜杠、空格仍拒。daemon 侧镜像同改(agent-node `.68`) |
+
+| 用户看到的 | `.52` | `.53` + agent-node `.68` + 桌面端 ≥ 0.2.62 |
+|---|---|---|
+| 桌面向导建 OpenCode 共存节点 | 「创建失败:model_invalid」(Vincent 2026-09-08) | 通过校验,daemon 起子节点 |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.53
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/commhub-server@0.9.0-preview.53
+# 生产 hub 走 deploy/hub/README.md 的六步(改 launcher 的 RUNTIME_DIR 那一行,pm2 restart),不要整文件覆盖
+```
+
+## 证据
+
+- `create-node-validate.test.ts` 37/37(+9:正例两条、反例 `a/b/c` `/model` `provider/` `../x` `x/.` 含空格)。
+
+## promote 时的 must_contain
+
+`"version": "0.9.0-preview.53"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json)。

--- a/docs/tests/release-v2.3.0-preview.88.md
+++ b/docs/tests/release-v2.3.0-preview.88.md
@@ -1,0 +1,25 @@
+# `@sleep2agi/agent-network@2.3.0-preview.88`
+
+## 为什么发这一版:配对 agent-node `.68`(同日成对规则)
+
+`.87` 之后 `agent-network/bin|src` 没有功能提交;本版只把配对版本推到 agent-node `.68`(#1853 daemon 侧模型名镜像),让 `anet node create` 装到带修复的 agent-node,并让 published-pins 门与 main 一致。
+
+| 用户看到的 | `.87` | `.88` |
+|---|---|---|
+| `anet node create` 配对装的 agent-node | `.67` | `.68` |
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.88
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.88
+```
+
+## 边界
+
+- anet 自身行为与 `.87` 逐字相同;不需要重启节点。

--- a/docs/tests/release-v2.5.0-preview.68.md
+++ b/docs/tests/release-v2.5.0-preview.68.md
@@ -1,0 +1,32 @@
+# agent-node 2.5.0-preview.68
+
+`.67` 之后 `agent-node/` 一个提交:
+
+| 提交 | PR | 内容 |
+|---|---|---|
+| `a2831ecc` | #1853 | daemon 侧 `create-node-daemon.ts` 的 MODEL_RE 与 hub 镜像同改:允许 `provider/model` 一个斜杠;纯点段等仍拒 |
+
+## 这一版带给用户什么
+
+配合 commhub-server `.53` 与桌面端 ≥ 0.2.62,向导建 OpenCode 共存节点(带 `opencode/…` 模型)不再被 daemon 拒。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.68
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-node@2.5.0-preview.68
+anet daemon restart <daemon>        # 或 anet node stop <name> && anet node start <name>
+```
+
+## 证据
+
+- `create-node-daemon.test.ts` 73/73(+1:正例 + 6 反例)。
+
+## promote 时的 must_contain
+
+`"version": "2.5.0-preview.68"`(闸 4 对整个 `package/` 目录 `grep -rq`,命中 package.json)。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.52",
+  "version": "0.9.0-preview.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.52",
+      "version": "0.9.0-preview.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.52",
+  "version": "0.9.0-preview.53",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
把 #1853 发到 preview,三包同日:commhub-server `0.9.0-preview.53`(hub 校验)、agent-node `2.5.0-preview.68`(daemon 镜像)、agent-network `2.3.0-preview.88`(仅配对)。stamps 齐,三份 release notes(Install/Upgrade/must_contain);version-claims / pins rc=0。

合并后依次 release.yml publish:agent-node .68 → agent-network .88 → commhub-server .53;随后桌面捆绑 Hub pin .52→.53 + 0.2.62。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD