### PR TITLE
chore(release): agent-network 2.3.0-preview.89(#1856 生命周期控制器)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.88",
+  "version": "2.3.0-preview.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.88",
+      "version": "2.3.0-preview.89",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.88",
+  "version": "2.3.0-preview.89",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.88";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.89";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.68";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.88 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.89 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -102,7 +102,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 | `2.3.0-preview.76` (current `latest`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
-| `2.3.0-preview.88` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.89` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.3.0-preview.76 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.88 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.89 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -100,7 +100,7 @@ anet hub dashboard
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 | `2.3.0-preview.76`(当前 `latest`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
-| `2.3.0-preview.88`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.89`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.89.md
+++ b/docs/tests/release-v2.3.0-preview.89.md
@@ -1,0 +1,36 @@
+# `@sleep2agi/agent-network@2.3.0-preview.89`
+
+## 为什么发这一版:Codex TUI 共存节点的生命周期控制器(#1856 A–E1)
+
+`.88` 之后 `agent-network/bin|src` 合入五个 PR(#1857 / #1858 / #1859 / #1860 / #1863),都在包的 `dist` 里:
+
+| 用户看到的 | `.88` | `.89` |
+|---|---|---|
+| `anet node codex preflight\|verify <alias>` | 无 | 只读体检,receipt 落 `.anet/nodes/<id>/receipts/`,exit 0/2 |
+| `anet node codex start\|restart\|resume` | 无 | 确定性状态机:停 Bridge→TUI→App Server,起 App Server→端口→exact TUI→Bridge(`--tui-first`),失败回滚一次,`--probe-from <peer>` nonce 验收 |
+| `anet node codex fork <源> --name <新> --workdir <目录>` | 无 | 继承历史(rollout 复制改写 id/cwd),其余全新 |
+| `anet node codex account register\|list\|install` / `rollback` | 无 | `codex-login:<profile-id>` host-bound registry;fresh 探针 → 备份 → 0600 安装 → 完整重启 → 指纹核对;失败回滚 |
+| `anet node codex canary <alias>...` | 无 | 顺序 verify,第一个 FAIL 即停 |
+| `anet node edit --workdir <dir>` | 无 | 给旧共存节点补 `codexProjectDir` |
+| 共存桥再入 | PATH 上的 `anet` | 当前这份 anet 自调用(PATH 上另一版本时不再把桥起错) |
+| codex 更新提示 | 重启卡住 | 受控启动前记 `version.json` 的 `dismissed_version` |
+
+真机(DEV,#1856 记录):fork 通信牛 → start 52s → account install 39s → rollback 34s 全 PASS;通信牛 preflight 8/8。
+
+## Install
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.89
+```
+
+## Upgrade
+
+```bash
+npm i -g @sleep2agi/agent-network@2.3.0-preview.89
+```
+
+## 边界
+
+- 配对 agent-node 仍为 `2.5.0-preview.68`(agent-node 本版未动)。
+- 生命周期命令只作用于 `runtime=codex-app-server` 的共存节点;其它运行时行为与 `.88` 逐字相同。
+- 已在跑的节点不需要重启;`anet node codex …` 在节点的 workdir(含 `.anet` 的目录)里执行。


### PR DESCRIPTION
版本 bump:package.json + lock、PAIRED_AGENT_NETWORK_VERSION、getting-started zh/en 版本戳、docs/tests/release-v2.3.0-preview.89.md(## Install / ## Upgrade)。agent-node 未动(仍配对 .68)。合入后 release.yml `-f package=agent-network -f version=2.3.0-preview.89 -f publish=true`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUVHxe3MmQn4vE3v6ZvTDD